### PR TITLE
Add continuous sovereign mode: perpetual self-improving loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ One command installs the `wizard` binary, Ollama, and an official **Qwen 3.6** m
 
 **Genie / Sovereign dual modes.** Genie is the interactive default: full TUI, confirms every write, shell command, and evolution before it runs. Sovereign is the autonomous mode: headless-capable, auto-approves everything, circuit-breaks on repeated failures, controllable mid-run via a loop-control file. Same tools, same model — different trust posture, switchable live with `/genie` and `/sovereign`.
 
+**Perpetual `--continuous` mode.** Sovereign can also run *forever*. Given one goal, `--continuous` never stops at "done": it persists a durable mission to `.wizard/mission.toml`, self-directs the next most valuable action each cycle, sleeps-and-wakes through transient model-server outages instead of dying, compacts its own context so it never overflows, and — when it improves itself via `evolve`, up to rebuilding its own binary — re-execs into the new image and resumes the mission. Zero human in the loop; the kill switch is one line in `.wizard/loop-control`, and deep self-modification stays gated by an automated build + smoke test with `wizard.prev` rollback. See [docs/modes.md](docs/modes.md#continuous-mode-perpetual-sovereign).
+
 ---
 
 ## Quick start
@@ -35,6 +37,9 @@ wizard
 
 # Sovereign autonomous mode
 wizard --mode sovereign -p "refactor the auth module and add tests"
+
+# Perpetual mode — keeps working and self-improving until you stop it
+wizard --continuous -p "keep hardening this codebase: tests, docs, performance"
 
 # Self-extension: add a capability live (skill / MCP server / scripted tool)
 wizard --evolve -p "add a skill for conventional commit messages"

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -63,6 +63,7 @@ Sovereign mode is the autonomous, proactive agent. It runs with minimal human in
 |------|--------|
 | `--max-hours 2` | Time limit for the run |
 | `--loop 10` | Max outer loop iterations |
+| `--continuous` | Run perpetually — never stop at "done" (implies sovereign). See below |
 | `--auto` | Implicit in sovereign mode; included for consistency |
 | `--cwd /path/to/repo` | Set project root |
 
@@ -84,6 +85,59 @@ wizard --mode sovereign \
   --max-hours 1 \
   --cwd ~/projects/myapp
 ```
+
+## Continuous mode (perpetual sovereign)
+
+```bash
+wizard --continuous -p "keep hardening this codebase: tests, docs, performance"
+```
+
+`--continuous` turns sovereign mode into a perpetual, self-directing agent. Given an
+initial goal it works toward it and **does not stop when a sub-task completes** — it
+records the cycle, re-examines the project, and chooses the next most valuable action.
+When the mission itself is fully done it shifts to high-value improvements (tests, docs,
+robustness) or extends its own capabilities via the `evolve` tool. There is no human in
+the loop; the automated rails below are what keep it safe.
+
+### What makes it run forever
+
+- **Durable mission.** The goal is persisted to `<project>/.wizard/mission.toml` along
+  with a cycle count and rolling progress log. It survives restarts and binary
+  self-replacement — relaunch with `--continuous` (no `-p`) and it resumes the mission.
+- **Sleep-and-wake.** Transient Ollama failures (server unreachable, busy, `429`/`5xx`,
+  dropped stream) no longer abort the run. The loop backs off exponentially
+  (`retry_base_secs` → `retry_max_secs`) and retries indefinitely, so a paused or
+  restarting model server is waited out, not fatal.
+- **Context compaction.** When the conversation grows past `compact_threshold_bytes`,
+  older history is summarized into a compact progress note so a run can continue
+  indefinitely without overflowing the model's context window.
+- **Self-evolution + re-exec.** When the agent calls `evolve` (adding a skill, MCP
+  server, scripted tool, subagent, or — with `deep` — rebuilding its own binary), the
+  loop saves the mission and re-execs into the freshly built/extended image to load the
+  new capabilities, then resumes the mission.
+
+### Stopping it
+
+The same `.wizard/loop-control` file is your kill switch — write `stop` for a graceful
+shutdown after the current step, or `pause` to hold. `--max-hours` and the circuit
+breaker (3 identical failures in a row) also terminate a continuous run. Deep
+self-modification remains gated by an automated `cargo build` + `--version` smoke test,
+with the previous binary kept as `wizard.prev` for one-`mv` rollback and every evolution
+appended to `~/.wizard/evolution.jsonl`.
+
+### Tuning (`~/.wizard/config.toml`)
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `continuous` | `false` | Start in perpetual mode without the flag |
+| `retry_base_secs` | `5` | Base backoff when the model server is unavailable |
+| `retry_max_secs` | `300` | Cap on backoff between retries |
+| `cycle_pause_secs` | `0` | Pause between continuous cycles |
+| `compact_threshold_bytes` | `48000` | History size that triggers compaction |
+
+> **Run it in a container or VM.** Continuous mode auto-approves every tool call with no
+> human in the loop and can rewrite its own binary. Point it only at work you're willing
+> to let it touch unattended, and read [SECURITY.md](../SECURITY.md) first.
 
 ## Switching modes in the TUI
 

--- a/src/agent/mission.rs
+++ b/src/agent/mission.rs
@@ -82,8 +82,7 @@ impl Mission {
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("creating control dir at {}", dir.display()))?;
         let path = mission_path(project_root);
-        let serialized =
-            toml::to_string_pretty(self).context("serializing mission to TOML")?;
+        let serialized = toml::to_string_pretty(self).context("serializing mission to TOML")?;
         std::fs::write(&path, serialized)
             .with_context(|| format!("writing mission file at {}", path.display()))?;
         Ok(())
@@ -119,8 +118,11 @@ mod tests {
     impl TempDir {
         fn new() -> Self {
             let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-            let dir = std::env::temp_dir()
-                .join(format!("wizard-mission-test-{}-{}", std::process::id(), n));
+            let dir = std::env::temp_dir().join(format!(
+                "wizard-mission-test-{}-{}",
+                std::process::id(),
+                n
+            ));
             std::fs::create_dir_all(&dir).expect("create temp dir");
             Self(dir)
         }

--- a/src/agent/mission.rs
+++ b/src/agent/mission.rs
@@ -1,0 +1,174 @@
+//! Durable mission state for continuous sovereign mode.
+//!
+//! A `Mission` is the long-lived goal a perpetual agent works toward. It is
+//! persisted to `<project_root>/.wizard/mission.toml` so the loop survives
+//! restarts and binary self-replacement (deep `/evolve`). Marker files in the
+//! same directory coordinate self-evolution hand-offs.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Cap on the rolling progress log so the mission file stays bounded.
+const MAX_NOTES: usize = 50;
+
+/// Directory holding all wizard control state for a project.
+pub fn control_dir(project_root: &Path) -> PathBuf {
+    project_root.join(".wizard")
+}
+
+/// Path to the persisted mission file.
+pub fn mission_path(project_root: &Path) -> PathBuf {
+    control_dir(project_root).join("mission.toml")
+}
+
+/// Marker requesting the loop re-exec a freshly built binary (deep evolve).
+pub fn reexec_marker(project_root: &Path) -> PathBuf {
+    control_dir(project_root).join("evolve-reexec")
+}
+
+/// Marker requesting the loop reload state in place (shallow evolve).
+pub fn reload_marker(project_root: &Path) -> PathBuf {
+    control_dir(project_root).join("evolve-reload")
+}
+
+/// A durable, long-lived goal for a continuous sovereign agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Mission {
+    /// The standing goal the agent works toward.
+    pub goal: String,
+    /// When the mission was first created.
+    pub created: DateTime<Utc>,
+    /// When the mission was last updated.
+    pub updated: DateTime<Utc>,
+    /// Number of completed continuous cycles.
+    pub cycles: u64,
+    /// Rolling progress log (most recent last), capped at [`MAX_NOTES`].
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+impl Mission {
+    /// Create a fresh mission for `goal`, with no recorded cycles.
+    pub fn new(goal: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            goal: goal.into(),
+            created: now,
+            updated: now,
+            cycles: 0,
+            notes: Vec::new(),
+        }
+    }
+
+    /// Load the mission for `project_root`, returning `Ok(None)` if none exists.
+    pub fn load(project_root: &Path) -> Result<Option<Self>> {
+        let path = mission_path(project_root);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading mission file at {}", path.display()))?;
+        let mission = toml::from_str(&raw)
+            .with_context(|| format!("parsing mission file at {}", path.display()))?;
+        Ok(Some(mission))
+    }
+
+    /// Persist the mission to `<project_root>/.wizard/mission.toml`.
+    pub fn save(&self, project_root: &Path) -> Result<()> {
+        let dir = control_dir(project_root);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating control dir at {}", dir.display()))?;
+        let path = mission_path(project_root);
+        let serialized =
+            toml::to_string_pretty(self).context("serializing mission to TOML")?;
+        std::fs::write(&path, serialized)
+            .with_context(|| format!("writing mission file at {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Record completion of one cycle, optionally logging a progress note.
+    ///
+    /// The note is appended to [`Mission::notes`]; once the log exceeds
+    /// [`MAX_NOTES`], the oldest entries are dropped from the front.
+    pub fn record_cycle(&mut self, note: Option<String>) {
+        self.cycles += 1;
+        self.updated = Utc::now();
+        if let Some(n) = note {
+            self.notes.push(n);
+            if self.notes.len() > MAX_NOTES {
+                let excess = self.notes.len() - MAX_NOTES;
+                self.notes.drain(0..excess);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Temp project dir removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let dir = std::env::temp_dir()
+                .join(format!("wizard-mission-test-{}-{}", std::process::id(), n));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        let tmp = TempDir::new();
+        let mut mission = Mission::new("ship the sovereign loop");
+        mission.record_cycle(Some("first pass".to_string()));
+        mission.save(&tmp.0).expect("save mission");
+
+        let loaded = Mission::load(&tmp.0)
+            .expect("load mission")
+            .expect("mission present");
+        assert_eq!(loaded.goal, "ship the sovereign loop");
+        assert_eq!(loaded.cycles, 1);
+        assert_eq!(loaded.notes, vec!["first pass".to_string()]);
+    }
+
+    #[test]
+    fn load_missing_is_none() {
+        let tmp = TempDir::new();
+        let loaded = Mission::load(&tmp.0).expect("load from empty dir");
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn record_cycle_caps_notes() {
+        let mut mission = Mission::new("endure");
+        let total = MAX_NOTES + 10;
+        for i in 0..total {
+            mission.record_cycle(Some(format!("note-{i}")));
+        }
+        assert_eq!(mission.notes.len(), MAX_NOTES);
+        assert_eq!(mission.cycles, total as u64);
+        // The newest note is retained at the back.
+        assert_eq!(
+            mission.notes.last().expect("non-empty notes"),
+            &format!("note-{}", total - 1)
+        );
+        // The oldest survivor is the expected front entry.
+        assert_eq!(mission.notes.first().expect("non-empty notes"), "note-10");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -634,7 +634,8 @@ impl Agent {
             Ok(summary) => {
                 let replacement =
                     ChatMessage::system(format!("[Compacted progress summary]\n{summary}"));
-                self.history.splice(start..end, std::iter::once(replacement));
+                self.history
+                    .splice(start..end, std::iter::once(replacement));
                 let _ = emit(
                     events,
                     AgentEvent::Error(format!("compacted {middle_count} messages → summary")),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@
 //! The loop is UI-agnostic: it emits [`AgentEvent`]s over a channel that the
 //! Ratatui TUI (genie) or the headless runner (sovereign) consumes.
 
+pub mod mission;
 pub mod prompts;
 pub mod session;
 pub mod subagent;
@@ -210,6 +211,9 @@ pub struct Agent {
 
 /// Consecutive identical failures that trip the sovereign circuit breaker.
 const CIRCUIT_BREAKER_LIMIT: u32 = 3;
+
+/// Number of most-recent messages preserved verbatim when compacting history.
+const KEEP_RECENT: usize = 10;
 
 /// Consecutive failures of one tool (any args) before the model is nudged
 /// to change approach.
@@ -444,6 +448,7 @@ impl Agent {
         events: &mpsc::Sender<AgentEvent>,
     ) -> Result<DoneReason> {
         self.push(ChatMessage::user(input));
+        self.compact_if_needed(events).await;
         let max_steps = self.config.max_steps.max(1);
 
         for step in 1..=max_steps {
@@ -458,7 +463,7 @@ impl Agent {
                 return Ok(reason);
             }
 
-            let (content, mut tool_calls) = self.stream_completion(events).await?;
+            let (content, mut tool_calls) = self.stream_completion_with_retry(events).await?;
             let assistant = ChatMessage {
                 role: Role::Assistant,
                 content: content.clone(),
@@ -536,6 +541,160 @@ impl Agent {
             }
         }
         Ok((content, tool_calls))
+    }
+
+    /// [`stream_completion`] with sleep-and-wake exponential backoff so a
+    /// transient LLM outage (server down, rate-limited, mid-stream drop)
+    /// pauses and retries instead of aborting the run. In continuous mode it
+    /// retries indefinitely; otherwise it gives up after ~6 attempts. A
+    /// non-transient error (e.g. missing model) returns immediately.
+    async fn stream_completion_with_retry(
+        &self,
+        events: &mpsc::Sender<AgentEvent>,
+    ) -> Result<(String, Vec<ToolCall>)> {
+        let mut attempt: u32 = 0;
+        loop {
+            match self.stream_completion(events).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    // Default to transient so mid-stream interruptions (which
+                    // are not typed `OllamaError`) also retry.
+                    let transient = err
+                        .downcast_ref::<crate::llm::ollama::OllamaError>()
+                        .map(|e| e.is_transient())
+                        .unwrap_or(true);
+                    if !transient {
+                        return Err(err);
+                    }
+                    if !self.config.continuous && attempt >= 6 {
+                        return Err(err);
+                    }
+                    let secs = self.config.retry_max_secs.min(
+                        self.config
+                            .retry_base_secs
+                            .saturating_mul(2u64.saturating_pow(attempt)),
+                    );
+                    let n = attempt + 1;
+                    let _ = emit(
+                        events,
+                        AgentEvent::Error(format!(
+                            "LLM unavailable ({err:#}); sleeping {secs}s then retrying (attempt {n})"
+                        )),
+                    )
+                    .await;
+                    tokio::time::sleep(Duration::from_secs(secs)).await;
+                    attempt += 1;
+                }
+            }
+        }
+    }
+
+    /// Keep history bounded so the agent can run indefinitely. When the
+    /// serialized history exceeds `compact_threshold_bytes`, summarize the
+    /// middle span (everything between the system prompt and the last
+    /// [`KEEP_RECENT`] messages) into a single progress note. Best-effort:
+    /// a summarization failure falls back to dropping the middle span. Never
+    /// aborts the turn.
+    async fn compact_if_needed(&mut self, events: &mpsc::Sender<AgentEvent>) {
+        let total: usize = self.history.iter().map(|msg| msg.content.len()).sum();
+        if total <= self.config.compact_threshold_bytes {
+            return;
+        }
+        // Need history[0] (system prompt) + a non-empty middle + the recent tail.
+        if self.history.len() <= KEEP_RECENT + 1 {
+            return;
+        }
+        let start = 1;
+        let end = self.history.len() - KEEP_RECENT;
+        if start >= end {
+            return;
+        }
+        let middle_count = end - start;
+
+        // Render the middle span as one text blob, capped to ~20k chars.
+        let mut blob = String::new();
+        for msg in &self.history[start..end] {
+            let role = match msg.role {
+                Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::Tool => "tool",
+            };
+            blob.push_str(role);
+            blob.push_str(": ");
+            blob.push_str(&msg.content);
+            blob.push('\n');
+            if blob.len() >= 20_000 {
+                blob.truncate(20_000);
+                break;
+            }
+        }
+
+        match self.summarize_transcript(&blob).await {
+            Ok(summary) => {
+                let replacement =
+                    ChatMessage::system(format!("[Compacted progress summary]\n{summary}"));
+                self.history.splice(start..end, std::iter::once(replacement));
+                let _ = emit(
+                    events,
+                    AgentEvent::Error(format!("compacted {middle_count} messages → summary")),
+                )
+                .await;
+            }
+            Err(err) => {
+                // Fall back to truncation: drop the middle span outright.
+                self.history.drain(start..end);
+                let _ = emit(
+                    events,
+                    AgentEvent::Error(format!(
+                        "compacted {middle_count} messages by truncation (summary LLM failed: {err:#})"
+                    )),
+                )
+                .await;
+            }
+        }
+    }
+
+    /// Summarize a transcript blob into a terse progress note via the model.
+    /// Used by [`compact_if_needed`]; deltas are not forwarded to the UI.
+    async fn summarize_transcript(&self, blob: &str) -> Result<String> {
+        let request = ChatRequest {
+            model: self.config.model.clone(),
+            messages: vec![
+                ChatMessage::system(
+                    "Summarize the following Wizard agent transcript into a compact progress \
+                     note. Preserve: the mission/goal, decisions made, files changed, commands \
+                     run, what worked/failed, and open next steps. Be terse and factual.",
+                ),
+                ChatMessage::user(blob.to_string()),
+            ],
+            tools: Vec::new(),
+            stream: true,
+            options: Some(ChatOptions {
+                temperature: Some(0.2),
+                num_ctx: None,
+            }),
+        };
+
+        let mut stream = self
+            .client
+            .chat_stream(request)
+            .await
+            .context("starting compaction summary")?;
+        let mut summary = String::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.context("reading compaction stream")?;
+            if let Some(message) = chunk.message {
+                summary.push_str(&message.content);
+            }
+            if chunk.done {
+                break;
+            }
+        }
+        if summary.trim().is_empty() {
+            anyhow::bail!("empty summary");
+        }
+        Ok(summary)
     }
 
     /// Gate, execute, and feed back one tool call. Returns `Some(reason)`
@@ -722,17 +881,30 @@ fn read_project_instructions(project_root: &Path) -> Option<String> {
     None
 }
 
-/// Sovereign-mode headless runner: builds an [`Agent`], runs the task from
-/// `cli.prompt` in an outer loop with `--max-hours` / `--loop` limits, the
-/// `.wizard/loop-control` file, and a circuit breaker (stop after 3
-/// consecutive identical failures). Prints progress to stdout instead of the
-/// TUI.
+/// Sovereign-mode headless runner: builds an [`Agent`] and drives it in an
+/// outer loop. The goal comes from `cli.prompt`, or (on a self-evolve
+/// re-exec) from the persisted [`mission::Mission`]. With `--continuous` it
+/// runs perpetually — persisting a mission, self-directing the next action
+/// after each completed cycle, sleeping-and-waking through transient LLM
+/// outages, compacting context, and re-exec'ing itself after a self-evolve —
+/// until stopped via `.wizard/loop-control`, `--max-hours`, or the circuit
+/// breaker. Otherwise it honors the `--loop N` bound. Prints progress to
+/// stdout instead of the TUI.
 pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
-    let task = cli
-        .prompt
-        .clone()
-        .context("headless mode needs a task: pass -p \"<task>\"")?;
     let project_root = std::env::current_dir().context("determining project root")?;
+
+    // Goal resolution: an explicit `-p` wins; otherwise resume the standing
+    // mission (this is the path taken after a self-evolve re-exec, which
+    // relaunches without `-p`); otherwise there is nothing to do.
+    let goal = if let Some(prompt) = cli.prompt.clone() {
+        prompt
+    } else if let Some(existing) = mission::Mission::load(&project_root)? {
+        existing.goal
+    } else {
+        return Err(anyhow::anyhow!(
+            "headless mode needs a task: pass -p \"<task>\""
+        ));
+    };
 
     let client = OllamaClient::new(&config.ollama_host);
     client
@@ -792,6 +964,9 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
         subagent_configs,
         client.clone(),
         Arc::clone(&base),
+    )));
+    registry.register(Arc::new(crate::tools::evolve::EvolveTool::new(
+        config.clone(),
     )));
 
     // Skills: repo/bundled roots + user (~/.wizard/skills), user shadowing.
@@ -858,24 +1033,53 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     });
 
     println!(
-        "wizard {} — model {} @ {} — task: {task}",
+        "wizard {} — model {} @ {} — task: {goal}",
         config.mode, config.model, config.ollama_host
     );
 
+    // Continuous mode persists a long-lived mission so the loop survives
+    // restarts and binary self-replacement (deep evolve re-exec).
+    let mut mission_state = if config.continuous {
+        let mission = match mission::Mission::load(&project_root)? {
+            Some(existing) => existing,
+            None => {
+                let fresh = mission::Mission::new(goal.clone());
+                fresh.save(&project_root)?;
+                fresh
+            }
+        };
+        Some(mission)
+    } else {
+        None
+    };
+
     let max_iterations = cli.loop_limit.unwrap_or(1).max(1);
-    let mut input = task;
+    let mut input = goal.clone();
     let mut final_reason = DoneReason::Completed;
     let mut run_error: Option<anyhow::Error> = None;
+    // Set when a self-evolve marker is consumed: after draining the printer we
+    // re-exec into the freshly built/extended binary.
+    let mut reexec_after = false;
+    let mut iteration: u32 = 0;
 
-    for iteration in 1..=max_iterations {
+    loop {
+        iteration += 1;
+        if !config.continuous && iteration > max_iterations {
+            break;
+        }
+
+        // Honor a graceful stop at the top of every cycle.
         if read_loop_control(&project_root) == Some(LoopControl::Stop) {
             clear_loop_control(&project_root);
             final_reason = DoneReason::Stopped;
             break;
         }
-        if max_iterations > 1 {
+        if config.continuous {
+            println!("\n=== cycle {iteration} ===");
+        } else if max_iterations > 1 {
             println!("\n=== iteration {iteration}/{max_iterations} ===");
         }
+
         match agent.run_turn(&input, tx.clone()).await {
             Ok(reason) => {
                 final_reason = reason;
@@ -885,10 +1089,33 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                                  complete, summarize what was done."
                             .to_string();
                     }
-                    DoneReason::Completed
-                    | DoneReason::Stopped
-                    | DoneReason::TimeLimit
-                    | DoneReason::CircuitBreaker => break,
+                    DoneReason::Completed => {
+                        if config.continuous {
+                            // Never idle: record the cycle and self-direct the
+                            // next most valuable action toward the mission.
+                            if let Some(mission) = mission_state.as_mut() {
+                                mission.record_cycle(Some(format!("cycle done: {reason:?}")));
+                                mission.save(&project_root)?;
+                                input = format!(
+                                    "You are operating CONTINUOUSLY and autonomously toward this \
+                                     standing mission:\n\n{goal}\n\nYou just reported the current \
+                                     sub-task complete (cycle {}). Re-examine the project state, \
+                                     then choose and carry out the single most valuable next \
+                                     action that advances the mission. If the mission itself is \
+                                     genuinely and fully complete, instead pick a high-value \
+                                     improvement to the project — better tests, docs, \
+                                     performance, robustness — or improve your OWN capabilities \
+                                     using the `evolve` tool. Never idle; always advance.",
+                                    mission.cycles
+                                );
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    DoneReason::Stopped | DoneReason::TimeLimit | DoneReason::CircuitBreaker => {
+                        break;
+                    }
                 }
             }
             Err(err) => {
@@ -896,10 +1123,46 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                 break;
             }
         }
+
+        // After the turn, react to self-evolution markers: a deep rebuild
+        // (`evolve-reexec`) or a tier-1 extension (`evolve-reload`) both mean
+        // the running image is stale, so we re-exec to reload everything.
+        // Only meaningful in continuous mode, where the persisted mission lets
+        // the relaunched process resume without a `-p` goal; a one-shot run
+        // just finishes and the next launch picks up the new binary.
+        let reexec = mission::reexec_marker(&project_root);
+        let reload = mission::reload_marker(&project_root);
+        if config.continuous && (reexec.exists() || reload.exists()) {
+            if let Some(mission) = mission_state.as_ref() {
+                mission.save(&project_root)?;
+            }
+            let _ = std::fs::remove_file(&reexec);
+            let _ = std::fs::remove_file(&reload);
+            reexec_after = true;
+            break;
+        }
+
+        if config.cycle_pause_secs > 0 {
+            tokio::time::sleep(Duration::from_secs(config.cycle_pause_secs)).await;
+        }
     }
 
     drop(tx);
     let _ = printer.await;
+
+    if reexec_after {
+        use std::os::unix::process::CommandExt;
+        let exe = std::env::current_exe().context("locating current executable for re-exec")?;
+        println!("[re-exec into evolved binary {}]", exe.display());
+        let err = std::process::Command::new(exe)
+            .arg("--mode")
+            .arg("sovereign")
+            .arg("--continuous")
+            .arg("--cwd")
+            .arg(&project_root)
+            .exec(); // never returns on success
+        return Err(anyhow::anyhow!("re-exec after evolve failed: {err}"));
+    }
 
     if let Some(err) = run_error {
         return Err(err);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,12 @@ pub struct Cli {
     #[arg(long = "loop", value_name = "N")]
     pub loop_limit: Option<u32>,
 
+    /// Run sovereign mode perpetually: keep working toward the goal,
+    /// self-directing and self-improving, until stopped (loop-control
+    /// `stop` or --max-hours). Implies --mode sovereign.
+    #[arg(long)]
+    pub continuous: bool,
+
     /// Project root override (defaults to the current directory).
     #[arg(long)]
     pub cwd: Option<PathBuf>,
@@ -76,6 +82,7 @@ mod tests {
         assert!(!cli.auto);
         assert_eq!(cli.max_hours, None);
         assert_eq!(cli.loop_limit, None);
+        assert!(!cli.continuous);
         assert_eq!(cli.cwd, None);
         assert!(!cli.resume);
     }
@@ -92,6 +99,7 @@ mod tests {
             "1.5",
             "--loop",
             "10",
+            "--continuous",
             "--cwd",
             "/tmp/project",
             "--resume",
@@ -102,6 +110,7 @@ mod tests {
         assert!(cli.auto);
         assert_eq!(cli.max_hours, Some(1.5));
         assert_eq!(cli.loop_limit, Some(10));
+        assert!(cli.continuous);
         assert_eq!(
             cli.cwd.as_deref(),
             Some(std::path::Path::new("/tmp/project"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,19 @@ pub struct Config {
     /// Agent loop limit per turn (genie). Sovereign uses its own default
     /// unless this is explicitly raised above it.
     pub max_steps: u32,
+    /// Perpetual sovereign operation: keep working/self-directing/self-improving
+    /// until stopped.
+    pub continuous: bool,
+    /// Base seconds for exponential backoff when the LLM server is unreachable
+    /// or rate-limited.
+    pub retry_base_secs: u64,
+    /// Cap on backoff sleep in seconds.
+    pub retry_max_secs: u64,
+    /// Pause between continuous cycles (0 = none).
+    pub cycle_pause_secs: u64,
+    /// When the serialized chat history exceeds this many bytes, compact older
+    /// messages into a summary.
+    pub compact_threshold_bytes: usize,
 }
 
 impl Default for Config {
@@ -76,6 +89,11 @@ impl Default for Config {
             mode: Mode::Genie,
             auto_approve: false,
             max_steps: 25,
+            continuous: false,
+            retry_base_secs: 5,
+            retry_max_secs: 300,
+            cycle_pause_secs: 0,
+            compact_threshold_bytes: 48_000,
         }
     }
 }
@@ -211,6 +229,10 @@ impl Config {
         if let Some(mode) = cli.mode {
             self.mode = mode;
         }
+        if cli.continuous {
+            self.mode = Mode::Sovereign;
+            self.continuous = true;
+        }
         if cli.auto || self.mode == Mode::Sovereign {
             self.auto_approve = true;
         }
@@ -239,6 +261,11 @@ mod tests {
         assert_eq!(config.mode, Mode::Genie);
         assert!(!config.auto_approve);
         assert_eq!(config.max_steps, 25);
+        assert!(!config.continuous);
+        assert_eq!(config.retry_base_secs, 5);
+        assert_eq!(config.retry_max_secs, 300);
+        assert_eq!(config.cycle_pause_secs, 0);
+        assert_eq!(config.compact_threshold_bytes, 48_000);
     }
 
     #[test]
@@ -268,6 +295,11 @@ mod tests {
             mode: Mode::Sovereign,
             auto_approve: true,
             max_steps: 200,
+            continuous: true,
+            retry_base_secs: 10,
+            retry_max_secs: 600,
+            cycle_pause_secs: 30,
+            compact_threshold_bytes: 96_000,
         };
         let raw = toml::to_string_pretty(&original).expect("serialize");
         let parsed: Config = toml::from_str(&raw).expect("parse back");
@@ -276,6 +308,14 @@ mod tests {
         assert_eq!(parsed.mode, original.mode);
         assert_eq!(parsed.auto_approve, original.auto_approve);
         assert_eq!(parsed.max_steps, original.max_steps);
+        assert_eq!(parsed.continuous, original.continuous);
+        assert_eq!(parsed.retry_base_secs, original.retry_base_secs);
+        assert_eq!(parsed.retry_max_secs, original.retry_max_secs);
+        assert_eq!(parsed.cycle_pause_secs, original.cycle_pause_secs);
+        assert_eq!(
+            parsed.compact_threshold_bytes,
+            original.compact_threshold_bytes
+        );
     }
 
     #[test]
@@ -327,6 +367,16 @@ mod tests {
         assert_eq!(config.mode, Mode::Sovereign);
         assert!(config.auto_approve, "sovereign implies auto-approve");
         assert_eq!(config.max_steps, 100, "sovereign raises the step budget");
+    }
+
+    #[test]
+    fn continuous_flag_forces_sovereign() {
+        let mut config = Config::default();
+        config.apply_cli(&cli(&["--continuous"]));
+        assert_eq!(config.mode, Mode::Sovereign);
+        assert!(config.continuous);
+        assert!(config.auto_approve);
+        assert_eq!(config.max_steps, 100);
     }
 
     #[test]

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -51,9 +51,7 @@ impl OllamaError {
         match self {
             OllamaError::Unreachable { .. } => true,
             OllamaError::ModelMissing(_) => false,
-            OllamaError::Api { status, .. } => {
-                status.as_u16() == 429 || status.is_server_error()
-            }
+            OllamaError::Api { status, .. } => status.as_u16() == 429 || status.is_server_error(),
         }
     }
 }

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -43,6 +43,21 @@ pub enum OllamaError {
     },
 }
 
+impl OllamaError {
+    /// Whether this error is transient — a retry after backoff may succeed.
+    /// Connection/timeout failures and server-busy/rate-limit/5xx statuses
+    /// are transient; a missing model or a 4xx (other than 429) is not.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            OllamaError::Unreachable { .. } => true,
+            OllamaError::ModelMissing(_) => false,
+            OllamaError::Api { status, .. } => {
+                status.as_u16() == 429 || status.is_server_error()
+            }
+        }
+    }
+}
+
 /// Client bound to one Ollama host. Cheap to clone.
 #[derive(Debug, Clone)]
 pub struct OllamaClient {
@@ -348,6 +363,33 @@ mod tests {
         let err = parse_chunk_line(r#"{"error":"model 'x' not found"}"#)
             .expect_err("error line must fail");
         assert!(err.to_string().contains("model 'x' not found"));
+    }
+
+    #[test]
+    fn transient_classification() {
+        let status = |code: u16| reqwest::StatusCode::from_u16(code).expect("valid status");
+        assert!(
+            OllamaError::Api {
+                status: status(503),
+                body: String::new(),
+            }
+            .is_transient()
+        );
+        assert!(
+            OllamaError::Api {
+                status: status(429),
+                body: String::new(),
+            }
+            .is_transient()
+        );
+        assert!(
+            !OllamaError::Api {
+                status: status(400),
+                body: String::new(),
+            }
+            .is_transient()
+        );
+        assert!(!OllamaError::ModelMissing("m".to_string()).is_transient());
     }
 
     #[tokio::test]

--- a/src/tools/evolve.rs
+++ b/src/tools/evolve.rs
@@ -1,0 +1,170 @@
+//! `evolve` tool: lets the agent extend or rebuild ITSELF at runtime.
+//! Wraps the tiered self-extension pipeline (`crate::evolve`). In sovereign
+//! mode this is auto-approved; in genie mode it is gated behind confirmation
+//! (`requires_approval` = true). A successful deep rebuild drops a re-exec
+//! marker so the continuous loop relaunches into the new binary.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{Tool, ToolContext, ToolError, ToolOutput, parse_args};
+use crate::config::Config;
+use crate::evolve::{EvolveOutcome, EvolveRequest, EvolveTier, Evolver};
+
+/// `evolve` — add a new capability to Wizard itself, or deep-rebuild its
+/// binary.
+pub struct EvolveTool {
+    config: Config,
+}
+
+impl EvolveTool {
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+}
+
+/// Arguments for [`EvolveTool`].
+#[derive(Debug, Deserialize)]
+pub struct EvolveArgs {
+    /// Precise natural-language spec of the capability to add.
+    pub description: String,
+    /// When true, change Wizard's own Rust source and rebuild the binary
+    /// (Tier 2). Defaults to a fast runtime extension (Tier 1).
+    #[serde(default)]
+    pub deep: bool,
+}
+
+#[async_trait]
+impl Tool for EvolveTool {
+    fn name(&self) -> &str {
+        "evolve"
+    }
+
+    fn description(&self) -> &str {
+        "Add a NEW capability to yourself when the current task needs one you \
+         lack. By default (deep=false) this performs a fast runtime extension — \
+         it adds a skill, MCP server, scripted tool, or subagent under \
+         ~/.wizard/ with no recompile. Set deep=true ONLY when the capability \
+         genuinely requires changing Wizard's own Rust source: this rebuilds and \
+         replaces the running binary, is much slower, and is gated by a build \
+         plus smoke test (falling back to a runtime extension if no toolchain or \
+         source is available). The `description` argument is a precise \
+         natural-language specification of the capability you want."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "Precise natural-language spec of the capability to add to yourself."
+                },
+                "deep": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Change Wizard's own Rust source and rebuild the binary (slow). Default false uses a fast runtime extension."
+                }
+            },
+            "required": ["description"]
+        })
+    }
+
+    fn requires_approval(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let args: EvolveArgs = parse_args(self.name(), args)?;
+
+        let request = EvolveRequest {
+            description: args.description,
+            tier: if args.deep {
+                EvolveTier::Deep
+            } else {
+                EvolveTier::Runtime
+            },
+            // The Tool-layer/genie approval gate already governs whether this
+            // `execute` is reached, so the pipeline itself need not re-prompt.
+            auto_approve: true,
+        };
+
+        let outcome = match Evolver::new(self.config.clone()).run(request).await {
+            Ok(outcome) => outcome,
+            Err(err) => return Ok(ToolOutput::error(format!("evolve failed: {err:#}"))),
+        };
+
+        let summary = match outcome {
+            EvolveOutcome::DeepRebuilt { binary } => {
+                let marker_note = write_marker(ctx, "evolve-reexec");
+                format!(
+                    "Deep evolve rebuilt Wizard's binary at {}. {marker_note}",
+                    binary.display()
+                )
+            }
+            EvolveOutcome::SkillAdded { name, path } => {
+                let marker_note = write_marker(ctx, "evolve-reload");
+                format!("Added skill '{name}' at {}. {marker_note}", path.display())
+            }
+            EvolveOutcome::McpServerRegistered { name } => {
+                let marker_note = write_marker(ctx, "evolve-reload");
+                format!("Registered MCP server '{name}'. {marker_note}")
+            }
+            EvolveOutcome::ScriptedToolAdded { name, path } => {
+                let marker_note = write_marker(ctx, "evolve-reload");
+                format!(
+                    "Added scripted tool '{name}' at {}. {marker_note}",
+                    path.display()
+                )
+            }
+            EvolveOutcome::SubagentAdded { name } => {
+                let marker_note = write_marker(ctx, "evolve-reload");
+                format!("Added subagent '{name}'. {marker_note}")
+            }
+            EvolveOutcome::FellBackToRuntime { reason, outcome } => {
+                let marker_note = write_marker(ctx, "evolve-reload");
+                format!(
+                    "Deep evolve fell back to a runtime extension ({reason}): {}. {marker_note}",
+                    describe_outcome(&outcome)
+                )
+            }
+            EvolveOutcome::Denied => {
+                return Ok(ToolOutput::error("evolve was denied"));
+            }
+        };
+
+        Ok(ToolOutput::ok(summary))
+    }
+}
+
+/// Drop an empty marker file under `<cwd>/.wizard/` so the supervising loop
+/// knows to react (relaunch on `evolve-reexec`, hot-reload the registry on
+/// `evolve-reload`). Returns a note describing success or failure rather than
+/// propagating the error.
+fn write_marker(ctx: &ToolContext, name: &str) -> String {
+    let dir = ctx.cwd.join(".wizard");
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        return format!("(could not create {} marker: {err})", dir.display());
+    }
+    let marker = dir.join(name);
+    match std::fs::write(&marker, b"") {
+        Ok(()) => format!("Wrote {} marker for the loop.", marker.display()),
+        Err(err) => format!("(could not write {} marker: {err})", marker.display()),
+    }
+}
+
+/// One-line description of a nested Tier-1 outcome (used for fallbacks).
+fn describe_outcome(outcome: &EvolveOutcome) -> String {
+    match outcome {
+        EvolveOutcome::SkillAdded { name, .. } => format!("added skill '{name}'"),
+        EvolveOutcome::McpServerRegistered { name } => format!("registered MCP server '{name}'"),
+        EvolveOutcome::ScriptedToolAdded { name, .. } => format!("added scripted tool '{name}'"),
+        EvolveOutcome::SubagentAdded { name } => format!("added subagent '{name}'"),
+        EvolveOutcome::DeepRebuilt { binary } => format!("rebuilt binary at {}", binary.display()),
+        EvolveOutcome::FellBackToRuntime { reason, outcome } => {
+            format!("fell back ({reason}): {}", describe_outcome(outcome))
+        }
+        EvolveOutcome::Denied => "denied".to_string(),
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@
 //! MCP tools (`crate::mcp`). All three present a uniform interface through
 //! [`registry::ToolRegistry`], so the model calls them identically.
 
+pub mod evolve;
 pub mod file;
 pub mod git;
 pub mod registry;


### PR DESCRIPTION
## What

Adds `--continuous`, turning sovereign mode into a **perpetual, self-directing agent with no human in the loop**. Given one goal it never stops at "done": each cycle it self-directs the next most valuable action, and when the mission is complete it shifts to improvements or extends its own capabilities via `evolve`.

```bash
wizard --continuous -p "keep hardening this codebase: tests, docs, performance"
```

## How it runs forever

| Capability | Mechanism |
|---|---|
| **Runs forever** | Unbounded outer loop in `--continuous`; a completed turn records a cycle and self-prompts the next action instead of breaking |
| **Sleeps & wakes** | Transient Ollama failures (unreachable, `429`/`5xx`, dropped stream) back off exponentially (`retry_base_secs`→`retry_max_secs`) and retry indefinitely instead of aborting |
| **Durable mission** | Goal + cycle count + progress log persisted to `.wizard/mission.toml`; survives restarts and binary self-replacement (relaunch with `--continuous`, no `-p`, resumes from disk) |
| **Self-improves** | `evolve` is now an agent-callable tool (auto-approved in sovereign, gated in genie). A tier-1 extension or deep binary rebuild saves the mission and **re-execs into the new image**, then resumes |
| **Never overflows** | History past `compact_threshold_bytes` is summarized into a compact progress note so runs continue indefinitely |

## Safety rails (automated, not human-in-the-loop)

Kept intact: `.wizard/loop-control` `stop` kill switch, circuit breaker (3 identical failures), `--max-hours`. Deep self-modification stays gated by `cargo build` + `--version` smoke test, with `wizard.prev` one-`mv` rollback and every evolution appended to `~/.wizard/evolution.jsonl`. Re-exec only fires in continuous mode, so a one-shot deep evolve doesn't relaunch into a missing mission.

## New surface

- **CLI:** `--continuous` (implies `--mode sovereign`)
- **Config:** `continuous`, `retry_base_secs` (5), `retry_max_secs` (300), `cycle_pause_secs` (0), `compact_threshold_bytes` (48000)
- **New files:** `src/agent/mission.rs`, `src/tools/evolve.rs`
- **Docs:** README + `docs/modes.md` "Continuous mode" section, with a container/VM warning

## Verification

- `cargo test`: 152 lib + 4 integration pass, 0 failed
- `cargo clippy --all-targets`: clean
- `cargo build` + `cargo build --release`: clean
- `--continuous` confirmed in `--help`

⚠️ **Compile-verified, not behavior-verified.** Not yet run against a live Ollama in a real perpetual loop — recommend a smoke test (`wizard --continuous -p "..." --max-hours 0.1` in a throwaway repo, then `echo stop > .wizard/loop-control`) before merge, given the unattended self-rewriting behavior.