### PR TITLE
feat: Claude Code feature parity — hooks, plan mode, web tools, checkpoints, scheduler, fleet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +444,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +505,27 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -615,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +763,37 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever_rcdom",
+ "phf",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
 
 [[package]]
 name = "http"
@@ -1094,6 +1199,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1268,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1214,6 +1359,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1459,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1526,6 +1730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1827,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.39.0",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1928,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1756,6 +2012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +2050,31 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -1892,6 +2179,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -2268,6 +2565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2769,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -2849,10 +3164,12 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "globset",
+ "htmd",
  "indicatif",
  "pulldown-cmark",
  "ratatui",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -2874,6 +3191,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,12 +413,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -425,11 +460,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -441,6 +487,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1072,7 +1149,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1625,7 +1702,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -2088,7 +2165,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2101,6 +2187,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3159,6 +3257,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "croner",
  "crossterm",
  "dirs",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 
+# Web tools: HTML → markdown for web_fetch, result scraping for web_search
+htmd = "0.5"
+scraper = "0.27"
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ indicatif = "0.17"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 
+# Cron parsing + next-occurrence math (`wizard schedule` / `wizard scheduler`)
+croner = "3"
+
 # File matching for list_files / skills discovery
 globset = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 - [Fork and distribute](docs/market.md): publish your evolved Wizard; one-line installer for your fork
 - [Default loadout](docs/loadout.md): the preconfigured browser MCP and subagent roster
 - [Bring your own model](docs/byom.md): any GGUF, or custom Ollama models
+- [Doctor & status](docs/doctor.md): `wizard doctor` diagnostics, `/status`
 - [Architecture](docs/architecture.md): how it's built
 - [Security](SECURITY.md): threat model
 - [WIZARD.md](WIZARD.md): the agent's bundled behavioral charter; inherited and editable by every fork

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 - [Bring your own model](docs/byom.md): any GGUF, or custom Ollama models
 - [Doctor & status](docs/doctor.md): `wizard doctor` diagnostics, `/status`
 - [Scheduler](docs/scheduler.md): cron-scheduled headless runs; `wizard schedule`, `wizard scheduler`
+- [Fleet](docs/fleet.md): parallel workers over git worktrees; `wizard fleet run -n N -p "<mission>"`
 - [Architecture](docs/architecture.md): how it's built
 - [Security](SECURITY.md): threat model
 - [WIZARD.md](WIZARD.md): the agent's bundled behavioral charter; inherited and editable by every fork

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 - [Default loadout](docs/loadout.md): the preconfigured browser MCP and subagent roster
 - [Bring your own model](docs/byom.md): any GGUF, or custom Ollama models
 - [Doctor & status](docs/doctor.md): `wizard doctor` diagnostics, `/status`
+- [Scheduler](docs/scheduler.md): cron-scheduled headless runs; `wizard schedule`, `wizard scheduler`
 - [Architecture](docs/architecture.md): how it's built
 - [Security](SECURITY.md): threat model
 - [WIZARD.md](WIZARD.md): the agent's bundled behavioral charter; inherited and editable by every fork

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 
 - [Getting started](docs/getting-started.md): install, tiers, first run, troubleshooting
 - [Modes](docs/modes.md): genie vs sovereign
+- [Headless output](docs/headless.md): `--output-format text|json|stream-json`, exit codes
 - [Checkpoints](docs/checkpoints.md): per-file snapshots, `/rewind`, perpetual rollback
 - [Custom commands & @files](docs/commands.md): your own `/commands`; `@path` file references
 - [Self-extension](docs/evolve.md): `/evolve` tiers, gates, rollback

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 - [Getting started](docs/getting-started.md): install, tiers, first run, troubleshooting
 - [Modes](docs/modes.md): genie vs sovereign
 - [Checkpoints](docs/checkpoints.md): per-file snapshots, `/rewind`, perpetual rollback
+- [Custom commands & @files](docs/commands.md): your own `/commands`; `@path` file references
 - [Self-extension](docs/evolve.md): `/evolve` tiers, gates, rollback
 - [Fork and distribute](docs/market.md): publish your evolved Wizard; one-line installer for your fork
 - [Default loadout](docs/loadout.md): the preconfigured browser MCP and subagent roster

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Wizard's bet is narrower: one binary, any model you choose, an onboarding that s
 
 - [Getting started](docs/getting-started.md): install, tiers, first run, troubleshooting
 - [Modes](docs/modes.md): genie vs sovereign
+- [Checkpoints](docs/checkpoints.md): per-file snapshots, `/rewind`, perpetual rollback
 - [Self-extension](docs/evolve.md): `/evolve` tiers, gates, rollback
 - [Fork and distribute](docs/market.md): publish your evolved Wizard; one-line installer for your fork
 - [Default loadout](docs/loadout.md): the preconfigured browser MCP and subagent roster

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,6 +231,7 @@ Ratatui + crossterm terminal UI:
 | `~/.wizard/evolution.jsonl` | Self-extension log |
 | `~/.wizard/logs/` | Debug traces |
 | `.wizard/loop-control` | Sovereign-mode run control (per project) |
+| `.wizard/checkpoints/` | Per-file edit snapshots powering `/rewind` (per project; see [checkpoints.md](checkpoints.md)) |
 
 ## Install scripts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,9 +146,13 @@ Sessions are appended to `~/.wizard/sessions/<timestamp>.jsonl` after each turn.
 | `edit_file` | Search-and-replace edit |
 | `list_files` | Directory listing with glob filter |
 | `search_files` | Ripgrep/grep content search |
-| `execute` | Run shell command with timeout |
+| `execute` | Run shell command with timeout; `run_in_background` detaches it as a background task ([tasks.md](tasks.md)) |
 | `git_status` | Working tree status |
 | `git_diff` | Staged/unstaged diff |
+| `web_fetch` | Fetch a URL, HTML converted to markdown; SSRF-guarded ([web.md](web.md)) |
+| `web_search` | Web search via DuckDuckGo (default), Brave, or Tavily ([web.md](web.md)) |
+| `task_output` | Status and buffered output of a background task ([tasks.md](tasks.md)) |
+| `task_kill` | Kill a running background task ([tasks.md](tasks.md)) |
 
 Both modes auto-approve tool calls by default. Genie is conversational and interactive; sovereign works continuously without human input.
 

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -1,0 +1,81 @@
+# Checkpoints and /rewind
+
+Wizard snapshots every file it is about to edit, per turn, so a turn (or a run of
+turns) can be rewound — files restored to their before-state and the conversation
+truncated to match. There are no approval prompts anywhere in this: every tool call
+still executes directly; checkpoints are the undo, not a gate.
+
+## How it works
+
+Before an edit-class tool (`write_file`, `edit_file`) runs — after pre-tool hooks have
+had their chance to rewrite the arguments — the dispatcher copies the target file's
+current content into the project's checkpoint store. Subagent edits go through the same
+seam, snapshotted under the parent's current turn. The first snapshot of a path within a
+turn wins: that is the turn's before-state, no matter how many times the turn rewrites
+the file. A tool about to create a new file records that instead, so a rewind deletes
+the file.
+
+Snapshotting is best-effort by design: a checkpoint failure is logged and the tool call
+proceeds. The agent can always work; it just might not be rewindable.
+
+### Why not shadow-git
+
+The repo Wizard runs in may be edited concurrently by other processes (other agents,
+editors, builds). A git-based snapshot would capture and restore *their* changes too.
+Copy-on-write snapshots only ever touch files Wizard itself modified.
+
+## On disk
+
+```
+<project>/.wizard/checkpoints/
+  index.jsonl        one record per snapshot: {turn, tool, path, snap, existed_before}
+  <turn>/<n>.snap    copied file contents
+```
+
+Turn ids are monotonic per project (they continue across sessions). Corrupt index lines
+are skipped on load. Like the rest of `.wizard/` (plan.md, mission.toml), the directory
+is plain files you can inspect or delete.
+
+## /rewind (TUI)
+
+```
+/rewind          # open the turn picker
+/rewind 12       # rewind directly to before turn 12
+```
+
+The picker lists recent turns newest first, each with its turn number, the first line of
+the prompt that started it, and the files its edits touched. ↑/↓ select, Enter rewinds,
+Esc cancels.
+
+Rewinding to turn N:
+
+- restores every snapshot from turn N onward — the earliest before-state of each file
+  wins, and files that did not exist before are deleted;
+- truncates the session file at turn N's marker and reloads the in-memory conversation,
+  so the model no longer remembers the rewound turns;
+- prunes the rewound turns from the checkpoint store.
+
+Session files carry one turn-marker line per turn for this; older session files without
+markers still load (they just cannot anchor a conversation truncation).
+
+## Perpetual rollback
+
+```toml
+# ~/.wizard/config.toml
+rollback_failed_cycles = true   # default false
+```
+
+In continuous mode, when a cycle ends in a circuit breaker or a hard error, the cycle's
+file edits are restored before the run ends, and the rollback is noted in the mission's
+progress log (`.wizard/mission.toml`). Off by default: a failed cycle's partial work is
+sometimes worth keeping.
+
+## Retention
+
+```toml
+[checkpoints]
+keep_turns = 50   # default
+```
+
+Snapshots of all but the most recent `keep_turns` turns are garbage-collected once at
+session start.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,52 @@
+# Custom commands and @file references
+
+Two ways to put reusable text in front of the model: `/commands` you define as markdown files, and `@path` tokens that inline file contents. Both work identically in the TUI and in headless `-p` runs — one shared preprocessing pipeline (`src/commands.rs`) handles them.
+
+## Custom slash commands
+
+A custom command is a markdown file whose body is a prompt template:
+
+- `~/.wizard/commands/*.md` — global, available in every project
+- `<project>/.wizard/commands/*.md` — per project, shadows a global command with the same name
+
+The file stem is the command name: `review.md` defines `/review`. An optional frontmatter block (the same `---`-fenced convention as skills) carries a `description` shown in the TUI suggestion popup:
+
+```markdown
+---
+description: review a file against the project conventions
+---
+Review $1 carefully. Check it against the conventions in @WIZARD.md.
+Focus on: $ARGUMENTS
+```
+
+### Placeholders
+
+| Placeholder | Expands to |
+|-------------|------------|
+| `$ARGUMENTS` | everything typed after the command name |
+| `$1` … `$9` | the whitespace-split positional arguments (missing ones expand to the empty string) |
+
+Expansion is a single pass: `$`-like text inside the arguments themselves is never re-expanded.
+
+### Invocation
+
+- **TUI:** type `/review src/app.rs` — custom commands show up in the same suggestion popup as builtins (builtins win a name collision). The transcript shows what you typed; the model sees the expanded template.
+- **Headless:** `wizard -p "/review src/app.rs"` expands exactly the same way.
+- A `/word` that matches no builtin and no custom command is passed to the model as a normal prompt.
+- `/reload` picks up new and edited command files without a restart.
+
+## @file references
+
+Any whitespace-delimited token of the form `@path` whose path resolves to an existing file expands to a fenced code block with the file's contents:
+
+```
+explain @src/main.rs and how it relates to @docs/architecture.md
+```
+
+- Paths resolve relative to the project root; absolute paths and `~/` work too.
+- Contents are capped at 50KB per file, with a truncation note when cut.
+- Image files (`.png .jpg .jpeg .gif .webp`) are replaced by a note — this build has no vision path to attach them to.
+- A token that does not resolve to a file is left untouched, so email addresses (`user@host`) and decorators pass through. `@@path` escapes a literal `@path`.
+- **TUI:** Tab completes the path under the cursor from its directory listing after you type `@`.
+
+The expansion happens before the prompt reaches the agent, so the file contents land in the conversation history (and survive into the session file) like any other user text.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,52 @@
+# Doctor and status
+
+## `wizard doctor`
+
+Diagnoses the environment and prints one line per check:
+
+```
+✓ config            /home/you/.wizard/config.toml parses
+✓ provider local    llamacpp @ http://127.0.0.1:8080 (qwen3-30b) reachable
+– provider openai   $OPENAI_API_KEY not set
+✗ mcp playwright    spawn failed: No such file or directory (os error 2)
+✓ native tools      14 tools registered
+– hooks (global)    /home/you/.wizard/hooks.toml absent (no hooks)
+✓ hooks (project)   2 hook(s) in .wizard/hooks.toml
+✓ ~/.wizard         /home/you/.wizard writable
+✓ project .wizard   .wizard writable
+✓ sessions          /home/you/.wizard/sessions writable
+✓ checkpoints       12 snapshot(s) across 4 turn(s)
+```
+
+Checks:
+
+- **config** — `~/.wizard/config.toml` parses (missing file is fine: defaults apply)
+- **provider \<name\>** — each configured LLM provider answers its health probe; skipped (`–`) when its API key env var is unset
+- **mcp \<name\>** — each `[[server]]` in `~/.wizard/mcp.toml` spawns and completes the MCP handshake (with tool count)
+- **native tools** — the compiled-in tool set is registered
+- **hooks** — global and project `hooks.toml` parse
+- **writable** — `~/.wizard`, the project's `.wizard/`, and the sessions dir accept writes
+- **checkpoints** — the snapshot index parses; stale snapshot directories are counted
+
+Every network probe is capped at 5 seconds, so doctor never hangs. Exit code: 0 when no check failed (`–` skips are not failures), 1 otherwise — usable as a preflight in scripts:
+
+```sh
+wizard doctor && wizard --mode sovereign -p "task"
+```
+
+`/doctor` in the TUI runs the same battery and prints the report to the transcript.
+
+## `/status`
+
+A one-shot snapshot of the running TUI session:
+
+```
+model: qwen3-30b
+provider: local (LlamaCpp @ http://127.0.0.1:8080)
+mode: genie
+session: 2026-06-11T09-30-00
+usage: 1200 prompt + 240 completion tokens
+background tasks: 1 running
+todos: 2/5 done
+plan mode: off
+```

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -1,0 +1,115 @@
+# Fleet: `wizard fleet`
+
+Parallel sovereign workers over git worktrees. One coordinator process plans
+a mission, fans the resulting tasks out to up to N headless `wizard` children
+(each in its own worktree on its own branch), supervises them, and finally
+merges the fleet branches back into the current branch.
+
+```bash
+wizard fleet run -n 3 -p "raise test coverage of the parser and document the public API"
+wizard fleet status   # task table: queued | running | done
+wizard fleet stop     # ask a running fleet to wind down
+```
+
+`fleet run` must be invoked inside a git repository with at least one commit
+— workers run in `git worktree`s. It loads `~/.wizard/config.toml` (the
+planning and synthesis turns drive a real in-process agent); `status` and
+`stop` only touch the project's `.wizard/fleet/` directory.
+
+## Lifecycle
+
+1. **Planning** — one in-process agent turn decomposes the mission into at
+   most `2 × N` independent tasks (`{id, title, prompt, files_hint}`). The
+   reply is parsed liberally (fenced or prose-wrapped JSON works); one retry
+   quotes the parse error back at the model. Each task lands in
+   `queue/<id>.json`.
+2. **Running** — the coordinator creates one worktree per worker slot
+   (`.wizard/fleet/worktrees/<i>`, branch `fleet/<i>-<slug>`; a timestamp
+   suffix is appended when a previous run already took the name) and then
+   supervises on a 1-second tick:
+   - **claiming**: the coordinator claims tasks for workers by atomically
+     renaming `queue/<id>.json` into `claimed/` and spawns
+     `wizard --mode sovereign -p "<task>" --cwd <worktree> --output-format json`
+     with `WIZARD_FLEET=1`, at most N children at a time. Worker prompts end
+     with: commit your changes with a descriptive message; do not push.
+   - **reaping**: when a child exits, its exit code, branch, and parsed JSON
+     summary (the `--output-format json` object from stdout) are written to
+     `results/<id>.json`, and the slot's worktree is reused for the next
+     queued task.
+   - **watchdog**: a child running past `[fleet] max_minutes` is killed and
+     recorded as timed out.
+   - **heartbeat**: `.wizard/fleet/heartbeat` is touched every tick.
+   - **stop**: a `stop` sentinel (written by `wizard fleet stop`) or ctrl-c
+     kills the children, marks `fleet.toml` stopped, and skips synthesis.
+3. **Synthesis** — once the queue drains and every child has exited, the
+   coordinator runs a second in-process turn in the MAIN checkout (never a
+   worktree): merge each fleet branch into the current branch sequentially,
+   resolve trivial conflicts, abort and report anything non-trivial. Nothing
+   is ever forced; failed merges are left to you, on their branches. Set
+   `[fleet] synthesize = false` to skip the merge and just print the branch
+   list and results table.
+4. **Teardown** — worktrees are removed, branches are kept (also on failure
+   or stop, so no work is ever lost), `fleet.toml` flips to `done`, and the
+   final task table prints.
+
+## File layout
+
+Project-local, rooted at the current directory:
+
+```
+.wizard/fleet/
+├── fleet.toml          # mission, worker count, status, child pids
+├── queue/<id>.json     # tasks not yet claimed
+├── claimed/<id>.json   # tasks claimed by a worker slot
+├── results/<id>.json   # task_id, title, branch, exit, timed_out, summary
+├── worktrees/<i>/      # per-slot git worktree (removed at the end)
+├── logs/<id>.stdout    # raw child output (the JSON summary)
+├── logs/<id>.stderr    # child diagnostics
+├── heartbeat           # unix timestamp, touched every supervision tick
+└── stop                # sentinel written by `wizard fleet stop`
+```
+
+`fleet.toml` status walks `planning → running → synthesizing → done` (or
+`stopped`). Each `wizard fleet run` resets `queue/`, `claimed/`, `results/`,
+and `logs/` from the previous run.
+
+## status and stop
+
+`wizard fleet status` prints the mission, the fleet status line, live child
+pids, and a per-task table:
+
+```
+task        state    exit  branch            title
+add-tests   done     0     fleet/0-raise-te  Add parser tests
+write-docs  running  -     -                 Document the API
+fix-lints   queued   -     -                 Fix clippy lints
+```
+
+`exit` is the child's exit code (the headless map: 0 completed/stopped,
+2 max-steps, 3 circuit breaker, 4 time limit), `timeout` for a watchdog
+kill, or `killed` for signal death / shutdown.
+
+`wizard fleet stop` writes the stop sentinel and returns immediately; the
+coordinator winds down on its next tick. Ctrl-c on the coordinator behaves
+the same way.
+
+## Config
+
+```toml
+[fleet]
+max_minutes = 30   # per-worker wall-clock cap; the watchdog kills past it
+synthesize = true  # false: skip the merge turn, just print branches + table
+```
+
+## Caveats
+
+- Workers share no state: tasks must be genuinely independent. The planning
+  prompt asks for non-overlapping files, but the model can get this wrong —
+  overlapping tasks surface as merge conflicts at synthesis, where
+  non-trivial ones are reported, not forced.
+- Branches are kept on every path — completed, failed, timed out, stopped —
+  so partial work is always recoverable with a manual `git merge`.
+- A worker slot reuses its worktree (and branch) for consecutive tasks, so
+  one `fleet/<i>-<slug>` branch can carry commits from several tasks.
+- The coordinator claims tasks; workers never touch the queue. Killing the
+  coordinator also kills the workers (`kill_on_drop`).

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,0 +1,68 @@
+# Headless output formats and exit codes
+
+A sovereign run (`wizard --mode sovereign -p "task"`, or any `-p` run without a terminal) prints to stdout. `--output-format` selects how:
+
+## `text` (default)
+
+The human-readable stream you get today: assistant deltas as they arrive, dimmed reasoning, `→ tool` / `← tool [ok]` one-liners, a busy spinner on terminals, and a `[run finished: ...]` trailer with token totals.
+
+## `json`
+
+Silent until the run ends, then exactly one JSON object on stdout:
+
+```json
+{
+  "result": "the assistant's accumulated text",
+  "reason": "completed",
+  "turns": 1,
+  "steps": 3,
+  "usage": {"prompt_tokens": 1200, "completion_tokens": 240},
+  "tool_calls": [{"name": "execute", "calls": 2, "errors": 0}],
+  "errors": []
+}
+```
+
+`reason` is one of `completed | max_steps | time_limit | stopped | circuit_breaker`.
+
+## `stream-json`
+
+One JSON object per line (JSONL) as events arrive, always terminated by a `done` line:
+
+```
+{"type":"tool_call","name":"execute","args":{"command":"cargo test"}}
+{"type":"tool_result","name":"execute","is_error":false,"output":"..."}
+{"type":"step","step":1}
+{"type":"text_delta","text":"All tests pass."}
+{"type":"usage","prompt_tokens":1200,"completion_tokens":240}
+{"type":"turn_done","reason":"completed"}
+{"type":"done","reason":"completed","usage":{"prompt_tokens":1200,"completion_tokens":240}}
+```
+
+Other line types you may see: `thinking_delta`, `todo`, `task_finished`, `plan` (auto-approved, with the plan text), `hook`, and `error`. `turn_done` closes each agent turn; the final `done` line carries the run outcome and total usage.
+
+In both structured formats the spinner and decorative headers are suppressed — stdout is pure JSON; diagnostics go to stderr.
+
+## Exit codes
+
+The process exit code encodes why the run ended:
+
+| Code | Meaning |
+|------|---------|
+| 0 | completed (or gracefully stopped via `.wizard/loop-control`) |
+| 1 | hard error (config, provider unreachable, ...) |
+| 2 | step budget exhausted (`max_steps`) |
+| 3 | circuit breaker (repeated identical failures) |
+| 4 | `--max-hours` time limit |
+
+So a CI invocation can distinguish "the agent finished" from "the agent gave up":
+
+```sh
+wizard --mode sovereign -p "make the tests pass" --output-format json > result.json
+case $? in
+  0) echo ok ;;
+  2) echo "ran out of steps" ;;
+  *) echo "failed" ;;
+esac
+```
+
+The TUI and the gateway are unaffected by `--output-format`; they always exit 0 on a clean quit.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,97 @@
+# Lifecycle hooks
+
+Hooks are shell commands that Wizard runs at fixed points of the agent's lifecycle: before and after every tool call, when a prompt is submitted, and at session and turn boundaries. They fire in **every mode** — genie (TUI), sovereign (headless), perpetual (`--continuous`), and the gateway — and apply to subagent tool calls too. Use them to enforce policy (block dangerous commands), inject context (project status, time of day), or log activity.
+
+There is no permission prompting in Wizard; hooks are the programmable seam where you put guardrails instead.
+
+## Declaring hooks
+
+Hooks live in TOML files, loaded when an agent is built:
+
+- `~/.wizard/hooks.toml` — global, applies everywhere
+- `<project>/.wizard/hooks.toml` — per project, appended after the global hooks
+
+```toml
+[[hooks]]
+event = "pre_tool_use"           # which lifecycle event (see below)
+matcher = "execute"              # optional glob over the tool name
+command = "/path/to/script.sh"   # run via `sh -c` in the project root
+timeout_secs = 30                # optional; default 60
+```
+
+`matcher` is a glob (`"execute"`, `"git_*"`, `"*file*"`) over the tool name and only applies to the tool events; other events ignore it. Omit it to match every tool. Hooks for the same event run sequentially in declaration order (global first, then project).
+
+A missing file means no hooks — the default behavior is unchanged. An invalid file or matcher is skipped with a logged warning; it never prevents startup.
+
+## Events
+
+| Event | When | What the hook can do |
+|-------|------|----------------------|
+| `pre_tool_use` | Before a tool call executes | Rewrite the arguments, or block the call |
+| `post_tool_use` | After a tool call executes | Append context to the tool result |
+| `user_prompt_submit` | When a message starts a turn | Block the turn, or append context to the message |
+| `session_start` | Once when a session begins | Append system context for the whole session |
+| `session_end` | Once when a session ends | Observe only |
+| `turn_end` | After every turn finishes | Observe only |
+
+"Session" means: TUI launch to quit, one headless run (including all continuous cycles), or the gateway's whole serve lifetime.
+
+## Payload
+
+Each hook receives one JSON object on stdin:
+
+```json
+{
+  "event": "pre_tool_use",
+  "tool_name": "execute",
+  "args": {"command": "cargo test"},
+  "cwd": "/path/to/project",
+  "session_id": "2026-06-11T09-30-00",
+  "mode": "genie"
+}
+```
+
+`tool_name` and `args` are `null` for the non-tool events. A hook that does not care about the payload can simply not read stdin.
+
+## Exit-code semantics
+
+- **Exit 0 — continue.**
+  - `pre_tool_use`: if stdout parses as JSON with `{"updated_args": {...}}`, the tool runs with those arguments instead (later hooks in the chain see the rewritten args). Any other stdout is ignored.
+  - `post_tool_use`: non-empty stdout is appended to the tool result the model sees.
+  - `user_prompt_submit` / `session_start`: non-empty stdout is appended to the user message / the session's system context.
+  - `session_end` / `turn_end`: stdout is ignored.
+- **Exit 2 — block.** stderr is the reason.
+  - `pre_tool_use`: the tool does not run; the model gets `blocked by pre_tool_use hook: <reason>` as an ordinary tool error and can adjust course. Repeated blocked calls count toward the same failure breakers as any other tool failure.
+  - `user_prompt_submit`: the turn ends immediately with a notice; the prompt never reaches the model.
+  - Other events cannot block; exit 2 there is treated like any other failure.
+- **Anything else — ignored.** A different exit code, a timeout (`timeout_secs`, default 60 — the process is killed), or a spawn failure is surfaced as a warning and the pipeline continues. Hooks must never wedge the agent.
+
+Hook activity that changes something (a rewrite, appended context, a block, a warning) shows up as a dim log line in the TUI and a printed line headless; silent successes stay silent.
+
+## Examples
+
+Block shell commands that mention `rm -rf`:
+
+```toml
+[[hooks]]
+event = "pre_tool_use"
+matcher = "execute"
+command = "jq -e '.args.command | test(\"rm -rf\") | not' > /dev/null || { echo 'rm -rf is not allowed' >&2; exit 2; }"
+```
+
+Remind the model of the branch policy on every prompt:
+
+```toml
+[[hooks]]
+event = "user_prompt_submit"
+command = "echo \"current branch: $(git branch --show-current) — never commit to main directly\""
+```
+
+Log every completed turn:
+
+```toml
+[[hooks]]
+event = "turn_end"
+command = "date >> ~/.wizard/logs/turns.log"
+timeout_secs = 5
+```

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -138,6 +138,7 @@ appended to `~/.wizard/evolution.jsonl`.
 | `retry_max_secs` | `300` | Cap on backoff between retries |
 | `cycle_pause_secs` | `0` | Pause between continuous cycles |
 | `compact_threshold_bytes` | `48000` | History size that triggers compaction |
+| `rollback_failed_cycles` | `false` | Restore a failed cycle's file checkpoints (see [checkpoints.md](checkpoints.md)) |
 
 > **Run it in a container or VM.** Continuous mode auto-approves every tool call with no
 > human in the loop and can rewrite its own binary. Point it only at work you're willing

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -143,6 +143,40 @@ appended to `~/.wizard/evolution.jsonl`.
 > human in the loop and can rewrite its own binary. Point it only at work you're willing
 > to let it touch unattended, and read [SECURITY.md](../SECURITY.md) first.
 
+## Plan mode
+
+Plan mode is an overlay that works in every mode (genie, sovereign, continuous, gateway): the agent first investigates with read-only tools, presents a plan, and only executes once the plan is approved.
+
+While plan mode is on:
+
+- Only read-only tools run (`read_file`, `list_files`, `search_files`, `git_status`, `git_diff`, ...). Every other tool — including `execute`, file writes, scripted/MCP tools, and `spawn_subagent` — returns a "blocked by plan mode" error to the model. These blocks are fed back as ordinary tool errors (not fatal) and are exempt from the circuit breakers.
+- The one way out is the `exit_plan` tool: the model calls it with the finished plan as markdown. The plan is saved to `<project>/.wizard/plan.md` and presented for a verdict.
+- Approval ends plan mode and the model executes the plan in the same turn. Rejection (with optional feedback) keeps plan mode on; the feedback is fed back so the model can revise and call `exit_plan` again.
+
+### TUI (genie)
+
+```
+/plan          # toggle plan mode (Shift+Tab does the same)
+```
+
+The status bar shows `PLAN` while active. When the model presents a plan, a review modal opens: `y`/Enter approves, `n` opens a feedback line (type the reason, Enter sends the rejection, Esc goes back), ↑/↓ scroll the plan.
+
+### Headless (sovereign / continuous / gateway)
+
+```bash
+wizard --mode sovereign --plan -p "refactor the config loader"
+```
+
+| Knob | Effect |
+|------|--------|
+| `--plan` (flag) | This run starts in plan mode |
+| `plan_first = true` (config) | Every session starts in plan mode |
+| `plan_each_cycle = true` (config) | Continuous mode re-enters plan mode at the top of every cycle |
+
+With no human in the loop, `exit_plan` is auto-approved: the plan is printed (or, on the gateway, included in the chat reply), approval is sent automatically, and the same turn proceeds to execute — a natural two-phase plan-then-execute turn. The gateway also accepts a `/plan` chat message to toggle plan mode for subsequent messages.
+
+The last presented plan is always available at `<project>/.wizard/plan.md`.
+
 ## Switching modes in the TUI
 
 ```

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,103 @@
+# Scheduler: `wizard schedule` and `wizard scheduler`
+
+Cron-style scheduled runs. Entries live in `~/.wizard/schedule.toml`; the
+`wizard scheduler` daemon fires each one as a headless wizard child process
+at its cron times. Like `bench` and `doctor`, the schedule commands are
+self-contained: they never load `~/.wizard/config.toml`, never trigger
+onboarding, and need no LLM in this process — the spawned jobs load their
+own config exactly like a user-invoked `wizard --mode sovereign -p "..."`.
+
+## schedule.toml
+
+```toml
+[[entries]]
+name = "nightly-cleanup"        # unique key, [a-zA-Z0-9_-]+
+cron = "0 3 * * *"              # standard 5-field cron, local time
+prompt = "tidy the repo, run tests, commit"
+cwd = "/home/user/proj"         # required: where the run executes
+mode = "sovereign"              # optional, default "sovereign"; or "continuous"
+max_hours = 2.0                 # optional wall-clock cap for the spawned run
+enabled = true                  # optional, default true
+```
+
+Cron expressions are strict 5-field (`minute hour day month weekday`) —
+no seconds or year fields — and are validated on `add` and on every load.
+Aliases like `MON-FRI` and `@daily` work.
+
+## CLI
+
+```bash
+# Add an entry (validates the cron, the mode, and that --cwd exists;
+# prints the next fire time):
+wizard schedule add nightly-cleanup \
+    --cron "0 3 * * *" \
+    --prompt "tidy the repo, run tests, commit" \
+    --cwd ~/proj --max-hours 2
+
+# Table of name, cron, enabled, next fire (absolute + relative), cwd:
+wizard schedule list
+
+# Remove by name (error if absent):
+wizard schedule remove nightly-cleanup
+
+# Run one entry's job right now, in the foreground, with inherited stdio —
+# the same child command the daemon would spawn. Exits with the child's
+# exit code (0 completed, 2 max-steps, 3 circuit breaker, 4 time limit):
+wizard schedule run nightly-cleanup
+```
+
+You can also edit `~/.wizard/schedule.toml` by hand; the daemon picks up
+changes on its next pass. `enabled = false` keeps an entry in the file
+without firing it.
+
+## The daemon
+
+```bash
+wizard scheduler
+```
+
+A long-running foreground process. Each pass (at least once a minute) it:
+
+1. Reaps finished jobs and kills any past `max_hours` (plus a short grace —
+   the child also receives `--max-hours`, so the normal path is a graceful
+   self-stop; the kill is the backstop).
+2. Reloads `schedule.toml`, so edits apply without a restart.
+3. Fires every due entry: `current_exe()` spawned as
+   `wizard --mode sovereign -p "<prompt>" --cwd <cwd> [--max-hours H]`
+   (`--continuous` for `mode = "continuous"`). Entries due at the same time
+   all spawn concurrently — runs are never serialized.
+4. Sleeps until the next fire, capped at 60 s.
+
+Semantics worth knowing:
+
+- **No backfill.** Each entry's clock starts when the daemon starts (or at
+  its last fire within this daemon's lifetime). Occurrences that passed
+  while the daemon was down are skipped, and several occurrences missed
+  during one sleep collapse into a single fire.
+- **Logging.** One timestamped line per fire / finish / timeout to
+  `~/.wizard/logs/scheduler.log` (rotated to `.log.old` past ~5 MB) and to
+  stdout. Job output itself is not captured here — the run's transcript
+  lives in the child's own `~/.wizard` state, like any headless run.
+- **Shutdown.** Ctrl-C (SIGINT) kills running jobs and exits 0.
+
+## Running under systemd
+
+The daemon stays in the foreground on purpose; let your init system own it.
+A user unit (`~/.config/systemd/user/wizard-scheduler.service`):
+
+```ini
+[Unit]
+Description=wizard scheduler
+
+[Service]
+ExecStart=%h/.local/bin/wizard scheduler
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user enable --now wizard-scheduler
+journalctl --user -u wizard-scheduler -f   # same lines as scheduler.log
+```

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,36 @@
+# Background tasks
+
+Long-running commands (dev servers, builds, watchers) don't have to block the agent loop. The `execute` tool takes an optional `run_in_background` flag:
+
+```json
+{ "command": "cargo build --release", "run_in_background": true }
+```
+
+The command is spawned detached and registered as a background task; the call returns immediately with `Background task #N started: <command>`. The agent keeps working while the task runs.
+
+## Lifecycle
+
+- Each task captures combined stdout/stderr into a per-task buffer capped at ~200 KB — when output exceeds the cap, only the most recent tail is kept
+- Background tasks are killed after **30 minutes**; the status reflects the timeout
+- At the top of every agent step (and every `--continuous` cycle), finished tasks are reported to the model exactly once, as a history note like:
+
+  ```
+  [background task #3 finished (exit 0)] cargo build --release
+  <last ~2 KB of output>
+  ```
+
+- The TUI and headless surfaces print a one-line notice when a task finishes
+- All still-running tasks are killed when the agent shuts down
+
+The spawn still flows through the regular tool dispatch pipeline, so `pre_tool_use`/`post_tool_use` hooks apply to it like any other `execute` call.
+
+## Managing tasks
+
+Two companion tools:
+
+| Tool | Arguments | Does |
+|------|-----------|------|
+| `task_output` | `id`, `tail_bytes` (optional, default 20 000) | Return the task's status and the tail of its buffered output. Read-only — works in plan mode. |
+| `task_kill` | `id` | Terminate a running task. |
+
+Statuses: `running`, `exit <code>`, `killed`, `timed out`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,71 @@
+# Usage tracking, todos, and project instructions
+
+Core agent upgrades that work identically in every mode (genie TUI,
+sovereign headless, perpetual, gateway).
+
+## Token usage and cost
+
+Wizard accumulates the prompt/completion token counts every provider reports
+on its final stream chunk.
+
+- **TUI**: the status bar shows a compact session total (`12.3k tok`);
+  `/cost` prints the full prompt/completion breakdown.
+- **Headless**: the final summary line includes the run's totals:
+  `[run finished: Completed — 1234 prompt + 567 completion tokens]`.
+- **Log**: every turn appends one JSON line to `~/.wizard/usage.jsonl`:
+
+  ```json
+  {"ts":1760000000,"project":"/home/u/proj","model":"claude-fable-5","provider":"claude","prompt_tokens":1234,"completion_tokens":567,"mode":"genie"}
+  ```
+
+- **Cost estimates**: set per-provider prices (USD per million tokens) in
+  `~/.wizard/config.toml` and `/cost` adds an estimate:
+
+  ```toml
+  [[providers]]
+  name = "claude"
+  kind = "anthropic"
+  # ...
+  usd_per_mtok_in = 3.0
+  usd_per_mtok_out = 15.0
+  ```
+
+## Token-aware compaction
+
+History compaction now triggers on **either** the byte threshold
+(`compact_threshold_bytes`, default 48 kB) **or** the last prompt exceeding
+~80% of the model's context window, when the window is known:
+
+- anthropic / openai / xai: static tables per model family
+- llama.cpp: live `GET /props` probe for the loaded model's `n_ctx` (cached)
+- ollama / unknown models: byte threshold only
+
+Compaction also runs *between steps inside a turn*, so a long tool loop
+cannot overflow the window mid-turn. The most recent messages (including the
+in-flight turn's tool results) are always preserved verbatim, and the
+summary is instructed to carry over the todo list state and the plan file
+path (`.wizard/plan.md`).
+
+## Todo list
+
+The native `todo` tool lets the agent maintain a working todo list (action
+`write` replaces the whole list of `{content, status}` items; `read` returns
+it; statuses: `pending` / `in_progress` / `completed`). It is read-only for
+the plan gate, so the agent can draft its list while planning.
+
+- **TUI**: a side panel mirrors the list (`/todos` toggles it; it auto-shows
+  on the first update).
+- **Headless**: each update prints `≡ todo: 2/5 done — current: <item>`.
+- **Subagents** get the tool too, with their own isolated list.
+
+## Project instructions hierarchy
+
+The system prompt's project-instructions section is assembled from every
+directory between the filesystem root and the project root — in each
+directory the first of `WIZARD.md` > `AGENTS.md` > `CLAUDE.md` wins — plus
+the global `~/.wizard/WIZARD.md`. Files are concatenated outermost-first
+(the project root's file has the last word), each prefixed with a comment
+naming its path.
+
+A line consisting of `@relative/path` inlines that file (one level deep,
+~10 kB per include); the whole block is capped at ~40 kB.

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,50 @@
+# Web tools
+
+Two native tools give the agent web access: `web_fetch` (read a page) and `web_search` (query a search engine). Both are read-only, so they stay available in plan mode. Settings live in the `[web]` section of `~/.wizard/config.toml`.
+
+## web_fetch
+
+Fetch a URL over HTTP(S) and return its content.
+
+- **Arguments:** `url` (required), `max_bytes` (optional cap on response bytes read; clamped to the config cap)
+- HTML pages are converted to markdown; other text content types (plain text, JSON, XML, ...) are returned as-is; binary content is summarized, not dumped
+- Sends a desktop browser user agent, follows redirects (max 10), 30-second timeout
+- The response body is read up to `fetch_max_bytes` (default 100 000) and marked when capped
+
+### SSRF guard
+
+By default, `web_fetch` refuses to touch the local network. A request is rejected when its host:
+
+- is a literal loopback, private, or link-local address (`127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, and the IPv6 equivalents `::1`, `fc00::/7`, `fe80::/10`)
+- is `localhost` or a `*.local` mDNS name
+- resolves via DNS to any of the above ranges
+
+Redirects are re-checked hop by hop. Non-`http(s)` schemes are always rejected. To fetch from your own LAN or a local dev server, set `allow_local = true`.
+
+## web_search
+
+Query a search backend and return a numbered markdown list of results (title, url, snippet).
+
+- **Arguments:** `query` (required), `count` (optional, default 5, max 10)
+
+Three backends, selected by `search_backend`:
+
+| Backend | Key needed | How |
+|---------|-----------|-----|
+| `duckduckgo` (default) | none | scrapes the DuckDuckGo HTML endpoint |
+| `brave` | yes | Brave Search API (`X-Subscription-Token`) |
+| `tavily` | yes | Tavily Search API |
+
+For the keyed backends, set `search_api_key_env` to the **name** of the environment variable holding the key. The key itself is never written to config or disk; it is read from the environment at call time.
+
+## Configuration
+
+```toml
+[web]
+fetch_max_bytes = 100000          # cap on web_fetch response bytes (default 100000)
+allow_local = false               # permit localhost/private-range fetches (default false)
+search_backend = "duckduckgo"     # "duckduckgo" | "brave" | "tavily"
+search_api_key_env = "BRAVE_API_KEY"  # env var name holding the search key (keyed backends)
+```
+
+Every key is optional; a missing `[web]` section means the defaults above.

--- a/src/agent/mission.rs
+++ b/src/agent/mission.rs
@@ -96,11 +96,19 @@ impl Mission {
         self.cycles += 1;
         self.updated = Utc::now();
         if let Some(n) = note {
-            self.notes.push(n);
-            if self.notes.len() > MAX_NOTES {
-                let excess = self.notes.len() - MAX_NOTES;
-                self.notes.drain(0..excess);
-            }
+            self.note(n);
+        }
+    }
+
+    /// Append a progress note (bumping `updated`) without counting a cycle —
+    /// e.g. a checkpoint rollback after a failed cycle. The log stays capped
+    /// at [`MAX_NOTES`].
+    pub fn note(&mut self, note: impl Into<String>) {
+        self.updated = Utc::now();
+        self.notes.push(note.into());
+        if self.notes.len() > MAX_NOTES {
+            let excess = self.notes.len() - MAX_NOTES;
+            self.notes.drain(0..excess);
         }
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1400,6 +1400,10 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
             "headless mode needs a task: pass -p \"<task>\""
         ));
     };
+    // The same preprocessing the TUI applies on submit: custom `/command`
+    // expansion and `@file` references.
+    let custom_commands = crate::commands::load(&project_root);
+    let goal = crate::commands::preprocess(&goal, &custom_commands, &project_root);
 
     let active = config.active();
     let model = active.model.clone();

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -112,6 +112,16 @@ pub enum AgentEvent {
         plan: String,
         respond: tokio::sync::oneshot::Sender<PlanVerdict>,
     },
+    /// Token usage of one completed model call, when the backend reported
+    /// counts. Surfaces accumulate these (status bar, headless summary).
+    Usage {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+    },
+    /// The todo list was replaced via the `todo` tool. Carries the full new
+    /// list; the TUI mirrors it in a side panel, headless prints a one-line
+    /// summary, the gateway ignores it.
+    TodoUpdated(Vec<crate::tools::todo::TodoItem>),
     /// The turn is over.
     Done { reason: DoneReason },
 }
@@ -247,7 +257,9 @@ pub struct Agent {
     native_tools: bool,
     /// Skills baked into the system prompt (kept for `/mode` rebuilds).
     skills: Vec<Skill>,
-    /// Project `AGENTS.md` / `WIZARD.md` contents, if present.
+    /// Assembled instruction hierarchy (`WIZARD.md` / `AGENTS.md` /
+    /// `CLAUDE.md` from the project root up, plus `~/.wizard/WIZARD.md` —
+    /// see [`crate::instructions`]), if any file exists.
     agents_md: Option<String>,
     /// Persistent memory index (MEMORY.md) for this project, if any
     /// memories are saved. Re-read on every system prompt refresh so
@@ -264,10 +276,19 @@ pub struct Agent {
     /// Whether the plan-mode instruction block is currently baked into the
     /// system prompt; [`Agent::sync_plan_prompt`] refreshes on mismatch.
     plan_prompt_on: bool,
+    /// Token counters fed from `ChatChunk` eval counts during streaming.
+    usage: crate::usage::UsageTracker,
+    /// Where per-turn usage records are appended
+    /// (`~/.wizard/usage.jsonl`); `None` disables the log.
+    usage_log: Option<PathBuf>,
 }
 
 /// Number of most-recent messages preserved verbatim when compacting history.
 const KEEP_RECENT: usize = 10;
+
+/// Fraction of the provider's context window the last prompt may fill before
+/// token-aware compaction kicks in.
+const COMPACT_WINDOW_FRACTION: f64 = 0.8;
 
 /// User-role nudge injected (in memory only) when a completion comes back
 /// with no visible text and no tool calls.
@@ -296,7 +317,7 @@ impl Agent {
         native_tools: bool,
         hooks: Arc<HookEngine>,
     ) -> Result<Self> {
-        let agents_md = read_project_instructions(&project_root);
+        let agents_md = crate::instructions::load(&project_root);
         let memory_index = read_memory_index(&project_root);
         let model = config.active().model;
         let mut load_warning = None;
@@ -345,6 +366,8 @@ impl Agent {
             load_warning,
             plan_mode,
             plan_prompt_on: false,
+            usage: crate::usage::UsageTracker::new(),
+            usage_log: crate::usage::default_log_path(),
         };
         agent
             .history
@@ -426,6 +449,17 @@ impl Agent {
         self.refresh_system_prompt();
     }
 
+    /// Session token counters (prompt/completion totals, last prompt size).
+    pub fn usage(&self) -> &crate::usage::UsageTracker {
+        &self.usage
+    }
+
+    /// Redirect (or disable) the per-turn usage JSONL log. Defaults to
+    /// `~/.wizard/usage.jsonl`; tests point it into a temp dir.
+    pub fn set_usage_log(&mut self, path: Option<PathBuf>) {
+        self.usage_log = path;
+    }
+
     /// Whether plan mode is active.
     pub fn plan_mode(&self) -> bool {
         self.plan_mode.load(std::sync::atomic::Ordering::SeqCst)
@@ -482,6 +516,15 @@ impl Agent {
                 &self.dispatcher.registry().specs(),
             ));
         }
+        if self
+            .dispatcher
+            .registry()
+            .get(crate::tools::todo::TODO_TOOL_NAME)
+            .is_some()
+        {
+            prompt.push_str("\n\n");
+            prompt.push_str(prompts::TODO_PROMPT);
+        }
         if self.plan_mode() {
             prompt.push_str("\n\n");
             prompt.push_str(prompts::PLAN_MODE_PROMPT);
@@ -522,6 +565,7 @@ impl Agent {
         if let Some(warning) = self.load_warning.take() {
             let _ = emit(&events, AgentEvent::Error(warning)).await;
         }
+        self.usage.begin_turn();
         let result = match self.turn_inner(input, &events).await {
             Ok(reason) => {
                 let _ = emit(&events, AgentEvent::Done { reason }).await;
@@ -541,7 +585,33 @@ impl Agent {
         };
         // turn_end hooks: observational, fired however the turn ended.
         self.hooks.turn_end(self.mode, Some(&events)).await;
+        self.record_turn_usage();
         result
+    }
+
+    /// Append this turn's token usage to the JSONL log (when the backend
+    /// reported counts and the log is enabled). Best-effort: failures are
+    /// logged, never surfaced.
+    fn record_turn_usage(&self) {
+        let (prompt_tokens, completion_tokens) = self.usage.turn_totals();
+        if prompt_tokens == 0 && completion_tokens == 0 {
+            return;
+        }
+        let Some(path) = &self.usage_log else {
+            return;
+        };
+        let record = crate::usage::UsageRecord {
+            ts: crate::usage::unix_now(),
+            project: self.ctx.cwd.display().to_string(),
+            model: self.model.clone(),
+            provider: self.config.active().name,
+            prompt_tokens,
+            completion_tokens,
+            mode: self.mode.to_string(),
+        };
+        if let Err(err) = crate::usage::append(path, &record) {
+            tracing::warn!("could not append usage record: {err:#}");
+        }
     }
 
     async fn turn_inner(
@@ -638,6 +708,13 @@ impl Agent {
                 }
             }
 
+            // Compact between steps too, so a long tool loop cannot outgrow
+            // the context window mid-turn. The compactor always keeps the
+            // most recent messages verbatim, so the in-flight turn's tail —
+            // the tool calls and results the model is reasoning about —
+            // stays intact.
+            self.compact_if_needed(events).await;
+
             if !emit(events, AgentEvent::StepCompleted { step }).await {
                 return Ok(DoneReason::Stopped);
             }
@@ -675,6 +752,8 @@ impl Agent {
 
         let mut content = String::new();
         let mut tool_calls = Vec::new();
+        let mut prompt_tokens = None;
+        let mut completion_tokens = None;
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.context("reading chat stream")?;
             if let Some(message) = chunk.message {
@@ -690,9 +769,26 @@ impl Agent {
                 }
                 tool_calls.extend(message.tool_calls);
             }
+            if chunk.prompt_eval_count.is_some() {
+                prompt_tokens = chunk.prompt_eval_count;
+            }
+            if chunk.eval_count.is_some() {
+                completion_tokens = chunk.eval_count;
+            }
             if chunk.done {
                 break;
             }
+        }
+        if prompt_tokens.is_some() || completion_tokens.is_some() {
+            self.usage.record(prompt_tokens, completion_tokens);
+            let _ = emit(
+                events,
+                AgentEvent::Usage {
+                    prompt_tokens: prompt_tokens.unwrap_or(0),
+                    completion_tokens: completion_tokens.unwrap_or(0),
+                },
+            )
+            .await;
         }
         Ok((content, tool_calls))
     }
@@ -743,15 +839,32 @@ impl Agent {
         }
     }
 
-    /// Keep history bounded so the agent can run indefinitely. When the
-    /// serialized history exceeds `compact_threshold_bytes`, summarize the
-    /// middle span (everything between the system prompt and the last
-    /// [`KEEP_RECENT`] messages) into a single progress note. Best-effort:
-    /// a summarization failure falls back to dropping the middle span. Never
-    /// aborts the turn.
-    async fn compact_if_needed(&mut self, events: &mpsc::Sender<AgentEvent>) {
+    /// Whether the history is close enough to overflowing to warrant
+    /// compaction: either the serialized history exceeds the byte threshold,
+    /// or the last model call's reported prompt size exceeds
+    /// [`COMPACT_WINDOW_FRACTION`] of the provider's known context window.
+    async fn should_compact(&self) -> bool {
         let total: usize = self.history.iter().map(|msg| msg.content.len()).sum();
-        if total <= self.config.compact_threshold_bytes {
+        if total > self.config.compact_threshold_bytes {
+            return true;
+        }
+        let Some(last_prompt) = self.usage.last_prompt_tokens() else {
+            return false;
+        };
+        let Some(window) = self.client.context_window(&self.model).await else {
+            return false;
+        };
+        last_prompt as f64 > f64::from(window) * COMPACT_WINDOW_FRACTION
+    }
+
+    /// Keep history bounded so the agent can run indefinitely. When
+    /// [`Self::should_compact`] fires (byte threshold, or the last prompt
+    /// nearing the provider's context window), summarize the middle span
+    /// (everything between the system prompt and the last [`KEEP_RECENT`]
+    /// messages) into a single progress note. Best-effort: a summarization
+    /// failure falls back to dropping the middle span. Never aborts the turn.
+    async fn compact_if_needed(&mut self, events: &mpsc::Sender<AgentEvent>) {
+        if !self.should_compact().await {
             return;
         }
         // Need history[0] (system prompt) + a non-empty middle + the recent tail.
@@ -808,6 +921,9 @@ impl Agent {
                 .await;
             }
         }
+        // The history just shrank: the last reported prompt size is stale
+        // and must not re-trigger compaction on the next step.
+        self.usage.clear_last_prompt();
     }
 
     /// Summarize a transcript blob into a terse progress note via the model.
@@ -819,7 +935,10 @@ impl Agent {
                 ChatMessage::system(
                     "Summarize the following Wizard agent transcript into a compact progress \
                      note. Preserve: the mission/goal, decisions made, files changed, commands \
-                     run, what worked/failed, and open next steps. Be terse and factual.",
+                     run, what worked/failed, and open next steps. Preserve the current todo \
+                     list state verbatim (every item and its status) if one was maintained, \
+                     and mention the plan file path (.wizard/plan.md) if a plan was written. \
+                     Be terse and factual.",
                 ),
                 ChatMessage::user(blob.to_string()),
             ],
@@ -911,21 +1030,6 @@ impl Agent {
             }
         }
     }
-}
-
-/// Read project-level instructions: `AGENTS.md`, falling back to
-/// `WIZARD.md`.
-fn read_project_instructions(project_root: &Path) -> Option<String> {
-    for name in ["AGENTS.md", "WIZARD.md"] {
-        let path = project_root.join(name);
-        match std::fs::read_to_string(&path) {
-            Ok(contents) if !contents.trim().is_empty() => return Some(contents),
-            Ok(_) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => tracing::warn!("could not read {}: {err}", path.display()),
-        }
-    }
-    None
 }
 
 /// Read the persistent memory index (MEMORY.md) for `project_root`, if any
@@ -1125,7 +1229,11 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
 
     let (tx, mut rx) = mpsc::channel::<AgentEvent>(256);
     let printer_spinner = Arc::clone(&spinner);
+    // The printer returns the run's accumulated (prompt, completion) token
+    // totals for the final summary line.
     let printer = tokio::spawn(async move {
+        let mut prompt_total: u64 = 0;
+        let mut completion_total: u64 = 0;
         while let Some(event) = rx.recv().await {
             match event {
                 AgentEvent::TextDelta(delta) => {
@@ -1172,12 +1280,23 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                     let _ = respond.send(PlanVerdict::approve());
                     printer_spinner.show();
                 }
+                AgentEvent::Usage {
+                    prompt_tokens,
+                    completion_tokens,
+                } => {
+                    prompt_total += prompt_tokens;
+                    completion_total += completion_tokens;
+                }
+                AgentEvent::TodoUpdated(items) => {
+                    printer_spinner.println(&crate::tools::todo::summary_line(&items));
+                }
                 AgentEvent::Done { reason } => {
                     printer_spinner.hide();
                     println!("\n[turn done: {reason:?}]");
                 }
             }
         }
+        (prompt_total, completion_total)
     });
 
     println!(
@@ -1335,7 +1454,7 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     agent.fire_session_end(Some(&tx)).await;
 
     drop(tx);
-    let _ = printer.await;
+    let (prompt_tokens, completion_tokens) = printer.await.unwrap_or((0, 0));
     spinner.finish();
 
     if reexec_after {
@@ -1355,7 +1474,14 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     if let Some(err) = run_error {
         return Err(err);
     }
-    println!("[run finished: {final_reason:?}]");
+    if prompt_tokens > 0 || completion_tokens > 0 {
+        println!(
+            "[run finished: {final_reason:?} — {prompt_tokens} prompt + {completion_tokens} \
+             completion tokens]"
+        );
+    } else {
+        println!("[run finished: {final_reason:?}]");
+    }
     Ok(())
 }
 
@@ -1393,6 +1519,8 @@ mod tests {
     struct ScriptedProvider {
         responses: Mutex<VecDeque<Vec<ChatChunk>>>,
         requests: Mutex<Vec<ChatRequest>>,
+        /// Reported context window (None = unknown, like a local model).
+        context_window: Option<u32>,
     }
 
     impl ScriptedProvider {
@@ -1400,6 +1528,15 @@ mod tests {
             Arc::new(Self {
                 responses: Mutex::new(responses.into()),
                 requests: Mutex::new(Vec::new()),
+                context_window: None,
+            })
+        }
+
+        fn with_context_window(responses: Vec<Vec<ChatChunk>>, window: u32) -> Arc<Self> {
+            Arc::new(Self {
+                responses: Mutex::new(responses.into()),
+                requests: Mutex::new(Vec::new()),
+                context_window: Some(window),
             })
         }
     }
@@ -1431,6 +1568,10 @@ mod tests {
             )))
         }
 
+        async fn context_window(&self, _model: &str) -> Option<u32> {
+            self.context_window
+        }
+
         fn label(&self) -> String {
             "scripted:test".to_string()
         }
@@ -1449,6 +1590,15 @@ mod tests {
         }
     }
 
+    /// `done: true` chunk carrying token counts alongside `content`.
+    fn usage_chunk(content: &str, prompt_tokens: u64, completion_tokens: u64) -> ChatChunk {
+        ChatChunk {
+            eval_count: Some(completion_tokens),
+            prompt_eval_count: Some(prompt_tokens),
+            ..final_chunk(content)
+        }
+    }
+
     fn test_agent(responses: Vec<Vec<ChatChunk>>) -> (Agent, Arc<ScriptedProvider>, TempDir) {
         let tmp = TempDir::new();
         let (agent, provider) = test_agent_in(&tmp, responses, Vec::new(), ToolRegistry::new());
@@ -1464,14 +1614,26 @@ mod tests {
         registry: ToolRegistry,
     ) -> (Agent, Arc<ScriptedProvider>) {
         let provider = ScriptedProvider::new(responses);
+        let agent = test_agent_with(tmp, Arc::clone(&provider), hook_defs, registry);
+        (agent, provider)
+    }
+
+    /// Build a test agent around an existing provider. The usage log is
+    /// redirected into the temp dir so tests never touch ~/.wizard.
+    fn test_agent_with(
+        tmp: &TempDir,
+        provider: Arc<ScriptedProvider>,
+        hook_defs: Vec<HookDef>,
+        registry: ToolRegistry,
+    ) -> Agent {
         let session = Session::create(&tmp.0).expect("create session");
         let hooks = Arc::new(HookEngine::new(
             hook_defs,
             tmp.0.clone(),
             session.id.clone(),
         ));
-        let agent = Agent::new(
-            provider.clone(),
+        let mut agent = Agent::new(
+            provider,
             registry,
             Config::default(),
             Vec::new(),
@@ -1481,7 +1643,8 @@ mod tests {
             hooks,
         )
         .expect("build agent");
-        (agent, provider)
+        agent.set_usage_log(Some(tmp.0.join("usage.jsonl")));
+        agent
     }
 
     /// Drain a finished turn's events into (text, errors).
@@ -2201,6 +2364,293 @@ mod tests {
         // A registry swap (/reload, /evolve) re-registers it.
         agent.set_registry(ToolRegistry::new());
         assert!(has_exit_plan(&agent), "re-registered after set_registry");
+    }
+
+    #[tokio::test]
+    async fn usage_counts_accumulate_emit_events_and_land_in_the_jsonl_log() {
+        let tmp = TempDir::new();
+        let provider = ScriptedProvider::new(vec![
+            vec![usage_chunk("first", 100, 20)],
+            vec![usage_chunk("second", 150, 30)],
+        ]);
+        let mut agent =
+            test_agent_with(&tmp, Arc::clone(&provider), Vec::new(), ToolRegistry::new());
+
+        let (tx, mut rx) = mpsc::channel(64);
+        agent.run_turn("one", tx).await.expect("turn ok");
+        let mut usage_events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AgentEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            } = event
+            {
+                usage_events.push((prompt_tokens, completion_tokens));
+            }
+        }
+        assert_eq!(usage_events, [(100, 20)], "one Usage event per model call");
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("two", tx).await.expect("turn ok");
+
+        assert_eq!(agent.usage().session_totals(), (250, 50));
+        assert_eq!(agent.usage().turn_totals(), (150, 30), "last turn only");
+        assert_eq!(agent.usage().last_prompt_tokens(), Some(150));
+
+        // One JSONL record per turn, in order.
+        let raw = std::fs::read_to_string(tmp.0.join("usage.jsonl")).expect("log written");
+        let records: Vec<crate::usage::UsageRecord> = raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("valid json"))
+            .collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].prompt_tokens, 100);
+        assert_eq!(records[0].completion_tokens, 20);
+        assert_eq!(records[1].prompt_tokens, 150);
+        assert_eq!(records[1].completion_tokens, 30);
+        assert_eq!(records[0].mode, "genie");
+        assert!(records[0].ts > 0);
+        assert_eq!(records[0].project, tmp.0.display().to_string());
+    }
+
+    #[tokio::test]
+    async fn turns_without_reported_counts_write_no_usage_records() {
+        let (mut agent, _provider, tmp) = test_agent(vec![vec![final_chunk("plain")]]);
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(agent.usage().session_totals(), (0, 0));
+        assert!(!tmp.0.join("usage.jsonl").exists(), "no counts, no log");
+    }
+
+    #[tokio::test]
+    async fn prompt_tokens_near_the_context_window_trigger_compaction() {
+        let tmp = TempDir::new();
+        // Window 1000 → compaction at >800 prompt tokens. The byte threshold
+        // (48k) is never reached: the messages are tiny.
+        let provider = ScriptedProvider::with_context_window(
+            vec![
+                // Turn 1: reports a prompt size of 900 tokens.
+                vec![usage_chunk("ok", 900, 10)],
+                // Turn 2: the compaction summary, then the actual reply.
+                vec![final_chunk("progress so far")],
+                vec![final_chunk("done")],
+            ],
+            1000,
+        );
+        let mut agent =
+            test_agent_with(&tmp, Arc::clone(&provider), Vec::new(), ToolRegistry::new());
+        for i in 0..14 {
+            agent.history.push(ChatMessage::user(format!("filler {i}")));
+        }
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("one", tx).await.expect("turn ok");
+        assert!(
+            !agent
+                .history
+                .iter()
+                .any(|m| m.content.contains("[Compacted progress summary]")),
+            "no compaction before a token count arrives"
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        agent.run_turn("two", tx).await.expect("turn ok");
+        assert!(
+            agent
+                .history
+                .iter()
+                .any(|m| m.content.contains("[Compacted progress summary]")),
+            "token threshold compacted the history"
+        );
+        let (_text, errors) = drain_events(&mut rx);
+        assert!(
+            errors.iter().any(|e| e.contains("compacted")),
+            "compaction surfaced: {errors:?}"
+        );
+        assert_eq!(
+            agent.usage().last_prompt_tokens(),
+            None,
+            "stale prompt size cleared so compaction does not re-trigger"
+        );
+
+        // The summarization request carried the extended preservation
+        // instructions (todo list + plan file).
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        let summarize_prompt = &requests[1].messages[0].content;
+        assert!(summarize_prompt.contains("todo"), "{summarize_prompt}");
+        assert!(
+            summarize_prompt.contains(".wizard/plan.md"),
+            "{summarize_prompt}"
+        );
+    }
+
+    /// Test tool returning a large fixed blob, to cross the byte threshold
+    /// mid-turn.
+    struct BigOutputTool;
+
+    #[async_trait::async_trait]
+    impl crate::tools::Tool for BigOutputTool {
+        fn name(&self) -> &str {
+            "big"
+        }
+
+        fn description(&self) -> &str {
+            "Return a large blob (test tool)."
+        }
+
+        fn parameters(&self) -> Value {
+            json!({ "type": "object", "properties": {} })
+        }
+
+        async fn execute(
+            &self,
+            _args: Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolOutput, crate::tools::ToolError> {
+            Ok(ToolOutput::ok("B".repeat(5_000)))
+        }
+    }
+
+    #[tokio::test]
+    async fn byte_threshold_compacts_between_steps_keeping_the_turn_tail() {
+        let tmp = TempDir::new();
+        let provider = ScriptedProvider::new(vec![
+            vec![tool_call_chunk("big", json!({}))],
+            vec![final_chunk("progress so far")], // compaction summary
+            vec![final_chunk("done")],
+        ]);
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(BigOutputTool));
+        let mut agent = test_agent_with(&tmp, Arc::clone(&provider), Vec::new(), registry);
+        for i in 0..13 {
+            agent.history.push(ChatMessage::user(format!("filler {i}")));
+        }
+        // Threshold just above the current size: crossed only once the 5k
+        // tool result lands, so the compaction must happen mid-turn.
+        let base: usize = agent.history.iter().map(|m| m.content.len()).sum();
+        agent.config.compact_threshold_bytes = base + 1_000;
+
+        let (tx, _rx) = mpsc::channel(256);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+
+        assert!(
+            agent
+                .history
+                .iter()
+                .any(|m| m.content.contains("[Compacted progress summary]")),
+            "mid-turn compaction happened"
+        );
+        // The in-flight turn's tail — the big tool result the model is
+        // reasoning about — survived verbatim.
+        assert!(
+            agent
+                .history
+                .iter()
+                .any(|m| m.role == Role::Tool && m.content.contains("BBBB")),
+            "tool feedback preserved through compaction"
+        );
+        // The final completion saw the compacted history.
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        assert!(
+            requests[2]
+                .messages
+                .iter()
+                .any(|m| m.content.contains("[Compacted progress summary]"))
+        );
+    }
+
+    #[tokio::test]
+    async fn todo_writes_update_shared_state_and_emit_events() {
+        let tmp = TempDir::new();
+        let items = json!([
+            { "content": "investigate", "status": "completed" },
+            { "content": "implement", "status": "in_progress" },
+            { "content": "test", "status": "pending" }
+        ]);
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "todo",
+                    json!({ "action": "write", "items": items }),
+                )],
+                vec![final_chunk("noted")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        agent.run_turn("go", tx).await.expect("turn ok");
+
+        let mut updates = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AgentEvent::TodoUpdated(items) = event {
+                updates.push(items);
+            }
+        }
+        assert_eq!(updates.len(), 1, "one TodoUpdated per write");
+        assert_eq!(updates[0].len(), 3);
+        assert_eq!(updates[0][1].content, "implement");
+        assert_eq!(
+            updates[0][1].status,
+            crate::tools::todo::TodoStatus::InProgress
+        );
+
+        // The shared state holds the list for later read calls.
+        assert_eq!(agent.ctx.todos.lock().unwrap().len(), 3);
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(feedback.contains("1/3 done"), "{feedback}");
+    }
+
+    #[tokio::test]
+    async fn todo_tool_stays_usable_in_plan_mode() {
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "todo",
+                    json!({ "action": "write", "items": [
+                        { "content": "draft plan", "status": "in_progress" }
+                    ] }),
+                )],
+                vec![final_chunk("planning")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        agent.set_plan_mode(true);
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("go", tx).await.expect("turn ok");
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(
+            feedback.contains("todo list updated"),
+            "todo runs under the plan gate: {feedback}"
+        );
+        assert!(agent.plan_mode(), "plan mode untouched");
+    }
+
+    #[test]
+    fn todo_instruction_appears_only_when_the_tool_is_registered() {
+        let tmp = TempDir::new();
+        let (agent, _provider) = test_agent_in(
+            &tmp,
+            Vec::new(),
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        assert!(agent.history[0].content.contains("## Working todo list"));
+
+        let (agent, _provider) = test_agent_in(&tmp, Vec::new(), Vec::new(), ToolRegistry::new());
+        assert!(
+            !agent.history[0].content.contains("## Working todo list"),
+            "no instruction without the tool"
+        );
     }
 
     #[tokio::test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -17,10 +17,11 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use serde_json::{Value, json};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use crate::cli::Cli;
 use crate::config::{Config, Mode, ProviderKind};
+use crate::dispatch::Dispatcher;
 use crate::llm::provider::LlmProvider;
 use crate::llm::{ChatMessage, ChatOptions, ChatRequest, FunctionCall, Role, ToolCall};
 use crate::mcp::{McpConfig, McpManager};
@@ -54,13 +55,6 @@ pub enum AgentEvent {
     /// Streaming model reasoning ("thinking") delta. Rendered dimmed by the
     /// TUI; never part of the assistant message or the session history.
     ThinkingDelta(String),
-    /// A tool call is requesting approval via the opt-in y/n gate (only fires
-    /// when `auto_approve = false`). Send `true` on `respond` to run it,
-    /// `false` to deny.
-    ApprovalRequest {
-        call: ToolCall,
-        respond: oneshot::Sender<bool>,
-    },
     /// A tool call is being executed.
     ToolStarted { name: String, args: Value },
     /// A tool call finished.
@@ -178,18 +172,19 @@ pub(crate) fn normalize_args(args: &Value) -> Value {
 }
 
 /// Send an event, reporting whether the receiver is still listening.
-async fn emit(events: &mpsc::Sender<AgentEvent>, event: AgentEvent) -> bool {
+pub(crate) async fn emit(events: &mpsc::Sender<AgentEvent>, event: AgentEvent) -> bool {
     events.send(event).await.is_ok()
 }
 
 /// The tool-calling agent. Owns the conversation history, the model client,
-/// the tool registry, and session persistence.
+/// the tool dispatcher, and session persistence.
 pub struct Agent {
     client: Arc<dyn LlmProvider>,
     /// Active model tag (from `config.active().model`); switched by
     /// [`Agent::set_model`].
     model: String,
-    registry: ToolRegistry,
+    /// Tool-call pipeline; owns the registry and the failure breakers.
+    dispatcher: Dispatcher,
     config: Config,
     mode: Mode,
     /// Full conversation including the system prompt at index 0.
@@ -209,18 +204,10 @@ pub struct Agent {
     memory_index: Option<String>,
     /// Wall-clock deadline for sovereign runs (`--max-hours`).
     deadline: Option<Instant>,
-    /// Circuit breaker state: signature of the last failing tool call and
-    /// how many consecutive times it has failed identically.
-    failure_streak: Option<(String, u32)>,
-    /// Per-tool consecutive-failure counts (args ignored).
-    tool_failures: ToolFailureCounter,
     /// Warning from session resume (corrupt/unreadable file), emitted on
     /// the next turn so the UI can surface it.
     load_warning: Option<String>,
 }
-
-/// Consecutive identical failures that trip the sovereign circuit breaker.
-const CIRCUIT_BREAKER_LIMIT: u32 = 3;
 
 /// Number of most-recent messages preserved verbatim when compacting history.
 const KEEP_RECENT: usize = 10;
@@ -233,52 +220,6 @@ const EMPTY_COMPLETION_NUDGE: &str = "(continue: reply to the user with your fin
 /// tool calls (e.g. a reasoning model that thought and then just stopped).
 pub(crate) fn completion_is_empty(content: &str, tool_calls: &[ToolCall]) -> bool {
     content.trim().is_empty() && tool_calls.is_empty()
-}
-
-/// Consecutive failures of one tool (any args) before the model is nudged
-/// to change approach.
-const TOOL_FAILURE_NUDGE: u32 = 5;
-/// Consecutive failures of one tool (any args) before the turn ends with
-/// [`DoneReason::CircuitBreaker`].
-const TOOL_FAILURE_TRIP: u32 = 8;
-
-/// What [`ToolFailureCounter::record`] says to do after a tool result.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FailureAction {
-    Continue,
-    /// Inject a system nudge telling the model to stop retrying the tool.
-    Nudge,
-    /// End the turn via the circuit breaker.
-    Trip,
-}
-
-/// Per-tool-name consecutive-failure counter, independent of arguments
-/// (catches models that jitter args to dodge the identical-failure
-/// breaker). A success of a tool resets that tool's count.
-#[derive(Debug, Default)]
-struct ToolFailureCounter {
-    counts: std::collections::HashMap<String, u32>,
-}
-
-impl ToolFailureCounter {
-    /// Record one tool result and return the action it warrants.
-    fn record(&mut self, name: &str, failed: bool) -> FailureAction {
-        if !failed {
-            self.counts.remove(name);
-            return FailureAction::Continue;
-        }
-        let count = self.counts.entry(name.to_string()).or_insert(0);
-        *count += 1;
-        match *count {
-            TOOL_FAILURE_NUDGE => FailureAction::Nudge,
-            count if count >= TOOL_FAILURE_TRIP => FailureAction::Trip,
-            _ => FailureAction::Continue,
-        }
-    }
-
-    fn reset(&mut self) {
-        self.counts.clear();
-    }
 }
 
 impl Agent {
@@ -316,7 +257,7 @@ impl Agent {
         let mut agent = Self {
             client,
             model,
-            registry,
+            dispatcher: Dispatcher::new(registry, config.mode),
             mode: config.mode,
             config,
             history: Vec::new(),
@@ -327,8 +268,6 @@ impl Agent {
             agents_md,
             memory_index,
             deadline: None,
-            failure_streak: None,
-            tool_failures: ToolFailureCounter::default(),
             load_warning,
         };
         agent
@@ -344,10 +283,11 @@ impl Agent {
     }
 
     /// Switch mode mid-session (`/mode`): swaps the system prompt and
-    /// approval behavior for subsequent turns.
+    /// circuit-breaker behavior for subsequent turns.
     pub fn set_mode(&mut self, mode: Mode) {
         self.mode = mode;
         self.config.mode = mode;
+        self.dispatcher.set_mode(mode);
         self.refresh_system_prompt();
     }
 
@@ -371,15 +311,14 @@ impl Agent {
     pub fn clear(&mut self) -> Result<()> {
         self.session = Session::create(&Config::sessions_dir()?)?;
         self.history.truncate(1);
-        self.failure_streak = None;
-        self.tool_failures.reset();
+        self.dispatcher.reset_failures();
         Ok(())
     }
 
     /// Swap the tool registry (after `/reload` or `/evolve`). Refreshes the
     /// system prompt so the JSON tool protocol's tool list stays current.
     pub fn set_registry(&mut self, registry: ToolRegistry) {
-        self.registry = registry;
+        self.dispatcher.set_registry(registry);
         self.refresh_system_prompt();
     }
 
@@ -410,7 +349,9 @@ impl Agent {
         );
         if !self.native_tools {
             prompt.push_str("\n\n");
-            prompt.push_str(&prompts::render_tool_protocol(&self.registry.specs()));
+            prompt.push_str(&prompts::render_tool_protocol(
+                &self.dispatcher.registry().specs(),
+            ));
         }
         prompt
     }
@@ -433,11 +374,6 @@ impl Agent {
             tracing::warn!("session append failed: {err}");
         }
         self.history.push(message);
-    }
-
-    /// Whether gated tools run without asking the user.
-    fn auto_approve(&self) -> bool {
-        self.mode == Mode::Sovereign || self.config.auto_approve
     }
 
     /// Run one user turn: append `input`, then loop
@@ -538,7 +474,7 @@ impl Agent {
             }
 
             for call in &tool_calls {
-                match self.dispatch_call(call, events).await? {
+                match self.dispatch_call(call, events).await {
                     None => {}
                     Some(reason) => return Ok(reason),
                 }
@@ -562,7 +498,7 @@ impl Agent {
             model: self.model.clone(),
             messages: self.history.clone(),
             tools: if self.native_tools {
-                self.registry.specs()
+                self.dispatcher.registry().specs()
             } else {
                 Vec::new()
             },
@@ -760,113 +696,22 @@ impl Agent {
         Ok(summary)
     }
 
-    /// Gate, execute, and feed back one tool call. Returns `Some(reason)`
-    /// when the turn must end early (UI gone, circuit breaker).
+    /// Run one tool call through the dispatcher and feed its results back to
+    /// the model. Returns `Some(reason)` when the turn must end early (UI
+    /// gone, circuit breaker).
     async fn dispatch_call(
         &mut self,
         call: &ToolCall,
         events: &mpsc::Sender<AgentEvent>,
-    ) -> Result<Option<DoneReason>> {
-        let name = call.function.name.clone();
-        let args = normalize_args(&call.function.arguments);
-
-        let needs_approval = self
-            .registry
-            .get(&name)
-            .map(|tool| tool.requires_approval())
-            .unwrap_or(false);
-
-        let approved = if needs_approval && !self.auto_approve() {
-            let (respond, response) = oneshot::channel();
-            if !emit(
-                events,
-                AgentEvent::ApprovalRequest {
-                    call: call.clone(),
-                    respond,
-                },
-            )
-            .await
-            {
-                return Ok(Some(DoneReason::Stopped));
-            }
-            match response.await {
-                Ok(approved) => approved,
-                // Sender dropped without answering: the UI is tearing down,
-                // so end the turn instead of feeding the model a denial.
-                Err(_) => return Ok(Some(DoneReason::Stopped)),
-            }
-        } else {
-            true
-        };
-
-        let output = if approved {
-            if !emit(
-                events,
-                AgentEvent::ToolStarted {
-                    name: name.clone(),
-                    args: args.clone(),
-                },
-            )
-            .await
-            {
-                return Ok(Some(DoneReason::Stopped));
-            }
-            match self.registry.execute(&name, args.clone(), &self.ctx).await {
-                Ok(output) => output,
-                Err(err) => ToolOutput::error(err.to_string()),
-            }
-        } else {
-            ToolOutput::error(format!(
-                "User denied execution of '{name}'. Do not retry it verbatim; ask or adjust."
-            ))
-        };
-
-        if !emit(
-            events,
-            AgentEvent::ToolFinished {
-                name: name.clone(),
-                output: output.clone(),
-            },
-        )
-        .await
-        {
-            return Ok(Some(DoneReason::Stopped));
+    ) -> Option<DoneReason> {
+        let outcome = self.dispatcher.dispatch(call, &self.ctx, events).await;
+        if let Some(output) = &outcome.output {
+            self.push(self.tool_feedback(&call.function.name, output));
         }
-
-        let breaker_tripped = self.track_failure(&name, &args, &output);
-        let failure_action = self.tool_failures.record(&name, output.is_error);
-        self.push(self.tool_feedback(&name, &output));
-
-        if breaker_tripped {
-            let _ = emit(
-                events,
-                AgentEvent::Error(format!(
-                    "circuit breaker: '{name}' failed identically {CIRCUIT_BREAKER_LIMIT} times in a row"
-                )),
-            )
-            .await;
-            return Ok(Some(DoneReason::CircuitBreaker));
+        if let Some(nudge) = outcome.nudge {
+            self.push(ChatMessage::system(nudge));
         }
-        match failure_action {
-            FailureAction::Continue => {}
-            FailureAction::Nudge => {
-                self.push(ChatMessage::system(format!(
-                    "Repeated failures with tool '{name}' ({TOOL_FAILURE_NUDGE} in a row) — \
-                     stop retrying it and change approach."
-                )));
-            }
-            FailureAction::Trip => {
-                let _ = emit(
-                    events,
-                    AgentEvent::Error(format!(
-                        "circuit breaker: '{name}' failed {TOOL_FAILURE_TRIP} times in a row"
-                    )),
-                )
-                .await;
-                return Ok(Some(DoneReason::CircuitBreaker));
-            }
-        }
-        Ok(None)
+        outcome.done
     }
 
     /// Build the message that feeds a tool result back to the model.
@@ -881,25 +726,6 @@ impl Agent {
         } else {
             ChatMessage::user(format!("Tool result for `{name}`:\n{body}"))
         }
-    }
-
-    /// Update circuit-breaker state (sovereign only). Returns true when the
-    /// breaker trips.
-    fn track_failure(&mut self, name: &str, args: &Value, output: &ToolOutput) -> bool {
-        if self.mode != Mode::Sovereign {
-            return false;
-        }
-        if !output.is_error {
-            self.failure_streak = None;
-            return false;
-        }
-        let signature = format!("{name}\u{1}{args}\u{1}{}", output.content);
-        let count = match &self.failure_streak {
-            Some((last, count)) if *last == signature => count + 1,
-            _ => 1,
-        };
-        self.failure_streak = Some((signature, count));
-        count >= CIRCUIT_BREAKER_LIMIT
     }
 
     /// Honor `.wizard/loop-control` between steps: `stop` ends the turn,
@@ -1136,10 +962,6 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                     printer_spinner.hide();
                     print!("\x1b[2m{delta}\x1b[0m");
                     let _ = std::io::stdout().flush();
-                }
-                AgentEvent::ApprovalRequest { respond, .. } => {
-                    // Both modes auto-approve by default; this is a safety net for the opt-in gating path.
-                    let _ = respond.send(true);
                 }
                 AgentEvent::ToolStarted { name, args } => {
                     printer_spinner.println(&format!("\n→ {name} {args}"));
@@ -1635,68 +1457,5 @@ mod tests {
     fn loop_control_absent_file_is_none() {
         let tmp = TempDir::new();
         assert_eq!(read_loop_control(&tmp.0), None);
-    }
-
-    #[test]
-    fn tool_failures_nudge_then_trip() {
-        let mut counter = ToolFailureCounter::default();
-        for i in 1..TOOL_FAILURE_NUDGE {
-            assert_eq!(
-                counter.record("execute", true),
-                FailureAction::Continue,
-                "failure {i}"
-            );
-        }
-        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
-        for i in TOOL_FAILURE_NUDGE + 1..TOOL_FAILURE_TRIP {
-            assert_eq!(
-                counter.record("execute", true),
-                FailureAction::Continue,
-                "failure {i}"
-            );
-        }
-        assert_eq!(counter.record("execute", true), FailureAction::Trip);
-    }
-
-    #[test]
-    fn tool_failures_reset_on_success_of_that_tool() {
-        let mut counter = ToolFailureCounter::default();
-        for _ in 0..TOOL_FAILURE_NUDGE - 1 {
-            counter.record("execute", true);
-        }
-        assert_eq!(counter.record("execute", false), FailureAction::Continue);
-        // The streak starts over after the success.
-        for i in 1..TOOL_FAILURE_NUDGE {
-            assert_eq!(
-                counter.record("execute", true),
-                FailureAction::Continue,
-                "failure {i}"
-            );
-        }
-        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
-    }
-
-    #[test]
-    fn tool_failures_count_per_tool_name() {
-        let mut counter = ToolFailureCounter::default();
-        for _ in 0..TOOL_FAILURE_NUDGE - 1 {
-            counter.record("execute", true);
-            counter.record("write_file", true);
-        }
-        // Each tool reaches the nudge threshold independently; a success of
-        // one tool does not reset the other.
-        counter.record("write_file", false);
-        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
-        assert_eq!(counter.record("write_file", true), FailureAction::Continue);
-    }
-
-    #[test]
-    fn tool_failures_reset_clears_all_counts() {
-        let mut counter = ToolFailureCounter::default();
-        for _ in 0..TOOL_FAILURE_TRIP {
-            counter.record("execute", true);
-        }
-        counter.reset();
-        assert_eq!(counter.record("execute", true), FailureAction::Continue);
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -22,6 +22,7 @@ use tokio::sync::mpsc;
 use crate::cli::Cli;
 use crate::config::{Config, Mode, ProviderKind};
 use crate::dispatch::Dispatcher;
+use crate::hooks::{HookEngine, PromptSubmit};
 use crate::llm::provider::LlmProvider;
 use crate::llm::{ChatMessage, ChatOptions, ChatRequest, FunctionCall, Role, ToolCall};
 use crate::mcp::{McpConfig, McpManager};
@@ -63,6 +64,17 @@ pub enum AgentEvent {
     StepCompleted { step: u32 },
     /// Non-fatal error surfaced to the user; the loop may continue.
     Error(String),
+    /// A lifecycle hook did something worth surfacing (rewrote arguments,
+    /// appended context, blocked, or failed). Plain successes are silent.
+    /// Rendered as a dim log line.
+    HookFired {
+        /// Lifecycle event name (e.g. `"pre_tool_use"`).
+        event: &'static str,
+        /// The hook's shell command.
+        command: String,
+        /// What the hook did.
+        outcome: crate::hooks::HookOutcome,
+    },
     /// The turn is over.
     Done { reason: DoneReason },
 }
@@ -185,6 +197,8 @@ pub struct Agent {
     model: String,
     /// Tool-call pipeline; owns the registry and the failure breakers.
     dispatcher: Dispatcher,
+    /// Lifecycle hooks; the dispatcher and the subagent spawner share it.
+    hooks: Arc<HookEngine>,
     config: Config,
     mode: Mode,
     /// Full conversation including the system prompt at index 0.
@@ -226,7 +240,9 @@ impl Agent {
     /// Build an agent: compose the system prompt from `mode`, `skills`, and
     /// any project `AGENTS.md`; seed history from `session` (resumed
     /// sessions replay their persisted messages under a fresh system
-    /// prompt).
+    /// prompt). `hooks` is loaded by the builders (`crate::hooks::load`) and
+    /// injected so tests can supply their own definitions.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client: Arc<dyn LlmProvider>,
         registry: ToolRegistry,
@@ -235,6 +251,7 @@ impl Agent {
         project_root: PathBuf,
         session: Session,
         native_tools: bool,
+        hooks: Arc<HookEngine>,
     ) -> Result<Self> {
         let agents_md = read_project_instructions(&project_root);
         let memory_index = read_memory_index(&project_root);
@@ -257,7 +274,8 @@ impl Agent {
         let mut agent = Self {
             client,
             model,
-            dispatcher: Dispatcher::new(registry, config.mode),
+            dispatcher: Dispatcher::new(registry, config.mode, Arc::clone(&hooks)),
+            hooks,
             mode: config.mode,
             config,
             history: Vec::new(),
@@ -310,9 +328,32 @@ impl Agent {
     /// session file.
     pub fn clear(&mut self) -> Result<()> {
         self.session = Session::create(&Config::sessions_dir()?)?;
+        self.hooks.set_session_id(self.session.id.clone());
         self.history.truncate(1);
         self.dispatcher.reset_failures();
         Ok(())
+    }
+
+    /// The lifecycle-hook engine this agent fires (shared for `/reload`
+    /// registry rebuilds).
+    pub fn hooks(&self) -> &Arc<HookEngine> {
+        &self.hooks
+    }
+
+    /// Fire the `session_start` hooks. Hook stdout is appended to the
+    /// session as system context, visible to the model on every turn.
+    pub async fn fire_session_start(&mut self, events: &mpsc::Sender<AgentEvent>) {
+        if let Some(extra) = self.hooks.session_start(self.mode, Some(events)).await {
+            self.push(ChatMessage::system(format!(
+                "[session_start hook]\n{extra}"
+            )));
+        }
+    }
+
+    /// Fire the `session_end` hooks. `events` is `None` when the surface is
+    /// already torn down (e.g. the TUI terminal was restored).
+    pub async fn fire_session_end(&self, events: Option<&mpsc::Sender<AgentEvent>>) {
+        self.hooks.session_end(self.mode, events).await;
     }
 
     /// Swap the tool registry (after `/reload` or `/evolve`). Refreshes the
@@ -389,7 +430,7 @@ impl Agent {
         if let Some(warning) = self.load_warning.take() {
             let _ = emit(&events, AgentEvent::Error(warning)).await;
         }
-        match self.turn_inner(input, &events).await {
+        let result = match self.turn_inner(input, &events).await {
             Ok(reason) => {
                 let _ = emit(&events, AgentEvent::Done { reason }).await;
                 Ok(reason)
@@ -405,7 +446,10 @@ impl Agent {
                 .await;
                 Err(err)
             }
-        }
+        };
+        // turn_end hooks: observational, fired however the turn ended.
+        self.hooks.turn_end(self.mode, Some(&events)).await;
+        result
     }
 
     async fn turn_inner(
@@ -413,6 +457,25 @@ impl Agent {
         input: &str,
         events: &mpsc::Sender<AgentEvent>,
     ) -> Result<DoneReason> {
+        // user_prompt_submit hooks: may veto the turn before the model sees
+        // the prompt (the message is never pushed to history), or append
+        // extra context to it.
+        let input = match self.hooks.user_prompt_submit(self.mode, Some(events)).await {
+            PromptSubmit::Block(reason) => {
+                let _ = emit(
+                    events,
+                    AgentEvent::Error(format!(
+                        "prompt blocked by user_prompt_submit hook: {reason}"
+                    )),
+                )
+                .await;
+                return Ok(DoneReason::Stopped);
+            }
+            PromptSubmit::Continue(Some(extra)) => {
+                format!("{input}\n\n[user_prompt_submit hook]\n{extra}")
+            }
+            PromptSubmit::Continue(None) => input.to_string(),
+        };
         self.push(ChatMessage::user(input));
         self.compact_if_needed(events).await;
         let max_steps = self.config.max_steps.max(1);
@@ -836,6 +899,25 @@ pub async fn build_headless_agent(
         println!("model '{model}' lacks native tool calling; using the JSON tool protocol");
     }
 
+    // Session first: the hook engine carries its id in every payload.
+    let sessions_dir = Config::sessions_dir()?;
+    let session = if resume {
+        match Session::open_latest(&sessions_dir)? {
+            Some(session) => session,
+            None => Session::create(&sessions_dir)?,
+        }
+    } else {
+        Session::create(&sessions_dir)?
+    };
+
+    // Lifecycle hooks, shared by the agent's dispatcher and the subagent
+    // spawner so subagent tool calls fire the same hooks.
+    let hooks = Arc::new(HookEngine::new(
+        crate::hooks::load(project_root),
+        project_root.to_path_buf(),
+        session.id.clone(),
+    ));
+
     // Tools: natives + scripted + MCP, then the subagent spawner on top.
     let mut base = ToolRegistry::with_native_tools();
     match Config::scripted_tools_dir() {
@@ -871,6 +953,7 @@ pub async fn build_headless_agent(
         subagent_configs,
         Arc::clone(&client),
         Arc::clone(&base),
+        Arc::clone(&hooks),
     )));
     registry.register(Arc::new(crate::tools::evolve::EvolveTool::new(
         config.clone(),
@@ -886,16 +969,6 @@ pub async fn build_headless_agent(
         Vec::new()
     });
 
-    let sessions_dir = Config::sessions_dir()?;
-    let session = if resume {
-        match Session::open_latest(&sessions_dir)? {
-            Some(session) => session,
-            None => Session::create(&sessions_dir)?,
-        }
-    } else {
-        Session::create(&sessions_dir)?
-    };
-
     Agent::new(
         client,
         registry,
@@ -904,6 +977,7 @@ pub async fn build_headless_agent(
         project_root.to_path_buf(),
         session,
         native_tools,
+        hooks,
     )
 }
 
@@ -981,6 +1055,13 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                     printer_spinner.hide();
                     eprintln!("\nwizard error: {message}");
                 }
+                AgentEvent::HookFired {
+                    event,
+                    command,
+                    outcome,
+                } => {
+                    printer_spinner.println(&format!("~ hook {event}: {outcome} ({command})"));
+                }
                 AgentEvent::Done { reason } => {
                     printer_spinner.hide();
                     println!("\n[turn done: {reason:?}]");
@@ -993,6 +1074,9 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
         "wizard {} — model {model} @ {endpoint} — task: {goal}",
         config.mode
     );
+
+    // session_start hooks fire once for the whole run.
+    agent.fire_session_start(&tx).await;
 
     // Continuous mode persists a long-lived mission so the loop survives
     // restarts and binary self-replacement (deep evolve re-exec).
@@ -1131,6 +1215,10 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
         }
     }
 
+    // session_end hooks fire however the run ended (including just before a
+    // self-evolve re-exec replaces the process).
+    agent.fire_session_end(Some(&tx)).await;
+
     drop(tx);
     let _ = printer.await;
     spinner.finish();
@@ -1164,6 +1252,7 @@ mod tests {
     use futures_util::stream;
 
     use super::*;
+    use crate::hooks::{HookDef, HookEvent};
     use crate::llm::{ChatChunk, ChatStream};
 
     /// Temp project dir removed on drop.
@@ -1247,19 +1336,37 @@ mod tests {
 
     fn test_agent(responses: Vec<Vec<ChatChunk>>) -> (Agent, Arc<ScriptedProvider>, TempDir) {
         let tmp = TempDir::new();
+        let (agent, provider) = test_agent_in(&tmp, responses, Vec::new(), ToolRegistry::new());
+        (agent, provider, tmp)
+    }
+
+    /// Build a test agent rooted in `tmp` with injected hook definitions and
+    /// a custom registry.
+    fn test_agent_in(
+        tmp: &TempDir,
+        responses: Vec<Vec<ChatChunk>>,
+        hook_defs: Vec<HookDef>,
+        registry: ToolRegistry,
+    ) -> (Agent, Arc<ScriptedProvider>) {
         let provider = ScriptedProvider::new(responses);
         let session = Session::create(&tmp.0).expect("create session");
+        let hooks = Arc::new(HookEngine::new(
+            hook_defs,
+            tmp.0.clone(),
+            session.id.clone(),
+        ));
         let agent = Agent::new(
             provider.clone(),
-            ToolRegistry::new(),
+            registry,
             Config::default(),
             Vec::new(),
             tmp.0.clone(),
             session,
             true,
+            hooks,
         )
         .expect("build agent");
-        (agent, provider, tmp)
+        (agent, provider)
     }
 
     /// Drain a finished turn's events into (text, errors).
@@ -1274,6 +1381,84 @@ mod tests {
             }
         }
         (text, errors)
+    }
+
+    /// Test tool that records the arguments of every call it receives.
+    struct RecordingTool {
+        calls: Arc<Mutex<Vec<Value>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::Tool for RecordingTool {
+        fn name(&self) -> &str {
+            "echo"
+        }
+
+        fn description(&self) -> &str {
+            "Echo the arguments back (test tool)."
+        }
+
+        fn parameters(&self) -> Value {
+            json!({ "type": "object", "properties": {} })
+        }
+
+        async fn execute(
+            &self,
+            args: Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolOutput, crate::tools::ToolError> {
+            self.calls.lock().unwrap().push(args.clone());
+            Ok(ToolOutput::ok(format!("echoed {args}")))
+        }
+    }
+
+    /// Registry holding one [`RecordingTool`], plus the shared call log.
+    fn recording_registry() -> (ToolRegistry, Arc<Mutex<Vec<Value>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(RecordingTool {
+            calls: Arc::clone(&calls),
+        }));
+        (registry, calls)
+    }
+
+    /// `done: true` chunk carrying one tool call.
+    fn tool_call_chunk(name: &str, arguments: Value) -> ChatChunk {
+        ChatChunk {
+            message: Some(ChatMessage {
+                role: Role::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    function: FunctionCall {
+                        name: name.to_string(),
+                        arguments,
+                    },
+                }],
+                tool_name: None,
+            }),
+            thinking: false,
+            done: true,
+            done_reason: None,
+            eval_count: None,
+            prompt_eval_count: None,
+        }
+    }
+
+    /// Write a hook script into `dir` and return the command that runs it
+    /// (via `sh`, so no exec bit is needed).
+    fn write_script(dir: &Path, name: &str, body: &str) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, body).expect("write hook script");
+        format!("sh {}", path.display())
+    }
+
+    fn hook(event: HookEvent, matcher: Option<&str>, command: String) -> HookDef {
+        HookDef {
+            event,
+            matcher: matcher.map(str::to_string),
+            command,
+            timeout_secs: None,
+        }
     }
 
     #[test]
@@ -1457,5 +1642,200 @@ mod tests {
     fn loop_control_absent_file_is_none() {
         let tmp = TempDir::new();
         assert_eq!(read_loop_control(&tmp.0), None);
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_block_feeds_reason_to_model_as_tool_error() {
+        let tmp = TempDir::new();
+        let command = write_script(
+            &tmp.0,
+            "block.sh",
+            "echo 'no echoing allowed' >&2\nexit 2\n",
+        );
+        let (registry, calls) = recording_registry();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("echo", json!({ "text": "hi" }))],
+                vec![final_chunk("understood")],
+            ],
+            vec![hook(HookEvent::PreToolUse, Some("echo"), command)],
+            registry,
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        assert!(calls.lock().unwrap().is_empty(), "blocked tool never ran");
+
+        // The block reason reached the model as an ordinary tool error.
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let feedback = requests[1]
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Tool)
+            .expect("tool feedback message");
+        assert!(
+            feedback.content.contains("blocked by pre_tool_use hook"),
+            "{}",
+            feedback.content
+        );
+        assert!(feedback.content.contains("no echoing allowed"));
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_updated_args_rewrite_the_call() {
+        let tmp = TempDir::new();
+        let command = write_script(
+            &tmp.0,
+            "rewrite.sh",
+            "echo '{\"updated_args\": {\"text\": \"rewritten\"}}'\n",
+        );
+        let (registry, calls) = recording_registry();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("echo", json!({ "text": "original" }))],
+                vec![final_chunk("done")],
+            ],
+            vec![hook(HookEvent::PreToolUse, None, command)],
+            registry,
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![json!({ "text": "rewritten" })],
+            "the tool ran with the hook's arguments"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_stdout_is_appended_to_the_result() {
+        let tmp = TempDir::new();
+        let command = write_script(&tmp.0, "annotate.sh", "echo 'lint: all clean'\n");
+        let (registry, calls) = recording_registry();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("echo", json!({ "text": "hi" }))],
+                vec![final_chunk("done")],
+            ],
+            vec![hook(HookEvent::PostToolUse, Some("echo"), command)],
+            registry,
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(calls.lock().unwrap().len(), 1, "the tool ran normally");
+
+        let requests = provider.requests.lock().unwrap();
+        let feedback = requests[1]
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Tool)
+            .expect("tool feedback message");
+        assert!(feedback.content.contains("echoed"), "{}", feedback.content);
+        assert!(
+            feedback.content.contains("lint: all clean"),
+            "hook stdout appended: {}",
+            feedback.content
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_block_ends_the_turn() {
+        let tmp = TempDir::new();
+        let command = write_script(
+            &tmp.0,
+            "veto.sh",
+            "echo 'not during business hours' >&2\nexit 2\n",
+        );
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            Vec::new(), // the model must never be asked
+            vec![hook(HookEvent::UserPromptSubmit, None, command)],
+            ToolRegistry::new(),
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let reason = agent.run_turn("do the thing", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Stopped);
+        assert!(provider.requests.lock().unwrap().is_empty());
+        assert_eq!(agent.history().len(), 1, "the prompt never entered history");
+
+        let (_text, errors) = drain_events(&mut rx);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("blocked") && e.contains("not during business hours")),
+            "notice emitted: {errors:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_stdout_is_appended_to_the_message() {
+        let tmp = TempDir::new();
+        let command = write_script(&tmp.0, "context.sh", "echo 'remember: deploy is frozen'\n");
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![vec![final_chunk("noted")]],
+            vec![hook(HookEvent::UserPromptSubmit, None, command)],
+            ToolRegistry::new(),
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent.run_turn("do the thing", tx).await.expect("turn ok");
+
+        let requests = provider.requests.lock().unwrap();
+        let prompt = requests[0].messages.last().expect("user message");
+        assert_eq!(prompt.role, Role::User);
+        assert!(
+            prompt.content.contains("do the thing"),
+            "{}",
+            prompt.content
+        );
+        assert!(
+            prompt.content.contains("remember: deploy is frozen"),
+            "hook context appended: {}",
+            prompt.content
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_timeout_does_not_hang_the_turn() {
+        let tmp = TempDir::new();
+        let command = write_script(&tmp.0, "slow.sh", "sleep 5\n");
+        let (registry, calls) = recording_registry();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("echo", json!({}))],
+                vec![final_chunk("done")],
+            ],
+            vec![HookDef {
+                event: HookEvent::PreToolUse,
+                matcher: None,
+                command,
+                timeout_secs: Some(1),
+            }],
+            registry,
+        );
+
+        let started = Instant::now();
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(calls.lock().unwrap().len(), 1, "the tool still ran");
+        assert!(
+            started.elapsed() < Duration::from_secs(4),
+            "the hook was killed at its 1s timeout (took {:?})",
+            started.elapsed()
+        );
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -9,7 +9,6 @@ pub mod prompts;
 pub mod session;
 pub mod subagent;
 
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -1348,7 +1347,8 @@ fn rollback_failed_cycle(
     project_root: &Path,
     first_turn: u64,
     why: &str,
-    spinner: &crate::progress::TurnSpinner,
+    // `None` in the structured output formats, where stdout is JSON-only.
+    spinner: Option<&crate::progress::TurnSpinner>,
 ) {
     if !config.rollback_failed_cycles {
         return;
@@ -1358,10 +1358,12 @@ fn rollback_failed_cycle(
             if restored.is_empty() {
                 return;
             }
-            spinner.println(&format!(
-                "[rolled back {} file(s) after {why}]",
-                restored.len()
-            ));
+            if let Some(spinner) = spinner {
+                spinner.println(&format!(
+                    "[rolled back {} file(s) after {why}]",
+                    restored.len()
+                ));
+            }
             if let Some(mission) = mission {
                 mission.note(format!(
                     "rolled back {} file(s) after {why} (cycle starting at turn {first_turn})",
@@ -1384,8 +1386,10 @@ fn rollback_failed_cycle(
 /// outages, compacting context, and re-exec'ing itself after a self-evolve —
 /// until stopped via `.wizard/loop-control`, `--max-hours`, or the circuit
 /// breaker. Otherwise it honors the `--loop N` bound. Prints progress to
-/// stdout instead of the TUI.
-pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
+/// stdout instead of the TUI (`--output-format` selects the
+/// [`crate::output::EventSink`]); the returned exit code encodes the
+/// outcome (see [`crate::output::exit_code`]).
+pub async fn run_headless(config: Config, cli: Cli) -> Result<i32> {
     let project_root = std::env::current_dir().context("determining project root")?;
 
     // Goal resolution: an explicit `-p` wins; otherwise resume the standing
@@ -1423,96 +1427,38 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     }
 
     // Busy spinner ("Conjuring…") shown while the model thinks or a tool
-    // runs, hidden while output streams. Shared with the printer task; a
-    // no-op when stderr is not a terminal.
+    // runs, hidden while output streams. Shared with the text sink; a
+    // no-op when stderr is not a terminal. The structured formats never
+    // show it and keep stdout pure JSON (`text_mode` gates every plain
+    // stdout line below).
     let spinner = Arc::new(crate::progress::TurnSpinner::new());
+    let text_mode = cli.output_format == crate::output::OutputFormat::Text;
 
     let (tx, mut rx) = mpsc::channel::<AgentEvent>(256);
-    let printer_spinner = Arc::clone(&spinner);
-    // The printer returns the run's accumulated (prompt, completion) token
-    // totals for the final summary line.
-    let printer = tokio::spawn(async move {
-        let mut prompt_total: u64 = 0;
-        let mut completion_total: u64 = 0;
-        while let Some(event) = rx.recv().await {
-            match event {
-                AgentEvent::TextDelta(delta) => {
-                    printer_spinner.hide();
-                    print!("{delta}");
-                    let _ = std::io::stdout().flush();
-                }
-                AgentEvent::ThinkingDelta(delta) => {
-                    // ANSI faint so reasoning reads as background noise.
-                    printer_spinner.hide();
-                    print!("\x1b[2m{delta}\x1b[0m");
-                    let _ = std::io::stdout().flush();
-                }
-                AgentEvent::ToolStarted { name, args } => {
-                    printer_spinner.println(&format!("\n→ {name} {args}"));
-                    // The tool may run for a while: keep the verb spinning.
-                    printer_spinner.show();
-                }
-                AgentEvent::ToolFinished { name, output } => {
-                    let status = if output.is_error { "error" } else { "ok" };
-                    printer_spinner.println(&format!("← {name} [{status}]"));
-                    // Back to the model: it is thinking about the result.
-                    printer_spinner.show();
-                }
-                AgentEvent::StepCompleted { step } => {
-                    tracing::debug!("step {step} completed");
-                }
-                AgentEvent::Error(message) => {
-                    printer_spinner.hide();
-                    eprintln!("\nwizard error: {message}");
-                }
-                AgentEvent::HookFired {
-                    event,
-                    command,
-                    outcome,
-                } => {
-                    printer_spinner.println(&format!("~ hook {event}: {outcome} ({command})"));
-                }
-                AgentEvent::PlanReady { plan, respond } => {
-                    // Headless: print the plan and approve it, so the turn
-                    // moves from planning to execution on its own.
-                    printer_spinner
-                        .println(&format!("\n=== plan ===\n{plan}\n=== plan approved ==="));
-                    let _ = respond.send(PlanVerdict::approve());
-                    printer_spinner.show();
-                }
-                AgentEvent::Usage {
-                    prompt_tokens,
-                    completion_tokens,
-                } => {
-                    prompt_total += prompt_tokens;
-                    completion_total += completion_tokens;
-                }
-                AgentEvent::TodoUpdated(items) => {
-                    printer_spinner.println(&crate::tools::todo::summary_line(&items));
-                }
-                AgentEvent::TaskFinished {
-                    id,
-                    command,
-                    status,
-                } => {
-                    printer_spinner.println(&format!(
-                        "⏺ background task #{id} finished ({}): {command}",
-                        status.describe()
-                    ));
-                }
-                AgentEvent::Done { reason } => {
-                    printer_spinner.hide();
-                    println!("\n[turn done: {reason:?}]");
-                }
-            }
+    // The sink consumes every agent event off the run loop; it is returned
+    // so `finish` can emit the run summary once the outcome is known.
+    let mut sink: Box<dyn crate::output::EventSink> = match cli.output_format {
+        crate::output::OutputFormat::Text => {
+            Box::new(crate::output::TextSink::new(Arc::clone(&spinner)))
         }
-        (prompt_total, completion_total)
+        crate::output::OutputFormat::Json => Box::new(crate::output::JsonSink::stdout()),
+        crate::output::OutputFormat::StreamJson => {
+            Box::new(crate::output::StreamJsonSink::stdout())
+        }
+    };
+    let printer = tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            sink.event(event);
+        }
+        sink
     });
 
-    println!(
-        "wizard {} — model {model} @ {endpoint} — task: {goal}",
-        config.mode
-    );
+    if text_mode {
+        println!(
+            "wizard {} — model {model} @ {endpoint} — task: {goal}",
+            config.mode
+        );
+    }
 
     // session_start hooks fire once for the whole run.
     agent.fire_session_start(&tx).await;
@@ -1555,24 +1501,28 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
             break;
         }
         if config.continuous {
-            spinner.println(&format!("\n=== cycle {iteration} ==="));
+            if text_mode {
+                spinner.println(&format!("\n=== cycle {iteration} ==="));
+            }
             // `plan_each_cycle = true`: every cycle starts by planning again
             // (the previous cycle's exit_plan approval cleared the flag).
             if config.plan_each_cycle {
                 agent.set_plan_mode(true);
             }
-        } else if max_iterations > 1 {
+        } else if max_iterations > 1 && text_mode {
             spinner.println(&format!("\n=== iteration {iteration}/{max_iterations} ==="));
         }
 
         // Fresh verb per turn (same mechanism as the TUI's busy spinner), so
-        // one turn reads as one activity.
-        let verb_seed = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |elapsed| elapsed.as_nanos() as u64)
-            .wrapping_add(u64::from(iteration));
-        spinner.set_verb(config.ui.spinner_verb(verb_seed));
-        spinner.show();
+        // one turn reads as one activity. Structured formats never spin.
+        if text_mode {
+            let verb_seed = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |elapsed| elapsed.as_nanos() as u64)
+                .wrapping_add(u64::from(iteration));
+            spinner.set_verb(config.ui.spinner_verb(verb_seed));
+            spinner.show();
+        }
 
         // Surface background tasks that finished between cycles (the turn
         // loop also drains at the top of every step).
@@ -1643,7 +1593,7 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                             &project_root,
                             cycle_first_turn,
                             "circuit breaker",
-                            &spinner,
+                            text_mode.then_some(&*spinner),
                         );
                         break;
                     }
@@ -1657,7 +1607,7 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                     &project_root,
                     cycle_first_turn,
                     "hard error",
-                    &spinner,
+                    text_mode.then_some(&*spinner),
                 );
                 run_error = Some(err);
                 break;
@@ -1692,13 +1642,18 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     agent.fire_session_end(Some(&tx)).await;
 
     drop(tx);
-    let (prompt_tokens, completion_tokens) = printer.await.unwrap_or((0, 0));
+    let mut sink = match printer.await {
+        Ok(sink) => sink,
+        Err(err) => return Err(anyhow::anyhow!("output task panicked: {err}")),
+    };
     spinner.finish();
 
     if reexec_after {
         use std::os::unix::process::CommandExt;
         let exe = std::env::current_exe().context("locating current executable for re-exec")?;
-        println!("[re-exec into evolved binary {}]", exe.display());
+        if text_mode {
+            println!("[re-exec into evolved binary {}]", exe.display());
+        }
         let err = std::process::Command::new(exe)
             .arg("--mode")
             .arg("sovereign")
@@ -1712,15 +1667,10 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
     if let Some(err) = run_error {
         return Err(err);
     }
-    if prompt_tokens > 0 || completion_tokens > 0 {
-        println!(
-            "[run finished: {final_reason:?} — {prompt_tokens} prompt + {completion_tokens} \
-             completion tokens]"
-        );
-    } else {
-        println!("[run finished: {final_reason:?}]");
-    }
-    Ok(())
+    // The sink emits the run summary (the text trailer line, or the final
+    // JSON object / `done` JSONL line) and leaves stdout flushed.
+    sink.finish(final_reason);
+    Ok(crate::output::exit_code(final_reason))
 }
 
 #[cfg(test)]
@@ -2759,7 +2709,7 @@ mod tests {
             &tmp.0,
             cycle_first_turn,
             "circuit breaker",
-            &spinner,
+            Some(&spinner),
         );
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "broken");
         assert!(mission.notes.is_empty());
@@ -2776,7 +2726,7 @@ mod tests {
             &tmp.0,
             cycle_first_turn,
             "circuit breaker",
-            &spinner,
+            Some(&spinner),
         );
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "good");
         assert!(
@@ -3202,5 +3152,55 @@ mod tests {
             "the hook was killed at its 1s timeout (took {:?})",
             started.elapsed()
         );
+    }
+
+    #[tokio::test]
+    async fn stream_json_sink_renders_a_scripted_run_as_jsonl_ending_in_done() {
+        use crate::output::{EventSink, StreamJsonSink, tests::SharedBuf};
+
+        let tmp = TempDir::new();
+        let (registry, _calls) = recording_registry();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("echo", json!({ "text": "hi" }))],
+                vec![usage_chunk("all wrapped up", 42, 7)],
+            ],
+            Vec::new(),
+            registry,
+        );
+
+        let (tx, mut rx) = mpsc::channel(256);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+
+        // Feed the turn's real event stream through the stream-json sink,
+        // exactly as run_headless wires it.
+        let buf = SharedBuf::default();
+        let mut sink = StreamJsonSink::new(buf.clone());
+        while let Ok(event) = rx.try_recv() {
+            sink.event(event);
+        }
+        sink.finish(reason);
+
+        let out = buf.contents();
+        let values: Vec<serde_json::Value> = out
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("every line is valid JSON"))
+            .collect();
+        assert!(values.len() >= 4, "got: {out}");
+        let types: Vec<&str> = values
+            .iter()
+            .filter_map(|value| value["type"].as_str())
+            .collect();
+        assert!(types.contains(&"tool_call"), "got: {types:?}");
+        assert!(types.contains(&"tool_result"), "got: {types:?}");
+        assert!(types.contains(&"text_delta"), "got: {types:?}");
+        assert!(types.contains(&"usage"), "got: {types:?}");
+        let done = values.last().expect("at least the done line");
+        assert_eq!(done["type"], "done");
+        assert_eq!(done["reason"], "completed");
+        assert_eq!(done["usage"]["prompt_tokens"], 42);
+        assert_eq!(done["usage"]["completion_tokens"], 7);
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -563,6 +563,17 @@ impl Agent {
         &self.usage
     }
 
+    /// Number of background tasks (`execute` with `run_in_background`)
+    /// still running, for `/status`.
+    pub fn running_tasks(&self) -> usize {
+        self.ctx
+            .tasks
+            .list()
+            .iter()
+            .filter(|task| !task.status.is_finished())
+            .count()
+    }
+
     /// Redirect (or disable) the per-turn usage JSONL log. Defaults to
     /// `~/.wizard/usage.jsonl`; tests point it into a temp dir.
     pub fn set_usage_log(&mut self, path: Option<PathBuf>) {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -122,6 +122,14 @@ pub enum AgentEvent {
     /// list; the TUI mirrors it in a side panel, headless prints a one-line
     /// summary, the gateway ignores it.
     TodoUpdated(Vec<crate::tools::todo::TodoItem>),
+    /// A background task (`execute` with `run_in_background`) finished; its
+    /// output tail was injected into history. The TUI and headless surfaces
+    /// print a one-liner, the gateway ignores it.
+    TaskFinished {
+        id: u32,
+        command: String,
+        status: crate::tools::tasks::TaskStatus,
+    },
     /// The turn is over.
     Done { reason: DoneReason },
 }
@@ -644,6 +652,8 @@ impl Agent {
         let max_steps = self.config.max_steps.max(1);
 
         for step in 1..=max_steps {
+            // Surface background tasks that finished since the last step.
+            self.drain_background_tasks(events).await;
             if let Some(deadline) = self.deadline
                 && Instant::now() >= deadline
             {
@@ -1031,6 +1041,45 @@ impl Agent {
             }
         }
     }
+
+    /// Drain background tasks that finished since the last check (each
+    /// reported exactly once): inject a notification with the output tail
+    /// into history so the model sees it on its next completion, and emit
+    /// [`AgentEvent::TaskFinished`] for the surfaces. Called at the top of
+    /// every agent step and every perpetual cycle.
+    async fn drain_background_tasks(&mut self, events: &mpsc::Sender<AgentEvent>) {
+        for task in self.ctx.tasks.drain_completed() {
+            let mut note = format!(
+                "[background task #{} finished ({})] {}",
+                task.id,
+                task.status.describe(),
+                task.command
+            );
+            let tail = task.tail.trim();
+            if !tail.is_empty() {
+                note.push('\n');
+                note.push_str(tail);
+            }
+            self.push(ChatMessage::system(note));
+            let _ = emit(
+                events,
+                AgentEvent::TaskFinished {
+                    id: task.id,
+                    command: task.command,
+                    status: task.status,
+                },
+            )
+            .await;
+        }
+    }
+}
+
+impl Drop for Agent {
+    /// Kill any still-running background tasks. Their children also carry
+    /// `kill_on_drop`; this makes the teardown explicit and immediate.
+    fn drop(&mut self) {
+        self.ctx.tasks.kill_all();
+    }
 }
 
 /// Read the persistent memory index (MEMORY.md) for `project_root`, if any
@@ -1291,6 +1340,16 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                 AgentEvent::TodoUpdated(items) => {
                     printer_spinner.println(&crate::tools::todo::summary_line(&items));
                 }
+                AgentEvent::TaskFinished {
+                    id,
+                    command,
+                    status,
+                } => {
+                    printer_spinner.println(&format!(
+                        "⏺ background task #{id} finished ({}): {command}",
+                        status.describe()
+                    ));
+                }
                 AgentEvent::Done { reason } => {
                     printer_spinner.hide();
                     println!("\n[turn done: {reason:?}]");
@@ -1364,6 +1423,10 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
             .wrapping_add(u64::from(iteration));
         spinner.set_verb(config.ui.spinner_verb(verb_seed));
         spinner.show();
+
+        // Surface background tasks that finished between cycles (the turn
+        // loop also drains at the top of every step).
+        agent.drain_background_tasks(&tx).await;
 
         let turn_started = Instant::now();
         let turn_prompt = input.clone();
@@ -2651,6 +2714,98 @@ mod tests {
         assert!(
             !agent.history[0].content.contains("## Working todo list"),
             "no instruction without the tool"
+        );
+    }
+
+    #[tokio::test]
+    async fn background_task_finish_is_injected_into_the_next_step() {
+        use crate::tools::tasks::TaskStatus;
+
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                // Turn 1: start a background task, then stop.
+                vec![tool_call_chunk(
+                    "execute",
+                    json!({ "command": "echo task-payload", "run_in_background": true }),
+                )],
+                vec![final_chunk("started it")],
+                // Turn 2: plain reply (the notification precedes it).
+                vec![final_chunk("noted the finish")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        agent
+            .run_turn("run it in the background", tx)
+            .await
+            .expect("turn ok");
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(
+            feedback.contains("Background task #1 started: echo task-payload"),
+            "spawn returns immediately with the id: {feedback}"
+        );
+
+        // Wait for the echo to actually finish in the registry.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while agent.ctx.tasks.status(1) == Some(TaskStatus::Running) {
+            assert!(Instant::now() < deadline, "background task finished");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let (tx, mut rx) = mpsc::channel(64);
+        agent.run_turn("anything new?", tx).await.expect("turn ok");
+
+        // The next step's request carried the finished-task notification
+        // (with the output tail) ahead of the model call.
+        {
+            let requests = provider.requests.lock().unwrap();
+            let request = requests.last().expect("turn 2 request");
+            let note = request
+                .messages
+                .iter()
+                .find(|m| {
+                    m.role == Role::System && m.content.contains("background task #1 finished")
+                })
+                .expect("notification in history");
+            assert!(note.content.contains("(exit 0)"), "{}", note.content);
+            assert!(
+                note.content.contains("task-payload"),
+                "output tail included: {}",
+                note.content
+            );
+        }
+
+        // The surfaces saw a TaskFinished event.
+        let mut finished = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AgentEvent::TaskFinished {
+                id,
+                command,
+                status,
+            } = event
+            {
+                finished.push((id, command, status));
+            }
+        }
+        assert_eq!(
+            finished,
+            [(1, "echo task-payload".to_string(), TaskStatus::Done(0))]
+        );
+
+        // Drained exactly once: nothing left for later steps.
+        assert!(agent.ctx.tasks.drain_completed().is_empty());
+        assert_eq!(
+            agent
+                .history()
+                .iter()
+                .filter(|m| m.content.contains("background task #1 finished"))
+                .count(),
+            1,
+            "the notification appears exactly once in history"
         );
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -47,6 +47,33 @@ pub enum DoneReason {
     CircuitBreaker,
 }
 
+/// Verdict on a plan presented via the `exit_plan` tool (plan mode).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanVerdict {
+    /// True when the plan was approved and execution may proceed.
+    pub approved: bool,
+    /// Reviewer feedback on rejection (empty = a generic rejection).
+    pub feedback: String,
+}
+
+impl PlanVerdict {
+    /// Approve the plan: plan mode ends and the model executes it.
+    pub fn approve() -> Self {
+        Self {
+            approved: true,
+            feedback: String::new(),
+        }
+    }
+
+    /// Reject the plan with `feedback`; plan mode stays on.
+    pub fn reject(feedback: impl Into<String>) -> Self {
+        Self {
+            approved: false,
+            feedback: feedback.into(),
+        }
+    }
+}
+
 /// Events emitted by the agent loop. The TUI renders them; the headless
 /// runner logs them.
 #[derive(Debug)]
@@ -74,6 +101,16 @@ pub enum AgentEvent {
         command: String,
         /// What the hook did.
         outcome: crate::hooks::HookOutcome,
+    },
+    /// Plan mode: the model presented a plan via `exit_plan` and the turn is
+    /// paused awaiting a verdict. The consumer must send exactly one
+    /// [`PlanVerdict`] on `respond` (the TUI renders a review; headless and
+    /// gateway auto-approve). Dropping the sender counts as no verdict and
+    /// keeps plan mode on.
+    PlanReady {
+        /// The plan markdown (also persisted to `.wizard/plan.md`).
+        plan: String,
+        respond: tokio::sync::oneshot::Sender<PlanVerdict>,
     },
     /// The turn is over.
     Done { reason: DoneReason },
@@ -221,6 +258,12 @@ pub struct Agent {
     /// Warning from session resume (corrupt/unreadable file), emitted on
     /// the next turn so the UI can surface it.
     load_warning: Option<String>,
+    /// Plan-mode flag, shared with the dispatcher (read-only gate) and the
+    /// `exit_plan` tool (cleared on approval).
+    plan_mode: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the plan-mode instruction block is currently baked into the
+    /// system prompt; [`Agent::sync_plan_prompt`] refreshes on mismatch.
+    plan_prompt_on: bool,
 }
 
 /// Number of most-recent messages preserved verbatim when compacting history.
@@ -271,10 +314,23 @@ impl Agent {
             .filter(|message| message.role != Role::System)
             .collect::<Vec<_>>();
 
+        // Plan mode: one flag shared by the dispatcher (read-only gate) and
+        // the always-registered exit_plan tool (cleared on approval).
+        let plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut registry = registry;
+        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
+            &plan_mode,
+        ))));
+
         let mut agent = Self {
             client,
             model,
-            dispatcher: Dispatcher::new(registry, config.mode, Arc::clone(&hooks)),
+            dispatcher: Dispatcher::new(
+                registry,
+                config.mode,
+                Arc::clone(&hooks),
+                Arc::clone(&plan_mode),
+            ),
             hooks,
             mode: config.mode,
             config,
@@ -287,6 +343,8 @@ impl Agent {
             memory_index,
             deadline: None,
             load_warning,
+            plan_mode,
+            plan_prompt_on: false,
         };
         agent
             .history
@@ -356,11 +414,41 @@ impl Agent {
         self.hooks.session_end(self.mode, events).await;
     }
 
-    /// Swap the tool registry (after `/reload` or `/evolve`). Refreshes the
-    /// system prompt so the JSON tool protocol's tool list stays current.
-    pub fn set_registry(&mut self, registry: ToolRegistry) {
+    /// Swap the tool registry (after `/reload` or `/evolve`). Re-registers
+    /// the always-present `exit_plan` tool (sharing this agent's plan-mode
+    /// flag) and refreshes the system prompt so the JSON tool protocol's
+    /// tool list stays current.
+    pub fn set_registry(&mut self, mut registry: ToolRegistry) {
+        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
+            &self.plan_mode,
+        ))));
         self.dispatcher.set_registry(registry);
         self.refresh_system_prompt();
+    }
+
+    /// Whether plan mode is active.
+    pub fn plan_mode(&self) -> bool {
+        self.plan_mode.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Turn plan mode on or off (`/plan`, `--plan`, `plan_each_cycle`).
+    /// While on, the dispatcher blocks every non-read-only tool except
+    /// `exit_plan`, and the system prompt instructs the model to plan.
+    pub fn set_plan_mode(&mut self, on: bool) {
+        self.plan_mode
+            .store(on, std::sync::atomic::Ordering::SeqCst);
+        self.sync_plan_prompt();
+    }
+
+    /// Re-compose the system prompt when the plan-mode flag changed since it
+    /// was last baked in. The flag can flip mid-turn (exit_plan approval
+    /// clears it), so the turn loop calls this before every completion.
+    fn sync_plan_prompt(&mut self) {
+        let on = self.plan_mode();
+        if on != self.plan_prompt_on {
+            self.plan_prompt_on = on;
+            self.refresh_system_prompt();
+        }
     }
 
     /// Switch models mid-session (`/model`) without resetting conversation
@@ -393,6 +481,10 @@ impl Agent {
             prompt.push_str(&prompts::render_tool_protocol(
                 &self.dispatcher.registry().specs(),
             ));
+        }
+        if self.plan_mode() {
+            prompt.push_str("\n\n");
+            prompt.push_str(prompts::PLAN_MODE_PROMPT);
         }
         prompt
     }
@@ -491,6 +583,9 @@ impl Agent {
             {
                 return Ok(reason);
             }
+            // Plan mode can flip mid-turn (exit_plan approval): keep the
+            // system prompt's plan-mode block in step with the flag.
+            self.sync_plan_prompt();
 
             let (mut content, mut tool_calls) = self.stream_completion_with_retry(events).await?;
 
@@ -1015,6 +1110,13 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
         cli.max_hours
             .map(|hours| Instant::now() + Duration::from_secs_f64(hours * 3600.0)),
     );
+    // `--plan` / `plan_first = true`: the first turn starts in plan mode.
+    // The model investigates read-only, presents a plan via exit_plan, the
+    // printer below auto-approves it, and the same turn proceeds to execute
+    // — a natural two-phase turn with no human in the loop.
+    if config.plan_first {
+        agent.set_plan_mode(true);
+    }
 
     // Busy spinner ("Conjuring…") shown while the model thinks or a tool
     // runs, hidden while output streams. Shared with the printer task; a
@@ -1061,6 +1163,14 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                     outcome,
                 } => {
                     printer_spinner.println(&format!("~ hook {event}: {outcome} ({command})"));
+                }
+                AgentEvent::PlanReady { plan, respond } => {
+                    // Headless: print the plan and approve it, so the turn
+                    // moves from planning to execution on its own.
+                    printer_spinner
+                        .println(&format!("\n=== plan ===\n{plan}\n=== plan approved ==="));
+                    let _ = respond.send(PlanVerdict::approve());
+                    printer_spinner.show();
                 }
                 AgentEvent::Done { reason } => {
                     printer_spinner.hide();
@@ -1117,6 +1227,11 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
         }
         if config.continuous {
             spinner.println(&format!("\n=== cycle {iteration} ==="));
+            // `plan_each_cycle = true`: every cycle starts by planning again
+            // (the previous cycle's exit_plan approval cleared the flag).
+            if config.plan_each_cycle {
+                agent.set_plan_mode(true);
+            }
         } else if max_iterations > 1 {
             spinner.println(&format!("\n=== iteration {iteration}/{max_iterations} ==="));
         }
@@ -1805,6 +1920,287 @@ mod tests {
             "hook context appended: {}",
             prompt.content
         );
+    }
+
+    /// Run a turn while a reviewer task answers every [`AgentEvent::PlanReady`]
+    /// with `verdict`. Returns (done reason, plans that were presented).
+    async fn run_turn_with_reviewer(
+        agent: &mut Agent,
+        input: &str,
+        verdict: PlanVerdict,
+    ) -> (DoneReason, Vec<String>) {
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(64);
+        let reviewer = async move {
+            let mut plans = Vec::new();
+            while let Some(event) = rx.recv().await {
+                if let AgentEvent::PlanReady { plan, respond } = event {
+                    plans.push(plan);
+                    respond.send(verdict.clone()).expect("verdict delivered");
+                }
+            }
+            plans
+        };
+        let (reason, plans) = tokio::join!(agent.run_turn(input, tx), reviewer);
+        (reason.expect("turn ok"), plans)
+    }
+
+    /// Last tool-result message of request `index`, as fed to the model.
+    fn tool_feedback_of(provider: &ScriptedProvider, index: usize) -> String {
+        let requests = provider.requests.lock().unwrap();
+        requests[index]
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Tool)
+            .expect("tool feedback message")
+            .content
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn plan_mode_blocks_non_read_only_tools_but_the_turn_continues() {
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "a.txt", "content": "x" }),
+                )],
+                vec![final_chunk("understood, planning instead")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        agent.set_plan_mode(true);
+
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        assert!(!tmp.0.join("a.txt").exists(), "the write never happened");
+
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(
+            feedback.contains("blocked by plan mode"),
+            "block reason fed to the model: {feedback}"
+        );
+        assert!(feedback.contains("exit_plan"), "{feedback}");
+        assert!(agent.plan_mode(), "plan mode stays on");
+
+        // The system prompt carried the plan-mode instructions.
+        let requests = provider.requests.lock().unwrap();
+        assert!(requests[0].messages[0].content.contains("PLAN MODE"));
+    }
+
+    #[tokio::test]
+    async fn plan_mode_allows_read_only_tools() {
+        let tmp = TempDir::new();
+        std::fs::write(tmp.0.join("notes.txt"), "remember the milk\n").unwrap();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("read_file", json!({ "path": "notes.txt" }))],
+                vec![final_chunk("read it")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        agent.set_plan_mode(true);
+
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(
+            feedback.contains("remember the milk"),
+            "read-only tools run normally: {feedback}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_mode_blocks_are_exempt_from_the_identical_failure_breaker() {
+        // Sovereign's breaker trips after 3 identical failures; a planning
+        // model probing the same write repeatedly must not end the turn.
+        let tmp = TempDir::new();
+        let write = || {
+            vec![tool_call_chunk(
+                "write_file",
+                json!({ "path": "a", "content": "x" }),
+            )]
+        };
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                write(),
+                write(),
+                write(),
+                write(),
+                vec![final_chunk("fine, I will plan")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        agent.set_mode(Mode::Sovereign);
+        agent.set_plan_mode(true);
+
+        let (tx, _rx) = mpsc::channel(256);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed, "no circuit breaker");
+    }
+
+    #[tokio::test]
+    async fn exit_plan_approval_writes_the_plan_and_clears_plan_mode() {
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "exit_plan",
+                    json!({ "plan": "# Plan\n1. do x" }),
+                )],
+                vec![final_chunk("executing the plan")],
+            ],
+            Vec::new(),
+            ToolRegistry::new(),
+        );
+        agent.set_plan_mode(true);
+
+        let (reason, plans) =
+            run_turn_with_reviewer(&mut agent, "go", PlanVerdict::approve()).await;
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(plans, ["# Plan\n1. do x"]);
+        assert!(!agent.plan_mode(), "approval clears plan mode");
+
+        let saved =
+            std::fs::read_to_string(tmp.0.join(".wizard").join("plan.md")).expect("plan persisted");
+        assert_eq!(saved, "# Plan\n1. do x");
+
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(
+            feedback.contains("Plan approved"),
+            "the model is told to execute: {feedback}"
+        );
+        // After approval, the system prompt no longer carries the plan block.
+        let requests = provider.requests.lock().unwrap();
+        assert!(requests[0].messages[0].content.contains("PLAN MODE"));
+        assert!(!requests[1].messages[0].content.contains("PLAN MODE"));
+    }
+
+    #[tokio::test]
+    async fn exit_plan_rejection_keeps_plan_mode_and_feeds_back_the_feedback() {
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("exit_plan", json!({ "plan": "# v1" }))],
+                vec![final_chunk("revising the plan")],
+            ],
+            Vec::new(),
+            ToolRegistry::new(),
+        );
+        agent.set_plan_mode(true);
+
+        let (reason, plans) =
+            run_turn_with_reviewer(&mut agent, "go", PlanVerdict::reject("add tests first")).await;
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(plans.len(), 1);
+        assert!(agent.plan_mode(), "rejection keeps plan mode on");
+
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(feedback.starts_with("Error:"), "{feedback}");
+        assert!(feedback.contains("add tests first"), "{feedback}");
+        assert!(
+            feedback.contains("call exit_plan again"),
+            "the model is told to retry: {feedback}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exit_plan_outside_plan_mode_is_an_error() {
+        let tmp = TempDir::new();
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("exit_plan", json!({ "plan": "# p" }))],
+                vec![final_chunk("ok")],
+            ],
+            Vec::new(),
+            ToolRegistry::new(),
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        let reason = agent.run_turn("go", tx).await.expect("turn ok");
+        assert_eq!(reason, DoneReason::Completed);
+        let feedback = tool_feedback_of(&provider, 1);
+        assert!(feedback.contains("not in plan mode"), "{feedback}");
+        assert!(
+            !tmp.0.join(".wizard").join("plan.md").exists(),
+            "no plan file written"
+        );
+    }
+
+    #[tokio::test]
+    async fn headless_two_phase_turn_blocks_then_plans_then_executes() {
+        // The --plan shape: write blocked while planning → exit_plan
+        // auto-approved → the same write succeeds in the same turn.
+        let tmp = TempDir::new();
+        let write_args = json!({ "path": "result.txt", "content": "done" });
+        let (mut agent, provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk("write_file", write_args.clone())],
+                vec![tool_call_chunk(
+                    "exit_plan",
+                    json!({ "plan": "# write result.txt" }),
+                )],
+                vec![tool_call_chunk("write_file", write_args)],
+                vec![final_chunk("all done")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+        agent.set_plan_mode(true);
+
+        let (reason, plans) =
+            run_turn_with_reviewer(&mut agent, "go", PlanVerdict::approve()).await;
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(plans, ["# write result.txt"]);
+        assert!(!agent.plan_mode());
+
+        // The phases happened in order: blocked, approved, executed.
+        assert!(
+            tool_feedback_of(&provider, 1).contains("blocked by plan mode"),
+            "phase 1: the write is blocked"
+        );
+        assert!(
+            tool_feedback_of(&provider, 2).contains("Plan approved"),
+            "phase 2: the plan is approved"
+        );
+        let executed = tool_feedback_of(&provider, 3);
+        assert!(
+            !executed.contains("blocked") && !executed.starts_with("Error:"),
+            "phase 3: the write succeeds: {executed}"
+        );
+        let written = std::fs::read_to_string(tmp.0.join("result.txt")).expect("file written");
+        assert_eq!(written, "done");
+    }
+
+    #[test]
+    fn exit_plan_is_always_registered() {
+        let tmp = TempDir::new();
+        let (mut agent, _provider) =
+            test_agent_in(&tmp, Vec::new(), Vec::new(), ToolRegistry::new());
+        let has_exit_plan = |agent: &Agent| {
+            agent
+                .dispatcher
+                .registry()
+                .get(crate::tools::plan::EXIT_PLAN_TOOL_NAME)
+                .is_some()
+        };
+        assert!(has_exit_plan(&agent), "registered at construction");
+        // A registry swap (/reload, /evolve) re-registers it.
+        agent.set_registry(ToolRegistry::new());
+        assert!(has_exit_plan(&agent), "re-registered after set_registry");
     }
 
     #[tokio::test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -289,6 +289,22 @@ pub struct Agent {
     /// Where per-turn usage records are appended
     /// (`~/.wizard/usage.jsonl`); `None` disables the log.
     usage_log: Option<PathBuf>,
+    /// Per-file checkpoint store (`.wizard/checkpoints/` in the project).
+    /// Shared with the tool context so the dispatcher and subagents snapshot
+    /// `Edit`-class targets into it; `/rewind` and perpetual rollback
+    /// restore from it.
+    checkpoints: Arc<crate::checkpoint::CheckpointStore>,
+}
+
+/// One row of the `/rewind` picker: a turn, the prompt that started it, and
+/// the files its tool calls snapshotted.
+#[derive(Debug, Clone)]
+pub struct RewindCandidate {
+    pub turn: u64,
+    /// First line of the turn's user prompt (empty when unknown).
+    pub prompt: String,
+    /// Files the turn snapshotted before editing.
+    pub files: Vec<PathBuf>,
 }
 
 /// Number of most-recent messages preserved verbatim when compacting history.
@@ -347,6 +363,21 @@ impl Agent {
         // the always-registered exit_plan tool (cleared on approval).
         let plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let web = config.web.clone();
+
+        // Checkpoints: per-file snapshots of everything this agent edits.
+        // Old turns are garbage-collected once per session, here.
+        let checkpoints = Arc::new(crate::checkpoint::CheckpointStore::open(
+            &project_root,
+            config.checkpoints.keep_turns,
+        ));
+        match checkpoints.gc() {
+            Ok(dropped) if dropped > 0 => {
+                tracing::debug!("checkpoint gc dropped {dropped} old turn(s)");
+            }
+            Ok(_) => {}
+            Err(err) => tracing::warn!("checkpoint gc failed: {err:#}"),
+        }
+
         let mut registry = registry;
         registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
             &plan_mode,
@@ -366,7 +397,9 @@ impl Agent {
             config,
             history: Vec::new(),
             session,
-            ctx: ToolContext::new(project_root).with_web(web),
+            ctx: ToolContext::new(project_root)
+                .with_web(web)
+                .with_checkpoints(Arc::clone(&checkpoints)),
             native_tools,
             skills,
             agents_md,
@@ -377,6 +410,7 @@ impl Agent {
             plan_prompt_on: false,
             usage: crate::usage::UsageTracker::new(),
             usage_log: crate::usage::default_log_path(),
+            checkpoints,
         };
         agent
             .history
@@ -407,6 +441,73 @@ impl Agent {
     /// Session this agent persists to.
     pub fn session(&self) -> &Session {
         &self.session
+    }
+
+    /// The per-file checkpoint store (snapshots powering `/rewind` and
+    /// perpetual rollback).
+    pub fn checkpoints(&self) -> &Arc<crate::checkpoint::CheckpointStore> {
+        &self.checkpoints
+    }
+
+    /// Recent turns `/rewind` can return to, newest first: this session's
+    /// turn markers (prompt snippets) joined with the checkpoint store's
+    /// per-turn file lists. Turns from before this session are listed only
+    /// when the session has no markers at all (old-format resume), since
+    /// only marked turns can also truncate the conversation.
+    pub fn rewind_candidates(&self, limit: usize) -> Vec<RewindCandidate> {
+        let markers = self.session.turn_markers().unwrap_or_default();
+        let first_marked = markers.first().map(|marker| marker.turn);
+        let mut by_turn: std::collections::BTreeMap<u64, RewindCandidate> = markers
+            .into_iter()
+            .map(|marker| {
+                (
+                    marker.turn,
+                    RewindCandidate {
+                        turn: marker.turn,
+                        prompt: marker.prompt,
+                        files: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+        for turn_files in self.checkpoints.recent_turns(usize::MAX) {
+            if first_marked.is_some_and(|first| turn_files.turn < first) {
+                continue;
+            }
+            by_turn
+                .entry(turn_files.turn)
+                .or_insert_with(|| RewindCandidate {
+                    turn: turn_files.turn,
+                    prompt: String::new(),
+                    files: Vec::new(),
+                })
+                .files = turn_files.files;
+        }
+        by_turn.into_values().rev().take(limit).collect()
+    }
+
+    /// `/rewind`: restore every file snapshot from `turn` onward, drop the
+    /// rewound turns from the session file, and reload the in-memory
+    /// conversation to match. Returns the restored file paths.
+    pub fn rewind_to(&mut self, turn: u64) -> Result<Vec<PathBuf>> {
+        let restored = self
+            .checkpoints
+            .restore_turns_from(turn)
+            .context("restoring checkpoints")?;
+        self.session
+            .truncate_after(turn)
+            .context("truncating session history")?;
+        let prior: Vec<ChatMessage> = self
+            .session
+            .load_messages()
+            .context("reloading session history")?
+            .into_iter()
+            .filter(|message| message.role != Role::System)
+            .collect();
+        self.history.truncate(1);
+        self.history.extend(prior);
+        self.dispatcher.reset_failures();
+        Ok(restored)
     }
 
     /// Set (or clear) the wall-clock deadline for this run (`--max-hours`).
@@ -647,6 +748,13 @@ impl Agent {
             }
             PromptSubmit::Continue(None) => input.to_string(),
         };
+        // Turn boundary: a fresh checkpoint turn for the dispatcher's
+        // snapshots, anchored in the session file so /rewind can truncate
+        // here. Best-effort — a marker failure never blocks the turn.
+        let turn = self.checkpoints.begin_turn();
+        if let Err(err) = self.session.append_marker(turn, &input) {
+            tracing::warn!("could not append turn marker: {err}");
+        }
         self.push(ChatMessage::user(input));
         self.compact_if_needed(events).await;
         let max_steps = self.config.max_steps.max(1);
@@ -1230,6 +1338,44 @@ pub async fn build_headless_agent(
     )
 }
 
+/// `rollback_failed_cycles`: restore every checkpoint from the failed
+/// cycle's first turn onward and note the rollback in the persisted mission.
+/// Best-effort — failures are logged and the run proceeds to its normal end.
+fn rollback_failed_cycle(
+    config: &Config,
+    agent: &Agent,
+    mission: Option<&mut mission::Mission>,
+    project_root: &Path,
+    first_turn: u64,
+    why: &str,
+    spinner: &crate::progress::TurnSpinner,
+) {
+    if !config.rollback_failed_cycles {
+        return;
+    }
+    match agent.checkpoints().restore_turns_from(first_turn) {
+        Ok(restored) => {
+            if restored.is_empty() {
+                return;
+            }
+            spinner.println(&format!(
+                "[rolled back {} file(s) after {why}]",
+                restored.len()
+            ));
+            if let Some(mission) = mission {
+                mission.note(format!(
+                    "rolled back {} file(s) after {why} (cycle starting at turn {first_turn})",
+                    restored.len()
+                ));
+                if let Err(err) = mission.save(project_root) {
+                    tracing::warn!("could not record rollback in mission.toml: {err:#}");
+                }
+            }
+        }
+        Err(err) => tracing::warn!("cycle rollback failed: {err:#}"),
+    }
+}
+
 /// Sovereign-mode headless runner: builds an [`Agent`] and drives it in an
 /// outer loop. The goal comes from `cli.prompt`, or (on a self-evolve
 /// re-exec) from the persisted [`mission::Mission`]. With `--continuous` it
@@ -1430,6 +1576,9 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
 
         let turn_started = Instant::now();
         let turn_prompt = input.clone();
+        // First checkpoint turn of this cycle, for rollback_failed_cycles
+        // (run_turn assigns the next id via begin_turn).
+        let cycle_first_turn = agent.checkpoints().current_turn() + 1;
         match agent.run_turn(&input, tx.clone()).await {
             Ok(reason) => {
                 final_reason = reason;
@@ -1479,12 +1628,33 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<()> {
                             break;
                         }
                     }
-                    DoneReason::Stopped | DoneReason::TimeLimit | DoneReason::CircuitBreaker => {
+                    DoneReason::Stopped | DoneReason::TimeLimit => {
+                        break;
+                    }
+                    DoneReason::CircuitBreaker => {
+                        rollback_failed_cycle(
+                            &config,
+                            &agent,
+                            mission_state.as_mut(),
+                            &project_root,
+                            cycle_first_turn,
+                            "circuit breaker",
+                            &spinner,
+                        );
                         break;
                     }
                 }
             }
             Err(err) => {
+                rollback_failed_cycle(
+                    &config,
+                    &agent,
+                    mission_state.as_mut(),
+                    &project_root,
+                    cycle_first_turn,
+                    "hard error",
+                    &spinner,
+                );
                 run_error = Some(err);
                 break;
             }
@@ -2428,6 +2598,195 @@ mod tests {
         // A registry swap (/reload, /evolve) re-registers it.
         agent.set_registry(ToolRegistry::new());
         assert!(has_exit_plan(&agent), "re-registered after set_registry");
+    }
+
+    #[tokio::test]
+    async fn rewind_restores_an_overwritten_file_and_truncates_history() {
+        let tmp = TempDir::new();
+        let file = tmp.0.join("notes.txt");
+        std::fs::write(&file, "before").unwrap();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "notes.txt", "content": "after" }),
+                )],
+                vec![final_chunk("overwritten")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let (tx, mut rx) = mpsc::channel(256);
+        let reason = agent.run_turn("overwrite notes.txt", tx).await.unwrap();
+        drain_events(&mut rx);
+        assert_eq!(reason, DoneReason::Completed);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "after");
+        assert!(agent.history().len() > 1);
+
+        let candidates = agent.rewind_candidates(10);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].prompt, "overwrite notes.txt");
+        assert_eq!(candidates[0].files, vec![file.clone()]);
+
+        let restored = agent.rewind_to(candidates[0].turn).unwrap();
+        assert_eq!(restored, vec![file.clone()]);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "before");
+        assert_eq!(
+            agent.history().len(),
+            1,
+            "only the system prompt survives a full rewind"
+        );
+        assert!(
+            agent.session().load_messages().unwrap().is_empty(),
+            "the session file was truncated"
+        );
+    }
+
+    #[tokio::test]
+    async fn rewind_deletes_a_file_the_turn_created() {
+        let tmp = TempDir::new();
+        let file = tmp.0.join("created.txt");
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "created.txt", "content": "fresh" }),
+                )],
+                vec![final_chunk("created")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let (tx, mut rx) = mpsc::channel(256);
+        agent.run_turn("create created.txt", tx).await.unwrap();
+        drain_events(&mut rx);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "fresh");
+
+        let candidates = agent.rewind_candidates(10);
+        assert_eq!(candidates.len(), 1);
+        agent.rewind_to(candidates[0].turn).unwrap();
+        assert!(!file.exists(), "rewind deletes a file that did not exist");
+    }
+
+    #[tokio::test]
+    async fn rewind_to_a_later_turn_keeps_earlier_turns() {
+        let tmp = TempDir::new();
+        let file = tmp.0.join("notes.txt");
+        std::fs::write(&file, "v0").unwrap();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "notes.txt", "content": "v1" }),
+                )],
+                vec![final_chunk("first done")],
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "notes.txt", "content": "v2" }),
+                )],
+                vec![final_chunk("second done")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let (tx, mut rx) = mpsc::channel(256);
+        agent.run_turn("write v1", tx.clone()).await.unwrap();
+        agent.run_turn("write v2", tx).await.unwrap();
+        drain_events(&mut rx);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "v2");
+
+        let candidates = agent.rewind_candidates(10);
+        assert_eq!(candidates.len(), 2, "newest first");
+        assert!(candidates[0].turn > candidates[1].turn);
+
+        agent.rewind_to(candidates[0].turn).unwrap();
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "v1");
+        let messages = agent.session().load_messages().unwrap();
+        assert_eq!(
+            messages.first().map(|m| m.content.as_str()),
+            Some("write v1"),
+            "the first turn's history survives"
+        );
+        assert!(
+            messages.iter().all(|m| m.content != "write v2"),
+            "the second turn's history is gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_failed_cycle_restores_files_and_notes_the_mission() {
+        let tmp = TempDir::new();
+        let file = tmp.0.join("data.txt");
+        std::fs::write(&file, "good").unwrap();
+        let (mut agent, _provider) = test_agent_in(
+            &tmp,
+            vec![
+                vec![tool_call_chunk(
+                    "write_file",
+                    json!({ "path": "data.txt", "content": "broken" }),
+                )],
+                vec![final_chunk("changed it")],
+            ],
+            Vec::new(),
+            ToolRegistry::with_native_tools(),
+        );
+
+        let cycle_first_turn = agent.checkpoints().current_turn() + 1;
+        let (tx, mut rx) = mpsc::channel(256);
+        agent.run_turn("break the data", tx).await.unwrap();
+        drain_events(&mut rx);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "broken");
+
+        let spinner = crate::progress::TurnSpinner::new();
+        let mut mission = mission::Mission::new("keep the data good");
+
+        // Disabled: a no-op.
+        let config = Config::default();
+        rollback_failed_cycle(
+            &config,
+            &agent,
+            Some(&mut mission),
+            &tmp.0,
+            cycle_first_turn,
+            "circuit breaker",
+            &spinner,
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "broken");
+        assert!(mission.notes.is_empty());
+
+        // Enabled: the cycle's edits are restored and the mission notes it.
+        let config = Config {
+            rollback_failed_cycles: true,
+            ..Config::default()
+        };
+        rollback_failed_cycle(
+            &config,
+            &agent,
+            Some(&mut mission),
+            &tmp.0,
+            cycle_first_turn,
+            "circuit breaker",
+            &spinner,
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "good");
+        assert!(
+            mission
+                .notes
+                .last()
+                .is_some_and(|note| note.contains("rolled back 1 file(s)")
+                    && note.contains("circuit breaker")),
+            "rollback noted in the mission: {:?}",
+            mission.notes
+        );
+        // The note was persisted to mission.toml.
+        let loaded = mission::Mission::load(&tmp.0).unwrap().expect("saved");
+        assert_eq!(loaded.notes, mission.notes);
     }
 
     #[tokio::test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -338,6 +338,7 @@ impl Agent {
         // Plan mode: one flag shared by the dispatcher (read-only gate) and
         // the always-registered exit_plan tool (cleared on approval).
         let plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let web = config.web.clone();
         let mut registry = registry;
         registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
             &plan_mode,
@@ -357,7 +358,7 @@ impl Agent {
             config,
             history: Vec::new(),
             session,
-            ctx: ToolContext::new(project_root),
+            ctx: ToolContext::new(project_root).with_web(web),
             native_tools,
             skills,
             agents_md,

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -38,6 +38,20 @@ repeat a failing action verbatim.
 - Keep edits minimal and consistent with the existing code style.
 - Commit when a coherent unit of work passes tests, with a clear message.";
 
+/// Appended to the system prompt while plan mode is active (the agent
+/// re-composes the prompt whenever the flag flips, so this block disappears
+/// once a plan is approved).
+pub const PLAN_MODE_PROMPT: &str = "\
+## Plan mode (active)
+
+You are in PLAN MODE. Investigate using read-only tools only (reading, \
+listing, and searching files; inspecting git state); every other tool is \
+blocked until your plan is approved. Do not attempt to make changes yet. \
+Once you understand the task, present your implementation plan by calling \
+the `exit_plan` tool with the complete plan as markdown. If the plan is \
+approved, plan mode ends and you carry it out; if it is rejected, refine \
+the plan using the feedback you receive and call `exit_plan` again.";
+
 /// Memory guidance injected when the project has saved memories; the index
 /// (MEMORY.md) follows it.
 const MEMORY_PROMPT_WITH_INDEX: &str = "\

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -52,6 +52,17 @@ the `exit_plan` tool with the complete plan as markdown. If the plan is \
 approved, plan mode ends and you carry it out; if it is rejected, refine \
 the plan using the feedback you receive and call `exit_plan` again.";
 
+/// Appended to the system prompt when the `todo` tool is registered: keep a
+/// working todo list for multi-step tasks so every surface can mirror
+/// progress.
+pub const TODO_PROMPT: &str = "\
+## Working todo list
+
+For multi-step work, maintain a todo list with the `todo` tool: write the \
+full list up front (action \"write\" replaces the entire list), keep exactly \
+one item in_progress while you work on it, and mark items completed as soon \
+as they are done. Skip the list for trivial single-step tasks.";
+
 /// Memory guidance injected when the project has saved memories; the index
 /// (MEMORY.md) follows it.
 const MEMORY_PROMPT_WITH_INDEX: &str = "\
@@ -74,7 +85,8 @@ already records.";
 
 /// Compose the full system prompt for `mode`: personality prompt, then the
 /// bundled `WIZARD.md` charter, then a rendered skills section, then the
-/// project's `AGENTS.md` contents (if present at the project root), then
+/// project's instruction hierarchy (`agents_md`, assembled by
+/// [`crate::instructions`] from WIZARD.md/AGENTS.md/CLAUDE.md files), then
 /// the persistent memory section (`memory_index` is the project's
 /// MEMORY.md, when any memories are saved).
 pub fn build_system_prompt(
@@ -102,7 +114,7 @@ pub fn build_system_prompt(
     }
 
     if let Some(agents_md) = agents_md {
-        prompt.push_str("\n\n## Project instructions (AGENTS.md)\n\n");
+        prompt.push_str("\n\n## Project instructions\n\n");
         prompt.push_str(agents_md);
     }
 
@@ -181,8 +193,8 @@ mod tests {
             .find("## Wizard charter (WIZARD.md)")
             .expect("charter present");
         let agents_pos = prompt
-            .find("## Project instructions (AGENTS.md)")
-            .expect("AGENTS.md section present");
+            .find("## Project instructions")
+            .expect("project instructions section present");
         assert!(
             charter_pos < agents_pos,
             "charter must appear before project instructions"

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -1,5 +1,8 @@
 //! JSONL session persistence under `~/.wizard/sessions/<timestamp>.jsonl`.
 //! One [`SessionRecord`] per line, appended after each message lands.
+//! Turn boundaries are marked by interleaved [`TurnMarker`] lines so
+//! `/rewind` can truncate history at a turn; files without markers (older
+//! sessions) still load.
 
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
@@ -17,6 +20,31 @@ pub struct SessionRecord {
     pub timestamp: DateTime<Utc>,
     pub message: ChatMessage,
 }
+
+/// A turn-boundary line, written just before the turn's user message. Anchors
+/// [`Session::truncate_after`] and labels the `/rewind` picker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnMarker {
+    pub timestamp: DateTime<Utc>,
+    /// Checkpoint turn id (monotonic per project — see
+    /// [`crate::checkpoint::CheckpointStore::begin_turn`]).
+    pub turn: u64,
+    /// First line of the user prompt that started the turn (truncated).
+    #[serde(default)]
+    pub prompt: String,
+}
+
+/// Either kind of session line. Untagged: a marker has a `turn` field, a
+/// message record has `message` — old files (messages only) parse unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SessionLine {
+    Marker(TurnMarker),
+    Message(SessionRecord),
+}
+
+/// Cap on the prompt snippet stored in a [`TurnMarker`].
+const MARKER_PROMPT_CHARS: usize = 120;
 
 /// Handle to one session file. Append-only; cheap to clone the path out of.
 #[derive(Debug, Clone)]
@@ -82,7 +110,33 @@ impl Session {
         Ok(())
     }
 
-    /// Load all messages back (for `--resume`). Corrupt lines are skipped.
+    /// Append a turn-boundary marker. `prompt` is reduced to its first line,
+    /// capped at [`MARKER_PROMPT_CHARS`] characters.
+    pub fn append_marker(&self, turn: u64, prompt: &str) -> Result<()> {
+        let snippet: String = prompt
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .chars()
+            .take(MARKER_PROMPT_CHARS)
+            .collect();
+        let marker = TurnMarker {
+            timestamp: Utc::now(),
+            turn,
+            prompt: snippet,
+        };
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("opening {}", self.path.display()))?;
+        let line = serde_json::to_string(&marker).context("serializing turn marker")?;
+        writeln!(file, "{line}").with_context(|| format!("writing {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// Load all messages back (for `--resume`). Turn markers and corrupt
+    /// lines are skipped.
     pub fn load_messages(&self) -> Result<Vec<ChatMessage>> {
         let file = std::fs::File::open(&self.path)
             .with_context(|| format!("opening {}", self.path.display()))?;
@@ -92,12 +146,57 @@ impl Session {
             if line.trim().is_empty() {
                 continue;
             }
-            match serde_json::from_str::<SessionRecord>(&line) {
-                Ok(record) => messages.push(record.message),
+            match serde_json::from_str::<SessionLine>(&line) {
+                Ok(SessionLine::Message(record)) => messages.push(record.message),
+                Ok(SessionLine::Marker(_)) => {}
                 Err(err) => tracing::warn!("skipping corrupt session line: {err}"),
             }
         }
         Ok(messages)
+    }
+
+    /// All turn markers in this session, in file order. Old-format files
+    /// (no markers) yield an empty vec.
+    pub fn turn_markers(&self) -> Result<Vec<TurnMarker>> {
+        let file = std::fs::File::open(&self.path)
+            .with_context(|| format!("opening {}", self.path.display()))?;
+        let mut markers = Vec::new();
+        for line in BufReader::new(file).lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(SessionLine::Marker(marker)) = serde_json::from_str::<SessionLine>(&line) {
+                markers.push(marker);
+            }
+        }
+        Ok(markers)
+    }
+
+    /// Drop turn `turn_id` and everything after it: the file is cut at the
+    /// first marker with `turn >= turn_id` (`>=` so a rewind survives gaps
+    /// in the marker sequence). Old-format files without markers are left
+    /// unchanged. Returns true when the file was truncated.
+    pub fn truncate_after(&self, turn_id: u64) -> Result<bool> {
+        let raw = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("reading {}", self.path.display()))?;
+        let lines: Vec<&str> = raw.lines().collect();
+        let cut = lines.iter().position(|line| {
+            matches!(
+                serde_json::from_str::<SessionLine>(line),
+                Ok(SessionLine::Marker(marker)) if marker.turn >= turn_id
+            )
+        });
+        let Some(cut) = cut else {
+            return Ok(false);
+        };
+        let mut kept = lines[..cut].join("\n");
+        if !kept.is_empty() {
+            kept.push('\n');
+        }
+        std::fs::write(&self.path, kept)
+            .with_context(|| format!("rewriting {}", self.path.display()))?;
+        Ok(true)
     }
 }
 
@@ -237,6 +336,85 @@ mod tests {
             .unwrap()
             .expect("a session exists");
         assert_eq!(latest.id, "2026-06-09T09-30-00");
+    }
+
+    #[test]
+    fn turn_markers_are_skipped_by_load_and_listed_separately() {
+        let tmp = TempDir::new();
+        let session = Session::create(&tmp.0).unwrap();
+        session
+            .append_marker(1, "first prompt\nsecond line ignored")
+            .unwrap();
+        session.append(&ChatMessage::user("first prompt")).unwrap();
+        session.append(&ChatMessage::assistant("reply")).unwrap();
+        session.append_marker(2, "second prompt").unwrap();
+        session.append(&ChatMessage::user("second prompt")).unwrap();
+
+        let messages = session.load_messages().unwrap();
+        assert_eq!(messages.len(), 3, "markers are not messages");
+        let markers = session.turn_markers().unwrap();
+        assert_eq!(markers.len(), 2);
+        assert_eq!(markers[0].turn, 1);
+        assert_eq!(markers[0].prompt, "first prompt");
+        assert_eq!(markers[1].turn, 2);
+    }
+
+    #[test]
+    fn truncate_after_drops_the_turn_and_its_tail() {
+        let tmp = TempDir::new();
+        let session = Session::create(&tmp.0).unwrap();
+        session.append_marker(1, "one").unwrap();
+        session.append(&ChatMessage::user("one")).unwrap();
+        session.append(&ChatMessage::assistant("ack one")).unwrap();
+        session.append_marker(2, "two").unwrap();
+        session.append(&ChatMessage::user("two")).unwrap();
+        session.append(&ChatMessage::assistant("ack two")).unwrap();
+
+        assert!(session.truncate_after(2).unwrap());
+        let messages = session.load_messages().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content, "one");
+        assert_eq!(messages[1].content, "ack one");
+        assert_eq!(session.turn_markers().unwrap().len(), 1);
+
+        // Appending continues to work after the rewrite.
+        session.append_marker(3, "three").unwrap();
+        session.append(&ChatMessage::user("three")).unwrap();
+        assert_eq!(session.load_messages().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn truncate_after_matches_the_next_marker_across_gaps() {
+        let tmp = TempDir::new();
+        let session = Session::create(&tmp.0).unwrap();
+        session.append_marker(1, "one").unwrap();
+        session.append(&ChatMessage::user("one")).unwrap();
+        session.append_marker(5, "five").unwrap();
+        session.append(&ChatMessage::user("five")).unwrap();
+
+        // Turn 3 has no marker: the cut lands on the next marker (5).
+        assert!(session.truncate_after(3).unwrap());
+        let messages = session.load_messages().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "one");
+    }
+
+    #[test]
+    fn old_format_files_without_markers_load_and_survive_truncate() {
+        let tmp = TempDir::new();
+        let session = Session::create(&tmp.0).unwrap();
+        // Old format: message records only.
+        session.append(&ChatMessage::user("hello")).unwrap();
+        session.append(&ChatMessage::assistant("hi")).unwrap();
+
+        assert!(session.turn_markers().unwrap().is_empty());
+        assert!(
+            !session.truncate_after(1).unwrap(),
+            "no marker to anchor on: the file is left unchanged"
+        );
+        let messages = session.load_messages().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content, "hello");
     }
 
     #[test]

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -141,8 +141,7 @@ pub fn scoped_registry(parent: &ToolRegistry, scope: Option<&[String]>) -> ToolR
 }
 
 /// Run `task` in an isolated context defined by `config`: fresh history,
-/// scoped registry, own step budget. Auto-approves tools (the parent already
-/// approved the spawn).
+/// scoped registry, own step budget.
 pub async fn spawn(
     config: &SubagentConfig,
     task: &str,
@@ -325,10 +324,6 @@ impl Tool for SpawnSubagentTool {
             },
             "required": ["subagent", "task"]
         })
-    }
-
-    fn requires_approval(&self) -> bool {
-        true
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -265,6 +265,10 @@ pub async fn spawn(
                     if let Some(updated) = updated {
                         args = updated;
                     }
+                    // Same checkpoint seam as the parent's dispatcher: the
+                    // subagent's edits are snapshotted under the parent's
+                    // current turn (the context carries the parent's store).
+                    crate::checkpoint::snapshot_edit_target(&scoped, &name, &args, &ctx);
                     let mut output = match scoped.execute(&name, args.clone(), &ctx).await {
                         Ok(output) => output,
                         Err(err) => ToolOutput::error(err.to_string()),

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -176,6 +176,15 @@ pub async fn spawn(
         ChatMessage::user(task.to_string()),
     ];
 
+    // Subagents share the parent's cwd and task registry but get their own
+    // todo list (their working notes must not clobber the parent's) and no
+    // event channel — their activity surfaces as one tool result.
+    let ctx = ToolContext {
+        todos: Arc::new(std::sync::Mutex::new(crate::tools::todo::TodoList::new())),
+        events: None,
+        ..ctx.clone()
+    };
+
     let mut steps_used = 0;
     let mut completed = false;
     let mut last_text = String::new();
@@ -256,7 +265,7 @@ pub async fn spawn(
                     if let Some(updated) = updated {
                         args = updated;
                     }
-                    let mut output = match scoped.execute(&name, args.clone(), ctx).await {
+                    let mut output = match scoped.execute(&name, args.clone(), &ctx).await {
                         Ok(output) => output,
                         Err(err) => ToolOutput::error(err.to_string()),
                     };

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::config::{Config, Mode};
+use crate::hooks::{HookEngine, PreToolUse};
 use crate::llm::provider::LlmProvider;
 use crate::llm::{ChatMessage, ChatOptions, ChatRequest, Role};
 use crate::tools::{Tool, ToolContext, ToolError, ToolOutput, registry::ToolRegistry};
@@ -141,12 +142,15 @@ pub fn scoped_registry(parent: &ToolRegistry, scope: Option<&[String]>) -> ToolR
 }
 
 /// Run `task` in an isolated context defined by `config`: fresh history,
-/// scoped registry, own step budget.
+/// scoped registry, own step budget. The parent's lifecycle `hooks` apply to
+/// the subagent's tool calls too (their activity is not surfaced as events —
+/// the subagent reports back as one tool result).
 pub async fn spawn(
     config: &SubagentConfig,
     task: &str,
     client: &Arc<dyn LlmProvider>,
     registry: &ToolRegistry,
+    hooks: &HookEngine,
     ctx: &ToolContext,
 ) -> Result<SubagentResult> {
     let model = Config::load()
@@ -238,10 +242,32 @@ pub async fn spawn(
 
         for call in tool_calls {
             let name = call.function.name.clone();
-            let args = normalize_args(&call.function.arguments);
-            let output = match scoped.execute(&name, args, ctx).await {
-                Ok(output) => output,
-                Err(err) => ToolOutput::error(err.to_string()),
+            let mut args = normalize_args(&call.function.arguments);
+            // Same hook pipeline as the parent's dispatcher: pre-hooks may
+            // rewrite the arguments or veto, post-hooks may append context.
+            let output = match hooks
+                .pre_tool_use(&name, &args, Mode::Sovereign, None)
+                .await
+            {
+                PreToolUse::Block(reason) => {
+                    ToolOutput::error(format!("blocked by pre_tool_use hook: {reason}"))
+                }
+                PreToolUse::Continue(updated) => {
+                    if let Some(updated) = updated {
+                        args = updated;
+                    }
+                    let mut output = match scoped.execute(&name, args.clone(), ctx).await {
+                        Ok(output) => output,
+                        Err(err) => ToolOutput::error(err.to_string()),
+                    };
+                    if let Some(extra) = hooks
+                        .post_tool_use(&name, &args, Mode::Sovereign, None)
+                        .await
+                    {
+                        crate::hooks::append_context(&mut output.content, &extra);
+                    }
+                    output
+                }
             };
             let body = if output.is_error {
                 format!("Error: {}", output.content)
@@ -277,6 +303,8 @@ pub struct SpawnSubagentTool {
     /// Parent tool set subagents scope down from. Built without the spawn
     /// tool itself, so subagents cannot recurse.
     registry: Arc<ToolRegistry>,
+    /// The parent's lifecycle hooks, applied to subagent tool calls too.
+    hooks: Arc<HookEngine>,
     /// Tool description, including the roster of available subagents.
     description: String,
 }
@@ -286,6 +314,7 @@ impl SpawnSubagentTool {
         configs: Vec<SubagentConfig>,
         client: Arc<dyn LlmProvider>,
         registry: Arc<ToolRegistry>,
+        hooks: Arc<HookEngine>,
     ) -> Self {
         let roster = configs
             .iter()
@@ -300,6 +329,7 @@ impl SpawnSubagentTool {
             configs,
             client,
             registry,
+            hooks,
             description,
         }
     }
@@ -354,12 +384,19 @@ impl Tool for SpawnSubagentTool {
                 ),
             })?;
 
-        let result = spawn(config, &args.task, &self.client, &self.registry, ctx)
-            .await
-            .map_err(|err| ToolError::Execution {
-                tool: "spawn_subagent".to_string(),
-                source: err,
-            })?;
+        let result = spawn(
+            config,
+            &args.task,
+            &self.client,
+            &self.registry,
+            &self.hooks,
+            ctx,
+        )
+        .await
+        .map_err(|err| ToolError::Execution {
+            tool: "spawn_subagent".to_string(),
+            source: err,
+        })?;
 
         let summary = format!(
             "Subagent '{}' {} after {} step(s).\n\n{}",

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,6 +101,9 @@ pub enum SlashCommand {
     /// Toggle plan mode (also Shift+Tab): read-only investigation until a
     /// plan is approved via `exit_plan`.
     Plan,
+    /// `/rewind [turn]` — restore file checkpoints and truncate history.
+    /// `None` opens the turn picker; `Some` rewinds to before that turn.
+    Rewind(Option<u64>),
     /// Toggle the git diff sidebar.
     Diff,
     /// Toggle the todo side panel.
@@ -251,6 +254,13 @@ impl SlashCommand {
             }
             "reload" => Ok(Self::Reload),
             "plan" => Ok(Self::Plan),
+            "rewind" => match args.first() {
+                None => Ok(Self::Rewind(None)),
+                Some(arg) => arg
+                    .parse::<u64>()
+                    .map(|turn| Self::Rewind(Some(turn)))
+                    .map_err(|_| "usage: /rewind [turn]".to_string()),
+            },
             "diff" => Ok(Self::Diff),
             "todos" => Ok(Self::Todos),
             "cost" => Ok(Self::Cost),
@@ -314,6 +324,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "plan",
         args: "",
         description: "toggle plan mode: read-only until a plan is approved",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "rewind",
+        args: "[turn]",
+        description: "rewind files and conversation to before a turn",
         takes_args: false,
     },
     CommandSpec {
@@ -401,6 +417,8 @@ pub const COMMANDS: &[CommandSpec] = &[
 pub enum PickerKind {
     Model,
     Mode,
+    /// A turn to rewind to (item values are turn ids).
+    Rewind,
 }
 
 /// One selectable row in a picker popup.
@@ -495,7 +513,7 @@ pub struct App {
     pub suggestions: Vec<&'static CommandSpec>,
     /// Highlighted row in `suggestions`.
     pub suggestion_index: usize,
-    /// Open selection popup (model / mode picker), if any.
+    /// Open selection popup (model / mode / rewind picker), if any.
     pub picker: Option<Picker>,
     /// Whether plan mode is active (mirrors the agent's flag for the status
     /// bar; toggled by `/plan` and Shift+Tab).
@@ -917,6 +935,13 @@ impl App {
                                 Mode::Genie
                             };
                             AppAction::Command(SlashCommand::Mode(Some(mode)))
+                        }
+                        PickerKind::Rewind => {
+                            // Item values are always turn ids we formatted.
+                            let Ok(turn) = item.value.parse::<u64>() else {
+                                return Ok(None);
+                            };
+                            AppAction::Command(SlashCommand::Rewind(Some(turn)))
                         }
                     };
                     return Ok(Some(action));
@@ -1534,6 +1559,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /mode [genie|sovereign]     pick or switch personality mode\n  \
 /genie · /sovereign         switch mode directly\n  \
 /plan                       toggle plan mode (read-only until a plan is approved)\n  \
+/rewind [turn]              rewind files and conversation to before a turn\n  \
 /evolve [--deep] <desc>     self-extension (skill / MCP / scripted tool)\n  \
 /publish [branch]           fork Wizard to your GitHub, get a one-line installer\n  \
 /provider [list|use|...]    add, remove, or switch LLM providers (llamacpp/ollama/openai/anthropic/openrouter/xai/xaioauth)\n  \
@@ -1966,6 +1992,8 @@ impl CommandContext<'_> {
             SlashCommand::Mode(None) => self.open_mode_picker(),
             SlashCommand::Mode(Some(mode)) => self.switch_mode(mode),
             SlashCommand::Plan => self.toggle_plan(),
+            SlashCommand::Rewind(None) => self.open_rewind_picker(),
+            SlashCommand::Rewind(Some(turn)) => self.rewind(turn),
             SlashCommand::Reload => self.reload().await,
             SlashCommand::Evolve { deep, description } => self.evolve(deep, description),
             SlashCommand::Publish { branch } => self.publish(branch),
@@ -2172,6 +2200,94 @@ impl CommandContext<'_> {
         } else {
             "plan mode off"
         });
+    }
+
+    /// `/rewind`: open the turn picker (newest first). Each row shows the
+    /// turn number, the files its edits snapshotted, and the first line of
+    /// the prompt that started it. Esc cancels.
+    fn open_rewind_picker(&mut self) {
+        if self.agent_unavailable("rewind") {
+            return;
+        }
+        let Some(agent) = self.agent_slot.as_ref() else {
+            self.app.notice("the agent is busy — try again in a moment");
+            return;
+        };
+        let candidates = agent.rewind_candidates(20);
+        if candidates.is_empty() {
+            self.app.notice("nothing to rewind yet");
+            return;
+        }
+        let items: Vec<PickerItem> = candidates
+            .iter()
+            .map(|candidate| {
+                let files = candidate
+                    .files
+                    .iter()
+                    .map(|path| {
+                        path.file_name()
+                            .map(|name| name.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| path.display().to_string())
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let detail = match (candidate.prompt.is_empty(), files.is_empty()) {
+                    (false, false) => format!("{} · {files}", candidate.prompt),
+                    (false, true) => candidate.prompt.clone(),
+                    (true, false) => files,
+                    (true, true) => String::new(),
+                };
+                PickerItem {
+                    value: candidate.turn.to_string(),
+                    detail,
+                    current: false,
+                }
+            })
+            .collect();
+        self.app.picker = Some(Picker {
+            kind: PickerKind::Rewind,
+            title: " rewind to before turn ".to_string(),
+            items,
+            selected: 0,
+        });
+    }
+
+    /// `/rewind <turn>` (or a picker selection): restore the files and drop
+    /// the rewound turns from the session and the transcript.
+    fn rewind(&mut self, turn: u64) {
+        if self.agent_unavailable("rewind") {
+            return;
+        }
+        let Some(agent) = self.agent_slot.as_mut() else {
+            self.app.notice("the agent is busy — try again in a moment");
+            return;
+        };
+        match agent.rewind_to(turn) {
+            Ok(restored) => {
+                // The rewound turns no longer exist: reset the transcript
+                // view to match the truncated conversation.
+                self.app.transcript.clear();
+                self.app.streaming.clear();
+                self.app.streaming_thinking.clear();
+                self.app.scroll = 0;
+                let files = if restored.is_empty() {
+                    "no files needed restoring".to_string()
+                } else {
+                    format!(
+                        "restored {}",
+                        restored
+                            .iter()
+                            .map(|path| path.display().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                self.app.notice(format!(
+                    "rewound to before turn {turn} — {files}; conversation truncated"
+                ));
+            }
+            Err(err) => self.app.notice(format!("rewind failed: {err:#}")),
+        }
     }
 
     fn switch_mode(&mut self, mode: Mode) {
@@ -2769,7 +2885,8 @@ mod tests {
     #[test]
     fn tab_completes_the_selected_suggestion() {
         let mut app = app();
-        type_str(&mut app, "/re");
+        // "/re" would be ambiguous between /rewind and /reload.
+        type_str(&mut app, "/rel");
         press(&mut app, KeyCode::Tab);
         assert_eq!(app.input, "/reload");
         assert_eq!(app.cursor, "/reload".chars().count());
@@ -2937,6 +3054,68 @@ mod tests {
     fn todos_and_cost_parse() {
         assert_eq!(SlashCommand::parse("/todos"), Some(Ok(SlashCommand::Todos)));
         assert_eq!(SlashCommand::parse("/cost"), Some(Ok(SlashCommand::Cost)));
+    }
+
+    #[test]
+    fn rewind_parses_with_and_without_a_turn() {
+        assert_eq!(
+            SlashCommand::parse("/rewind"),
+            Some(Ok(SlashCommand::Rewind(None)))
+        );
+        assert_eq!(
+            SlashCommand::parse("/rewind 7"),
+            Some(Ok(SlashCommand::Rewind(Some(7))))
+        );
+        let parsed = SlashCommand::parse("/rewind soon").expect("is a slash command");
+        let message = parsed.expect_err("non-numeric turn");
+        assert!(message.contains("/rewind [turn]"), "got: {message}");
+    }
+
+    #[test]
+    fn rewind_picker_selection_becomes_a_rewind_command() {
+        let mut app = app();
+        app.picker = Some(Picker {
+            kind: PickerKind::Rewind,
+            title: " rewind to before turn ".to_string(),
+            items: vec![
+                PickerItem {
+                    value: "9".to_string(),
+                    detail: "fix tests · notes.txt".to_string(),
+                    current: false,
+                },
+                PickerItem {
+                    value: "8".to_string(),
+                    detail: String::new(),
+                    current: false,
+                },
+            ],
+            selected: 0,
+        });
+        press(&mut app, KeyCode::Down);
+        let action = press(&mut app, KeyCode::Enter);
+        assert!(matches!(
+            action,
+            Some(AppAction::Command(SlashCommand::Rewind(Some(8))))
+        ));
+        assert!(app.picker.is_none(), "the picker closed");
+    }
+
+    #[test]
+    fn rewind_picker_esc_cancels() {
+        let mut app = app();
+        app.picker = Some(Picker {
+            kind: PickerKind::Rewind,
+            title: " rewind to before turn ".to_string(),
+            items: vec![PickerItem {
+                value: "3".to_string(),
+                detail: String::new(),
+                current: false,
+            }],
+            selected: 0,
+        });
+        let action = press(&mut app, KeyCode::Esc);
+        assert!(action.is_none());
+        assert!(app.picker.is_none(), "Esc closed the picker");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1242,6 +1242,16 @@ impl App {
                 self.status.prompt_tokens += prompt_tokens;
                 self.status.completion_tokens += completion_tokens;
             }
+            AgentEvent::TaskFinished {
+                id,
+                command,
+                status,
+            } => {
+                self.notice(format!(
+                    "background task #{id} finished ({}): {command}",
+                    status.describe()
+                ));
+            }
             AgentEvent::TodoUpdated(items) => {
                 self.todos = items;
                 // Auto-show the panel the first time the agent starts a

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
-use crate::agent::{Agent, AgentEvent, DoneReason, session::Session, subagent};
+use crate::agent::{Agent, AgentEvent, DoneReason, PlanVerdict, session::Session, subagent};
 use crate::cli::Cli;
 use crate::config::{Config, Mode, ProviderConfig, ProviderKind};
 use crate::event::{Event, EventLoop};
@@ -97,6 +97,9 @@ pub enum SlashCommand {
     },
     /// Reload skills, scripted tools, and MCP servers without restart.
     Reload,
+    /// Toggle plan mode (also Shift+Tab): read-only investigation until a
+    /// plan is approved via `exit_plan`.
+    Plan,
     /// Toggle the git diff sidebar.
     Diff,
     /// Show the saved project memories.
@@ -242,6 +245,7 @@ impl SlashCommand {
                 }
             }
             "reload" => Ok(Self::Reload),
+            "plan" => Ok(Self::Plan),
             "diff" => Ok(Self::Diff),
             "memory" => Ok(Self::Memory),
             "publish" => Ok(Self::Publish {
@@ -297,6 +301,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "sovereign",
         args: "",
         description: "switch to sovereign mode",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "plan",
+        args: "",
+        description: "toggle plan mode: read-only until a plan is approved",
         takes_args: false,
     },
     CommandSpec {
@@ -395,6 +405,21 @@ pub struct Picker {
     pub selected: usize,
 }
 
+/// In-flight plan review (plan mode): the model called `exit_plan` and the
+/// turn is paused inside the tool until a [`PlanVerdict`] is sent back.
+#[derive(Debug)]
+pub struct PlanReview {
+    /// The plan markdown, rendered in the review modal.
+    pub plan: String,
+    /// Verdict channel back into the paused `exit_plan` call; taken exactly
+    /// once when the review finishes.
+    respond: Option<tokio::sync::oneshot::Sender<PlanVerdict>>,
+    /// `Some` while collecting rejection feedback (the text typed so far).
+    pub feedback: Option<String>,
+    /// Scroll offset from the top of the plan.
+    pub scroll: u16,
+}
+
 /// Status bar contents.
 #[derive(Debug, Default)]
 pub struct StatusLine {
@@ -440,6 +465,12 @@ pub struct App {
     pub suggestion_index: usize,
     /// Open selection popup (model / mode picker), if any.
     pub picker: Option<Picker>,
+    /// Whether plan mode is active (mirrors the agent's flag for the status
+    /// bar; toggled by `/plan` and Shift+Tab).
+    pub plan_mode: bool,
+    /// Open plan-review modal (the turn is paused inside `exit_plan` until
+    /// it resolves), if any.
+    pub plan_review: Option<PlanReview>,
     /// Previously submitted inputs, oldest first (↑/↓ recall).
     pub history: Vec<String>,
     /// Position while browsing `history`; `None` when composing fresh input.
@@ -463,6 +494,7 @@ pub struct App {
 impl App {
     pub fn new(config: Config) -> Self {
         let mode = config.mode;
+        let plan_mode = config.plan_first;
         let spinner_verb = config.ui.spinner_verb(0).to_string();
         let status = StatusLine {
             model: config.active().model,
@@ -489,6 +521,8 @@ impl App {
             suggestions: Vec::new(),
             suggestion_index: 0,
             picker: None,
+            plan_mode,
+            plan_review: None,
             history: Vec::new(),
             history_pos: None,
             history_draft: String::new(),
@@ -803,6 +837,13 @@ impl App {
             }
         }
 
+        // An open plan review captures all keys: the turn is paused inside
+        // exit_plan until a verdict is sent.
+        if self.plan_review.is_some() {
+            self.handle_plan_review_key(key);
+            return Ok(None);
+        }
+
         // An open picker captures navigation keys.
         if let Some(picker) = self.picker.as_mut() {
             match key.code {
@@ -887,6 +928,8 @@ impl App {
                 }
                 None
             }
+            // Shift+Tab toggles plan mode (same as /plan).
+            KeyCode::BackTab => Some(AppAction::Command(SlashCommand::Plan)),
             KeyCode::Esc => {
                 if self.scroll > 0 {
                     self.scroll = 0;
@@ -1004,6 +1047,67 @@ impl App {
         }
     }
 
+    /// Keys while the plan-review modal is open. Review state: `y`/Enter
+    /// approves, `n` opens a feedback line, ↑/↓/PgUp/PgDn scroll the plan.
+    /// Feedback state: typing edits, Enter sends the rejection, Esc returns
+    /// to the review.
+    fn handle_plan_review_key(&mut self, key: KeyEvent) {
+        let Some(review) = self.plan_review.as_mut() else {
+            return;
+        };
+        if let Some(feedback) = review.feedback.as_mut() {
+            match key.code {
+                KeyCode::Enter => {
+                    let feedback = review.feedback.take().unwrap_or_default();
+                    self.finish_plan_review(PlanVerdict::reject(feedback));
+                }
+                KeyCode::Esc => review.feedback = None,
+                KeyCode::Backspace => {
+                    feedback.pop();
+                }
+                KeyCode::Char(c)
+                    if !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    feedback.push(c);
+                }
+                _ => {}
+            }
+            return;
+        }
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                self.finish_plan_review(PlanVerdict::approve());
+            }
+            KeyCode::Char('n') => review.feedback = Some(String::new()),
+            KeyCode::Up => review.scroll = review.scroll.saturating_sub(1),
+            KeyCode::Down => review.scroll = review.scroll.saturating_add(1),
+            KeyCode::PageUp => review.scroll = review.scroll.saturating_sub(10),
+            KeyCode::PageDown => review.scroll = review.scroll.saturating_add(10),
+            _ => {}
+        }
+    }
+
+    /// Close the plan review and send `verdict` back into the paused
+    /// `exit_plan` call. Approval mirrors the agent clearing its plan-mode
+    /// flag; rejection stays in plan mode.
+    fn finish_plan_review(&mut self, verdict: PlanVerdict) {
+        let Some(mut review) = self.plan_review.take() else {
+            return;
+        };
+        let approved = verdict.approved;
+        if let Some(respond) = review.respond.take() {
+            let _ = respond.send(verdict);
+        }
+        if approved {
+            self.plan_mode = false;
+            self.notice("plan approved — executing it");
+        } else {
+            self.notice("plan rejected — still in plan mode");
+        }
+    }
+
     /// Record a submitted input for ↑/↓ recall (skipping immediate repeats).
     fn push_history(&mut self, input: &str) {
         if self.history.last().map(String::as_str) != Some(input) {
@@ -1081,6 +1185,18 @@ impl App {
                 outcome,
             } => {
                 self.notice(format!("hook {event}: {outcome} ({command})"));
+            }
+            AgentEvent::PlanReady { plan, respond } => {
+                self.flush_streaming();
+                // A plan awaiting review implies plan mode is on, however
+                // the turn was started (e.g. `--plan`).
+                self.plan_mode = true;
+                self.plan_review = Some(PlanReview {
+                    plan,
+                    respond: Some(respond),
+                    feedback: None,
+                    scroll: 0,
+                });
             }
             AgentEvent::Done { reason } => {
                 self.flush_streaming();
@@ -1354,6 +1470,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /model [tag]                pick a model interactively, or switch directly\n  \
 /mode [genie|sovereign]     pick or switch personality mode\n  \
 /genie · /sovereign         switch mode directly\n  \
+/plan                       toggle plan mode (read-only until a plan is approved)\n  \
 /evolve [--deep] <desc>     self-extension (skill / MCP / scripted tool)\n  \
 /publish [branch]           fork Wizard to your GitHub, get a one-line installer\n  \
 /provider [list|use|...]    add, remove, or switch LLM providers (llamacpp/ollama/openai/anthropic/openrouter/xai/xaioauth)\n  \
@@ -1365,6 +1482,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /quit                       exit\n\
 keys:\n  \
 Tab / →                     accept command completion\n  \
+Shift+Tab                   toggle plan mode\n  \
 ↑ / ↓                       select suggestion · browse input history\n  \
 PgUp/PgDn · mouse wheel     scroll the transcript\n  \
 Ctrl-P                      model picker  ·  Ctrl-T toggle last tool card\n  \
@@ -1564,6 +1682,13 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
         )
         .await?,
     );
+    // `--plan` / `plan_first = true`: the session starts in plan mode (the
+    // App mirror is set from the same config in App::new below).
+    if config.plan_first
+        && let Some(agent) = agent_slot.as_mut()
+    {
+        agent.set_plan_mode(true);
+    }
     let mut agent_task: Option<JoinHandle<Agent>> = None;
 
     // Genie-mode max_steps as configured, used when switching back from
@@ -1609,7 +1734,12 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
                 app.config.model = model.clone();
                 app.status.model = model;
             }
-            if let Some(agent) = rebuild.agent {
+            if let Some(mut agent) = rebuild.agent {
+                // A rebuilt agent starts with plan mode off; restore the
+                // session's setting.
+                if app.plan_mode {
+                    agent.set_plan_mode(true);
+                }
                 agent_slot = Some(agent);
             }
             app.notice(rebuild.notice);
@@ -1766,6 +1896,7 @@ impl CommandContext<'_> {
             SlashCommand::Model(Some(tag)) => self.switch_model(tag),
             SlashCommand::Mode(None) => self.open_mode_picker(),
             SlashCommand::Mode(Some(mode)) => self.switch_mode(mode),
+            SlashCommand::Plan => self.toggle_plan(),
             SlashCommand::Reload => self.reload().await,
             SlashCommand::Evolve { deep, description } => self.evolve(deep, description),
             SlashCommand::Publish { branch } => self.publish(branch),
@@ -1921,6 +2052,24 @@ impl CommandContext<'_> {
             title: " select mode ".to_string(),
             items,
             selected,
+        });
+    }
+
+    /// `/plan` (and Shift+Tab): toggle plan mode on the live agent.
+    fn toggle_plan(&mut self) {
+        if self.agent_unavailable("toggle plan mode") {
+            return;
+        }
+        let on = !self.app.plan_mode;
+        if let Some(agent) = self.agent_slot.as_mut() {
+            agent.set_plan_mode(on);
+        }
+        self.app.plan_mode = on;
+        self.app.notice(if on {
+            "plan mode on — the agent investigates read-only and presents a plan via \
+             exit_plan for approval (/plan or Shift+Tab to leave)"
+        } else {
+            "plan mode off"
         });
     }
 
@@ -2085,7 +2234,12 @@ impl CommandContext<'_> {
         )
         .await
         {
-            Ok(agent) => {
+            Ok(mut agent) => {
+                // A rebuilt agent starts with plan mode off; restore the
+                // session's setting.
+                if self.app.plan_mode {
+                    agent.set_plan_mode(true);
+                }
                 *self.agent_slot = Some(agent);
                 self.app.status.model = self.app.config.active().model;
                 self.app.notice(summary);
@@ -2669,6 +2823,120 @@ mod tests {
         let parsed = SlashCommand::parse("/login").expect("is a slash command");
         let message = parsed.expect_err("missing provider");
         assert!(message.contains("/login xai"), "got: {message}");
+    }
+
+    #[test]
+    fn plan_parses_as_a_toggle() {
+        assert_eq!(SlashCommand::parse("/plan"), Some(Ok(SlashCommand::Plan)));
+    }
+
+    #[test]
+    fn backtab_toggles_plan_mode() {
+        let mut app = app();
+        let action = press(&mut app, KeyCode::BackTab);
+        assert!(matches!(
+            action,
+            Some(AppAction::Command(SlashCommand::Plan))
+        ));
+    }
+
+    #[test]
+    fn backtab_in_a_picker_still_navigates() {
+        let mut app = app();
+        app.picker = Some(Picker {
+            kind: PickerKind::Mode,
+            title: " select mode ".to_string(),
+            items: vec![
+                PickerItem {
+                    value: "genie".to_string(),
+                    detail: String::new(),
+                    current: true,
+                },
+                PickerItem {
+                    value: "sovereign".to_string(),
+                    detail: String::new(),
+                    current: false,
+                },
+            ],
+            selected: 0,
+        });
+        let action = press(&mut app, KeyCode::BackTab);
+        assert!(action.is_none(), "the picker captured the key");
+        assert_eq!(app.picker.as_ref().expect("open").selected, 1);
+    }
+
+    /// Open a plan review via the agent event, returning the verdict
+    /// receiver.
+    fn open_review(app: &mut App, plan: &str) -> tokio::sync::oneshot::Receiver<PlanVerdict> {
+        let (respond, rx) = tokio::sync::oneshot::channel();
+        app.handle_agent_event(AgentEvent::PlanReady {
+            plan: plan.to_string(),
+            respond,
+        });
+        rx
+    }
+
+    #[test]
+    fn plan_ready_opens_a_review_and_y_approves() {
+        let mut app = app();
+        let mut rx = open_review(&mut app, "# the plan");
+        let review = app.plan_review.as_ref().expect("review open");
+        assert_eq!(review.plan, "# the plan");
+        assert!(app.plan_mode, "a pending plan implies plan mode");
+
+        // Review keys never leak into the input line.
+        press(&mut app, KeyCode::Char('y'));
+        assert!(app.input.is_empty());
+        assert!(app.plan_review.is_none(), "review closed");
+        assert!(!app.plan_mode, "approval clears the plan-mode mirror");
+        assert_eq!(rx.try_recv(), Ok(PlanVerdict::approve()));
+    }
+
+    #[test]
+    fn plan_review_enter_also_approves() {
+        let mut app = app();
+        let mut rx = open_review(&mut app, "# p");
+        let action = press(&mut app, KeyCode::Enter);
+        assert!(action.is_none());
+        assert_eq!(rx.try_recv(), Ok(PlanVerdict::approve()));
+    }
+
+    #[test]
+    fn plan_review_rejection_collects_feedback() {
+        let mut app = app();
+        let mut rx = open_review(&mut app, "# p");
+
+        press(&mut app, KeyCode::Char('n'));
+        let review = app.plan_review.as_ref().expect("still open");
+        assert_eq!(review.feedback.as_deref(), Some(""));
+
+        type_str(&mut app, "add testz");
+        press(&mut app, KeyCode::Backspace);
+        type_str(&mut app, "s first");
+        assert!(app.input.is_empty(), "feedback typing never hits the input");
+        press(&mut app, KeyCode::Enter);
+
+        assert!(app.plan_review.is_none(), "review closed");
+        assert!(app.plan_mode, "rejection keeps plan mode on");
+        assert_eq!(rx.try_recv(), Ok(PlanVerdict::reject("add tests first")));
+    }
+
+    #[test]
+    fn plan_review_esc_leaves_feedback_entry() {
+        let mut app = app();
+        let mut rx = open_review(&mut app, "# p");
+        press(&mut app, KeyCode::Char('n'));
+        type_str(&mut app, "half a thought");
+        press(&mut app, KeyCode::Esc);
+        let review = app.plan_review.as_ref().expect("still open");
+        assert!(review.feedback.is_none(), "back to the review state");
+        assert!(rx.try_recv().is_err(), "no verdict sent yet");
+        // 'n' again starts fresh feedback.
+        press(&mut app, KeyCode::Char('n'));
+        assert_eq!(
+            app.plan_review.as_ref().expect("open").feedback.as_deref(),
+            Some("")
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,6 +20,7 @@ use crate::cli::Cli;
 use crate::config::{Config, Mode, ProviderConfig, ProviderKind};
 use crate::event::{Event, EventLoop};
 use crate::evolve::{EvolveOutcome, EvolveRequest, EvolveTier, Evolver, PublishRequest, publish};
+use crate::hooks::HookEngine;
 use crate::llm::provider::LlmProvider;
 use crate::mcp::{McpConfig, McpManager};
 use crate::memory::MemoryStore;
@@ -1074,6 +1075,13 @@ impl App {
                 self.flush_streaming();
                 self.notice(format!("error: {message}"));
             }
+            AgentEvent::HookFired {
+                event,
+                command,
+                outcome,
+            } => {
+                self.notice(format!("hook {event}: {outcome} ({command})"));
+            }
             AgentEvent::Done { reason } => {
                 self.flush_streaming();
                 self.status.busy = false;
@@ -1173,10 +1181,12 @@ fn load_skill_roots() -> Vec<Skill> {
 
 /// Native + scripted + MCP tools, freshly composed, with the subagent
 /// spawner layered on top. The spawn tool captures the base registry
-/// (without itself) so subagents cannot recurse.
+/// (without itself) so subagents cannot recurse, plus the lifecycle `hooks`
+/// so subagent tool calls fire the same hooks as the parent's.
 async fn build_registry(
     manager: &McpManager,
     client: &Arc<dyn LlmProvider>,
+    hooks: &Arc<HookEngine>,
 ) -> Result<ToolRegistry> {
     let mut base = ToolRegistry::with_native_tools();
     match Config::scripted_tools_dir() {
@@ -1199,6 +1209,7 @@ async fn build_registry(
         subagent_configs,
         Arc::clone(client),
         Arc::clone(&base),
+        Arc::clone(hooks),
     )));
     Ok(registry)
 }
@@ -1225,8 +1236,7 @@ async fn build_agent(
     manager: &McpManager,
     resume: bool,
 ) -> Result<Agent> {
-    let mut registry = build_registry(manager, client).await?;
-    attach_config_tools(&mut registry, config);
+    // Session first: the hook engine carries its id in every payload.
     let sessions_dir = Config::sessions_dir()?;
     let session = if resume {
         match Session::open_latest(&sessions_dir)? {
@@ -1236,6 +1246,13 @@ async fn build_agent(
     } else {
         Session::create(&sessions_dir)?
     };
+    let hooks = Arc::new(HookEngine::new(
+        crate::hooks::load(project_root),
+        project_root.to_path_buf(),
+        session.id.clone(),
+    ));
+    let mut registry = build_registry(manager, client, &hooks).await?;
+    attach_config_tools(&mut registry, config);
     let model = config.active().model;
     let native_tools = match client.supports_native_tools(&model).await {
         Ok(supported) => supported,
@@ -1252,6 +1269,7 @@ async fn build_agent(
         project_root.to_path_buf(),
         session,
         native_tools,
+        hooks,
     )
 }
 
@@ -1559,6 +1577,19 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
     // No startup notice: the welcome screen already shows the model, mode,
     // and help pointers until the first message arrives.
 
+    // session_start hooks fire before the first draw; their activity (and
+    // any failures) lands in the transcript as notices.
+    {
+        let (hook_tx, mut hook_rx) = mpsc::channel::<AgentEvent>(256);
+        if let Some(agent) = agent_slot.as_mut() {
+            agent.fire_session_start(&hook_tx).await;
+        }
+        drop(hook_tx);
+        while let Some(event) = hook_rx.recv().await {
+            app.handle_agent_event(event);
+        }
+    }
+
     let mut events = EventLoop::new(Duration::from_millis(100));
     let mut terminal = setup_terminal()?;
     let _guard = TerminalGuard;
@@ -1695,6 +1726,12 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
         if app.should_quit {
             break;
         }
+    }
+
+    // session_end hooks: best-effort — skipped when quitting mid-turn took
+    // the agent — with no event surfacing (the TUI is going away).
+    if let Some(agent) = agent_slot.as_ref() {
+        agent.fire_session_end(None).await;
     }
 
     drop(_guard);
@@ -1929,7 +1966,15 @@ impl CommandContext<'_> {
                 .app
                 .notice(format!("could not reload MCP config: {err:#}")),
         }
-        match build_registry(&manager, self.client).await {
+        // The rebuilt registry's subagent spawner keeps the session's hooks.
+        let Some(hooks) = self
+            .agent_slot
+            .as_ref()
+            .map(|agent| Arc::clone(agent.hooks()))
+        else {
+            return;
+        };
+        match build_registry(&manager, self.client, &hooks).await {
             Ok(registry) => {
                 let tool_count = registry.len();
                 if let Some(agent) = self.agent_slot.as_mut() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use serde_json::Value;
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::agent::{Agent, AgentEvent, DoneReason, session::Session, subagent};
@@ -20,7 +20,6 @@ use crate::cli::Cli;
 use crate::config::{Config, Mode, ProviderConfig, ProviderKind};
 use crate::event::{Event, EventLoop};
 use crate::evolve::{EvolveOutcome, EvolveRequest, EvolveTier, Evolver, PublishRequest, publish};
-use crate::llm::ToolCall;
 use crate::llm::provider::LlmProvider;
 use crate::mcp::{McpConfig, McpManager};
 use crate::memory::MemoryStore;
@@ -71,14 +70,6 @@ impl std::fmt::Debug for AgentRebuild {
     }
 }
 
-/// A gated tool call waiting for the user's y/n.
-#[derive(Debug)]
-pub struct PendingApproval {
-    pub call: ToolCall,
-    /// Send `true` to approve, `false` to deny. Dropping denies.
-    pub respond: oneshot::Sender<bool>,
-}
-
 /// What the input line is currently doing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InputMode {
@@ -87,8 +78,6 @@ pub enum InputMode {
     Chat,
     /// Composing a `/slash` command.
     Command,
-    /// Answering an approval prompt.
-    Approval,
 }
 
 /// Parsed `/slash` command (see the README table).
@@ -434,7 +423,6 @@ pub struct App {
     /// Partial model reasoning of the in-flight turn, rendered dimmed and
     /// flushed to the transcript alongside `streaming`.
     pub streaming_thinking: String,
-    pub pending_approval: Option<PendingApproval>,
     pub status: StatusLine,
     /// Git diff sidebar visibility and cached contents.
     pub show_diff: bool,
@@ -491,7 +479,6 @@ impl App {
             transcript: Vec::new(),
             streaming: String::new(),
             streaming_thinking: String::new(),
-            pending_approval: None,
             status,
             show_diff: false,
             diff_text: String::new(),
@@ -525,12 +512,10 @@ impl App {
             .push(TranscriptEntry::Notice(message.into()));
     }
 
-    /// Recompute [`InputMode`] from the pending approval and the input text,
-    /// then refresh the command suggestions.
+    /// Recompute [`InputMode`] from the input text, then refresh the command
+    /// suggestions.
     fn sync_input_mode(&mut self) {
-        self.input_mode = if self.pending_approval.is_some() {
-            InputMode::Approval
-        } else if self.input.trim_start().starts_with('/') {
+        self.input_mode = if self.input.trim_start().starts_with('/') {
             InputMode::Command
         } else {
             InputMode::Chat
@@ -719,18 +704,6 @@ impl App {
         }
     }
 
-    /// Answer the pending approval prompt, if any.
-    fn respond_approval(&mut self, approve: bool) {
-        if let Some(pending) = self.pending_approval.take() {
-            let name = pending.call.function.name.clone();
-            // The agent may have given up waiting; a closed channel is fine.
-            let _ = pending.respond.send(approve);
-            let verdict = if approve { "approved" } else { "denied" };
-            self.notice(format!("{verdict} tool call '{name}'"));
-        }
-        self.sync_input_mode();
-    }
-
     /// Dispatch one event from the merged stream. Returns the user action
     /// the main loop must perform (start a turn, run a slash command, ...).
     pub fn handle_event(&mut self, event: Event) -> Result<Option<AppAction>> {
@@ -749,10 +722,8 @@ impl App {
                 Ok(None)
             }
             Event::Paste(text) => {
-                if self.input_mode != InputMode::Approval {
-                    self.insert_str(&text);
-                    self.sync_input_mode();
-                }
+                self.insert_str(&text);
+                self.sync_input_mode();
                 Ok(None)
             }
             Event::Resize(_, _) => Ok(None),
@@ -775,7 +746,7 @@ impl App {
     }
 
     /// Keyboard handling for the current [`InputMode`]. Priority: global
-    /// chords, approval prompt, open picker, then line editing.
+    /// chords, open picker, then line editing.
     pub fn handle_key(&mut self, key: KeyEvent) -> Result<Option<AppAction>> {
         if key.kind == KeyEventKind::Release {
             return Ok(None);
@@ -821,27 +792,14 @@ impl App {
                 }
                 KeyCode::Char('p') => {
                     // Shortcut for the interactive model picker; ignored
-                    // while a turn runs or an approval prompt is up.
-                    if self.status.busy || self.pending_approval.is_some() {
+                    // while a turn runs.
+                    if self.status.busy {
                         return Ok(None);
                     }
                     return Ok(Some(AppAction::Command(SlashCommand::Model(None))));
                 }
                 _ => {}
             }
-        }
-
-        if self.input_mode == InputMode::Approval {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                    self.respond_approval(true);
-                }
-                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                    self.respond_approval(false);
-                }
-                _ => {}
-            }
-            return Ok(None);
         }
 
         // An open picker captures navigation keys.
@@ -1061,14 +1019,6 @@ impl App {
             AgentEvent::ThinkingDelta(delta) => {
                 self.streaming_thinking.push_str(&delta);
             }
-            AgentEvent::ApprovalRequest { call, respond } => {
-                // The approval modal takes over; drop any open picker so it
-                // cannot linger stale underneath (or after) the prompt.
-                self.picker = None;
-                self.pending_approval = Some(PendingApproval { call, respond });
-                self.scroll = 0;
-                self.sync_input_mode();
-            }
             AgentEvent::ToolStarted { name, args } => {
                 self.flush_streaming();
                 self.transcript.push(TranscriptEntry::ToolCard {
@@ -1128,9 +1078,6 @@ impl App {
                 self.flush_streaming();
                 self.status.busy = false;
                 self.turn_started = None;
-                // Dropping an unanswered approval denies it agent-side.
-                self.pending_approval = None;
-                self.sync_input_mode();
                 match reason {
                     DoneReason::Completed => {}
                     DoneReason::MaxSteps => self.notice(format!(
@@ -1404,7 +1351,6 @@ Tab / →                     accept command completion\n  \
 PgUp/PgDn · mouse wheel     scroll the transcript\n  \
 Ctrl-P                      model picker  ·  Ctrl-T toggle last tool card\n  \
 Ctrl-A/E Home/End ←/→       move cursor   ·  Ctrl-W/U/K kill word/to start/to end\n  \
-y / n                       approve / deny a gated tool call\n  \
 Ctrl-C                      quit";
 
 // ---------------------------------------------------------------------------
@@ -1953,7 +1899,6 @@ impl CommandContext<'_> {
         self.app.status.mode = mode;
         match mode {
             Mode::Sovereign => {
-                self.app.config.auto_approve = true;
                 self.app.config.max_steps = self
                     .app
                     .config
@@ -1961,7 +1906,6 @@ impl CommandContext<'_> {
                     .max(Mode::Sovereign.default_max_steps());
             }
             Mode::Genie => {
-                self.app.config.auto_approve = true;
                 self.app.config.max_steps = self.genie_max_steps;
             }
         }
@@ -2011,15 +1955,9 @@ impl CommandContext<'_> {
             "evolving ({}): {description}",
             if deep { "deep" } else { "runtime" }
         ));
-        // The TUI cannot use the Evolver's stdin y/N gate (the terminal
-        // is in raw mode and owned by the event loop). The explicit
-        // `/evolve` command is treated as the user's approval; the
-        // outcome notice reports exactly what was added.
-        let request = EvolveRequest {
-            description,
-            tier,
-            auto_approve: true,
-        };
+        // The explicit `/evolve` command is the user's consent; the outcome
+        // notice reports exactly what was added.
+        let request = EvolveRequest { description, tier };
         let mut evolver = Evolver::new(self.app.config.clone());
         let notify = self.events.sender();
         tokio::spawn(async move {
@@ -2044,10 +1982,7 @@ impl CommandContext<'_> {
         let config = self.app.config.clone();
         let notify = self.events.sender();
         tokio::spawn(async move {
-            let req = PublishRequest {
-                branch,
-                auto_approve: true,
-            };
+            let req = PublishRequest { branch };
             let message = match publish(&config, req, false).await {
                 Ok(outcome) => format!(
                     "publish: forked to {}  (branch: {})\n\nInstall one-liner:\n{}",

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,11 @@ pub enum SlashCommand {
     Cost,
     /// Show the saved project memories.
     Memory,
+    /// Run the environment diagnostics (same checks as `wizard doctor`).
+    Doctor,
+    /// Show the session status: model, provider, mode, session id, usage,
+    /// todo progress, background tasks, plan mode.
+    Status,
     /// `/publish [branch]` — fork Wizard and get a one-line installer.
     Publish {
         branch: Option<String>,
@@ -266,6 +271,8 @@ impl SlashCommand {
             "todos" => Ok(Self::Todos),
             "cost" => Ok(Self::Cost),
             "memory" => Ok(Self::Memory),
+            "doctor" => Ok(Self::Doctor),
+            "status" => Ok(Self::Status),
             "publish" => Ok(Self::Publish {
                 branch: args.first().map(|s| s.to_string()),
             }),
@@ -385,6 +392,18 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "memory",
         args: "",
         description: "show saved project memories",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "status",
+        args: "",
+        description: "show session status: model, usage, todos, tasks",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "doctor",
+        args: "",
+        description: "diagnose config, providers, MCP, hooks, state dirs",
         takes_args: false,
     },
     CommandSpec {
@@ -1731,6 +1750,8 @@ const HELP_TEXT: &str = "available commands:\n  \
 /todos                      toggle the todo side panel\n  \
 /cost                       show session token usage and cost\n  \
 /memory                     show saved project memories\n  \
+/status                     show session status (model, usage, todos, tasks)\n  \
+/doctor                     diagnose config, providers, MCP, hooks, state dirs\n  \
 /quit                       exit\n\
 keys:\n  \
 Tab / →                     accept command completion\n  \
@@ -2150,6 +2171,8 @@ impl CommandContext<'_> {
             SlashCommand::Todos => self.toggle_todos(),
             SlashCommand::Cost => self.cost(),
             SlashCommand::Memory => self.memory(),
+            SlashCommand::Doctor => self.doctor().await,
+            SlashCommand::Status => self.status(),
             SlashCommand::Clear => self.clear(),
             SlashCommand::Model(None) => self.open_model_picker().await,
             SlashCommand::Model(Some(tag)) => self.switch_model(tag),
@@ -2248,6 +2271,60 @@ impl CommandContext<'_> {
             }
             Err(err) => self.app.notice(format!("could not list memories: {err:#}")),
         }
+    }
+
+    /// `/doctor`: the same diagnostics as `wizard doctor`, in the
+    /// transcript. Network probes are capped at 5s each, but a slow
+    /// provider or MCP server still blocks the UI for that long.
+    async fn doctor(&mut self) {
+        let checks = crate::doctor::run_checks(self.project_root).await;
+        self.app
+            .notice(format!("doctor:\n{}", crate::doctor::render(&checks)));
+    }
+
+    /// `/status`: one snapshot of the session — model, provider, mode,
+    /// session id, usage, todo progress, background tasks, plan mode.
+    fn status(&mut self) {
+        let provider = self.app.config.active();
+        let mut text = format!(
+            "model: {}\nprovider: {} ({:?} @ {})\nmode: {}",
+            self.app.status.model, provider.name, provider.kind, provider.base_url, self.app.mode,
+        );
+        match self.agent_slot.as_ref() {
+            Some(agent) => {
+                let (prompt, completion) = agent.usage().session_totals();
+                text.push_str(&format!(
+                    "\nsession: {}\nusage: {prompt} prompt + {completion} completion tokens",
+                    agent.session().id,
+                ));
+                text.push_str(&format!(
+                    "\nbackground tasks: {} running",
+                    agent.running_tasks()
+                ));
+            }
+            None => {
+                // Mid-turn (or rebuilding): the status bar mirror is the
+                // best available source.
+                let (prompt, completion) = (
+                    self.app.status.prompt_tokens,
+                    self.app.status.completion_tokens,
+                );
+                text.push_str(&format!(
+                    "\nsession: (turn running)\nusage: {prompt} prompt + {completion} completion tokens",
+                ));
+            }
+        }
+        let (done, total) = crate::tools::todo::progress(&self.app.todos);
+        if total > 0 {
+            text.push_str(&format!("\ntodos: {done}/{total} done"));
+        } else {
+            text.push_str("\ntodos: none");
+        }
+        text.push_str(&format!(
+            "\nplan mode: {}",
+            if self.app.plan_mode { "on" } else { "off" }
+        ));
+        self.app.notice(text);
     }
 
     fn clear(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1890,8 +1890,9 @@ async fn startup_client(config: &mut Config) -> Result<Arc<dyn LlmProvider>> {
 /// screen), build the agent stack (LLM provider, registry with scripted +
 /// MCP tools, skills, session), pre-fill `cli.prompt` if given, and drive
 /// the [`EventLoop`](crate::event::EventLoop) until quit. Restores the
-/// terminal on exit and on panic.
-pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
+/// terminal on exit and on panic. Returns the process exit code: 0 from the
+/// TUI itself; the headless fallback propagates its outcome code.
+pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
     // No usable terminal: run headless when a task was given, otherwise we
     // cannot do anything sensible.
     if !std::io::stdout().is_terminal() || !std::io::stdin().is_terminal() {
@@ -2122,7 +2123,7 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
 
     drop(_guard);
     restore_terminal_best_effort();
-    Ok(())
+    Ok(0)
 }
 
 /// Everything a slash command may touch, borrowed from the main loop for

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ use crate::memory::MemoryStore;
 use crate::server;
 use crate::skills::Skill;
 use crate::tools::registry::ToolRegistry;
+use crate::tools::todo::TodoItem;
 
 /// One rendered entry in the chat transcript.
 #[derive(Debug)]
@@ -102,6 +103,10 @@ pub enum SlashCommand {
     Plan,
     /// Toggle the git diff sidebar.
     Diff,
+    /// Toggle the todo side panel.
+    Todos,
+    /// Show session token usage (and cost when rates are configured).
+    Cost,
     /// Show the saved project memories.
     Memory,
     /// `/publish [branch]` — fork Wizard and get a one-line installer.
@@ -247,6 +252,8 @@ impl SlashCommand {
             "reload" => Ok(Self::Reload),
             "plan" => Ok(Self::Plan),
             "diff" => Ok(Self::Diff),
+            "todos" => Ok(Self::Todos),
+            "cost" => Ok(Self::Cost),
             "memory" => Ok(Self::Memory),
             "publish" => Ok(Self::Publish {
                 branch: args.first().map(|s| s.to_string()),
@@ -346,6 +353,18 @@ pub const COMMANDS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        name: "todos",
+        args: "",
+        description: "toggle the todo side panel",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "cost",
+        args: "",
+        description: "show session token usage and cost",
+        takes_args: false,
+    },
+    CommandSpec {
         name: "memory",
         args: "",
         description: "show saved project memories",
@@ -430,6 +449,10 @@ pub struct StatusLine {
     pub max_steps: u32,
     /// True while a turn is streaming.
     pub busy: bool,
+    /// Session prompt-token total (from [`AgentEvent::Usage`]).
+    pub prompt_tokens: u64,
+    /// Session completion-token total.
+    pub completion_tokens: u64,
 }
 
 /// Full TUI state. [`crate::ui::draw`] renders it; [`App::handle_event`]
@@ -453,6 +476,15 @@ pub struct App {
     /// Git diff sidebar visibility and cached contents.
     pub show_diff: bool,
     pub diff_text: String,
+    /// Todo side panel visibility (toggled by `/todos`; auto-shown on the
+    /// first todo update of the session).
+    pub show_todos: bool,
+    /// The agent's current todo list, mirrored from
+    /// [`AgentEvent::TodoUpdated`].
+    pub todos: Vec<TodoItem>,
+    /// Whether a todo update has arrived yet (drives the one-time
+    /// auto-show).
+    todos_seen: bool,
     /// Transcript scroll offset from the bottom (0 = pinned to latest).
     pub scroll: u16,
     pub should_quit: bool,
@@ -502,6 +534,8 @@ impl App {
             step: 0,
             max_steps: config.max_steps,
             busy: false,
+            prompt_tokens: 0,
+            completion_tokens: 0,
         };
         Self {
             config,
@@ -515,6 +549,9 @@ impl App {
             status,
             show_diff: false,
             diff_text: String::new(),
+            show_todos: false,
+            todos: Vec::new(),
+            todos_seen: false,
             scroll: 0,
             should_quit: false,
             tick: 0,
@@ -1198,6 +1235,22 @@ impl App {
                     scroll: 0,
                 });
             }
+            AgentEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            } => {
+                self.status.prompt_tokens += prompt_tokens;
+                self.status.completion_tokens += completion_tokens;
+            }
+            AgentEvent::TodoUpdated(items) => {
+                self.todos = items;
+                // Auto-show the panel the first time the agent starts a
+                // list; afterwards /todos controls visibility.
+                if !self.todos_seen && !self.todos.is_empty() {
+                    self.todos_seen = true;
+                    self.show_todos = true;
+                }
+            }
             AgentEvent::Done { reason } => {
                 self.flush_streaming();
                 self.status.busy = false;
@@ -1478,6 +1531,8 @@ const HELP_TEXT: &str = "available commands:\n  \
 /login xai                  sign in with your xAI account (OAuth, no API key)\n  \
 /reload                     reload skills, scripted tools, and MCP servers\n  \
 /diff                       toggle the git diff sidebar\n  \
+/todos                      toggle the todo side panel\n  \
+/cost                       show session token usage and cost\n  \
 /memory                     show saved project memories\n  \
 /quit                       exit\n\
 keys:\n  \
@@ -1600,6 +1655,8 @@ async fn startup_client(config: &mut Config) -> Result<Arc<dyn LlmProvider>> {
             model: model.to_string(),
             api_key_env: Some(key_env.to_string()),
             gguf_path: None,
+            usd_per_mtok_in: None,
+            usd_per_mtok_out: None,
         };
         match try_provider(&provider).await {
             Ok(client) => {
@@ -1890,6 +1947,8 @@ impl CommandContext<'_> {
             SlashCommand::Help => self.app.notice(HELP_TEXT),
             SlashCommand::Quit => self.app.should_quit = true,
             SlashCommand::Diff => self.toggle_diff().await,
+            SlashCommand::Todos => self.toggle_todos(),
+            SlashCommand::Cost => self.cost(),
             SlashCommand::Memory => self.memory(),
             SlashCommand::Clear => self.clear(),
             SlashCommand::Model(None) => self.open_model_picker().await,
@@ -1930,6 +1989,38 @@ impl CommandContext<'_> {
                 Err(err) => format!("could not read git diff: {err:#}"),
             };
         }
+    }
+
+    /// `/todos`: toggle the todo side panel.
+    fn toggle_todos(&mut self) {
+        self.app.show_todos = !self.app.show_todos;
+        if self.app.show_todos && self.app.todos.is_empty() {
+            self.app
+                .notice("todo list is empty — the agent fills it via the `todo` tool");
+        }
+    }
+
+    /// `/cost`: session token totals, plus an estimate when the active
+    /// provider has `usd_per_mtok_in` / `usd_per_mtok_out` configured.
+    fn cost(&mut self) {
+        let prompt = self.app.status.prompt_tokens;
+        let completion = self.app.status.completion_tokens;
+        let mut text = format!("session usage: {prompt} prompt + {completion} completion tokens");
+        let provider = self.app.config.active();
+        match crate::usage::cost_usd(
+            prompt,
+            completion,
+            provider.usd_per_mtok_in,
+            provider.usd_per_mtok_out,
+        ) {
+            Some(cost) => text.push_str(&format!(" · est. ${cost:.4}")),
+            None => text.push_str(&format!(
+                "\nset usd_per_mtok_in / usd_per_mtok_out on provider '{}' in \
+                 ~/.wizard/config.toml for cost estimates",
+                provider.name
+            )),
+        }
+        self.app.notice(text);
     }
 
     /// `/memory`: list the saved project memories (name — description).
@@ -2333,6 +2424,8 @@ impl CommandContext<'_> {
             model,
             api_key_env: api_key_env.clone(),
             gguf_path: None,
+            usd_per_mtok_in: None,
+            usd_per_mtok_out: None,
         };
         // Dedup by name: replace an existing entry with the same name.
         self.app.config.providers.retain(|p| p.name != name);
@@ -2828,6 +2921,48 @@ mod tests {
     #[test]
     fn plan_parses_as_a_toggle() {
         assert_eq!(SlashCommand::parse("/plan"), Some(Ok(SlashCommand::Plan)));
+    }
+
+    #[test]
+    fn todos_and_cost_parse() {
+        assert_eq!(SlashCommand::parse("/todos"), Some(Ok(SlashCommand::Todos)));
+        assert_eq!(SlashCommand::parse("/cost"), Some(Ok(SlashCommand::Cost)));
+    }
+
+    #[test]
+    fn todo_update_mirrors_the_list_and_auto_shows_the_panel_once() {
+        use crate::tools::todo::{TodoItem, TodoStatus};
+        let mut app = app();
+        assert!(!app.show_todos);
+
+        let items = vec![TodoItem {
+            content: "first".to_string(),
+            status: TodoStatus::InProgress,
+        }];
+        app.handle_agent_event(AgentEvent::TodoUpdated(items.clone()));
+        assert_eq!(app.todos, items);
+        assert!(app.show_todos, "first update auto-shows the panel");
+
+        // The user hides it; later updates respect that.
+        app.show_todos = false;
+        app.handle_agent_event(AgentEvent::TodoUpdated(items.clone()));
+        assert!(!app.show_todos, "auto-show happens only once");
+        assert_eq!(app.todos, items, "the list still updates");
+    }
+
+    #[test]
+    fn usage_events_accumulate_session_totals_in_the_status_bar() {
+        let mut app = app();
+        app.handle_agent_event(AgentEvent::Usage {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+        });
+        app.handle_agent_event(AgentEvent::Usage {
+            prompt_tokens: 50,
+            completion_tokens: 5,
+        });
+        assert_eq!(app.status.prompt_tokens, 150);
+        assert_eq!(app.status.completion_tokens, 25);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use tokio::task::JoinHandle;
 
 use crate::agent::{Agent, AgentEvent, DoneReason, PlanVerdict, session::Session, subagent};
 use crate::cli::Cli;
+use crate::commands::CustomCommand;
 use crate::config::{Config, Mode, ProviderConfig, ProviderKind};
 use crate::event::{Event, EventLoop};
 use crate::evolve::{EvolveOutcome, EvolveRequest, EvolveTier, Evolver, PublishRequest, publish};
@@ -412,6 +413,56 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
 ];
 
+/// One row in the suggestion popup: a builtin [`CommandSpec`] or a custom
+/// command loaded from `~/.wizard/commands/` / `<project>/.wizard/commands/`.
+#[derive(Debug, Clone)]
+pub struct Suggestion {
+    pub name: String,
+    /// Argument hint shown after the name.
+    pub args: String,
+    pub description: String,
+    /// Completion appends a trailing space and waits for arguments instead
+    /// of submitting immediately.
+    pub takes_args: bool,
+}
+
+impl From<&CommandSpec> for Suggestion {
+    fn from(spec: &CommandSpec) -> Self {
+        Self {
+            name: spec.name.to_string(),
+            args: spec.args.to_string(),
+            description: spec.description.to_string(),
+            takes_args: spec.takes_args,
+        }
+    }
+}
+
+impl From<&CustomCommand> for Suggestion {
+    fn from(command: &CustomCommand) -> Self {
+        let takes_args = command.expects_args();
+        Self {
+            name: command.name.clone(),
+            args: if takes_args {
+                "[args]".to_string()
+            } else {
+                String::new()
+            },
+            description: command
+                .description
+                .clone()
+                .unwrap_or_else(|| "custom command".to_string()),
+            takes_args,
+        }
+    }
+}
+
+/// True when `name` is a builtin command word ([`COMMANDS`] plus the parse
+/// aliases that have no table entry). Unknown words fall through to the
+/// model as a normal prompt.
+fn is_builtin_command(name: &str) -> bool {
+    COMMANDS.iter().any(|spec| spec.name == name) || matches!(name, "q" | "exit")
+}
+
 /// What an open [`Picker`] selects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PickerKind {
@@ -508,11 +559,17 @@ pub struct App {
     pub should_quit: bool,
     /// Tick counter driving the busy spinner.
     pub tick: u64,
-    /// Matching [`COMMANDS`] entries for the current `/input`, shown as the
-    /// suggestion popup.
-    pub suggestions: Vec<&'static CommandSpec>,
+    /// Matching commands (builtin [`COMMANDS`] plus custom commands) for the
+    /// current `/input`, shown as the suggestion popup.
+    pub suggestions: Vec<Suggestion>,
     /// Highlighted row in `suggestions`.
     pub suggestion_index: usize,
+    /// Custom commands loaded from `~/.wizard/commands/` and
+    /// `<project>/.wizard/commands/` (set by `run_tui`, refreshed by
+    /// `/reload`).
+    pub custom_commands: Vec<CustomCommand>,
+    /// Project root `@file` references resolve against.
+    pub project_root: PathBuf,
     /// Open selection popup (model / mode / rewind picker), if any.
     pub picker: Option<Picker>,
     /// Whether plan mode is active (mirrors the agent's flag for the status
@@ -575,6 +632,8 @@ impl App {
             tick: 0,
             suggestions: Vec::new(),
             suggestion_index: 0,
+            custom_commands: Vec::new(),
+            project_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             picker: None,
             plan_mode,
             plan_review: None,
@@ -623,7 +682,7 @@ impl App {
         let previous = if self.suggestion_index > 0 {
             self.suggestions
                 .get(self.suggestion_index)
-                .map(|spec| spec.name)
+                .map(|spec| spec.name.clone())
         } else {
             None
         };
@@ -640,18 +699,26 @@ impl App {
             self.suggestion_index = 0;
             return;
         }
+        // Builtins in display order, then custom commands (already sorted).
+        let candidates: Vec<Suggestion> = COMMANDS
+            .iter()
+            .map(Suggestion::from)
+            .chain(self.custom_commands.iter().map(Suggestion::from))
+            .collect();
         // Rank: exact match, then prefix matches, then substring matches.
         self.suggestions
-            .extend(COMMANDS.iter().filter(|spec| spec.name == token));
+            .extend(candidates.iter().filter(|spec| spec.name == token).cloned());
         self.suggestions.extend(
-            COMMANDS
+            candidates
                 .iter()
-                .filter(|spec| spec.name != token && spec.name.starts_with(token)),
+                .filter(|spec| spec.name != token && spec.name.starts_with(token))
+                .cloned(),
         );
         self.suggestions.extend(
-            COMMANDS
+            candidates
                 .iter()
-                .filter(|spec| !spec.name.starts_with(token) && spec.name.contains(token)),
+                .filter(|spec| !spec.name.starts_with(token) && spec.name.contains(token))
+                .cloned(),
         );
         self.suggestion_index = previous
             .and_then(|name| self.suggestions.iter().position(|spec| spec.name == name))
@@ -659,9 +726,9 @@ impl App {
     }
 
     /// Replace the input with the highlighted suggestion. Returns the
-    /// completed spec, or `None` when nothing is highlighted.
-    fn accept_suggestion(&mut self) -> Option<&'static CommandSpec> {
-        let spec = *self.suggestions.get(self.suggestion_index)?;
+    /// completed suggestion, or `None` when nothing is highlighted.
+    fn accept_suggestion(&mut self) -> Option<Suggestion> {
+        let spec = self.suggestions.get(self.suggestion_index)?.clone();
         let mut text = format!("/{}", spec.name);
         if spec.takes_args {
             text.push(' ');
@@ -987,6 +1054,8 @@ impl App {
             KeyCode::Tab => {
                 if suggesting {
                     self.accept_suggestion();
+                } else {
+                    self.complete_at_path();
                 }
                 None
             }
@@ -1060,10 +1129,12 @@ impl App {
                 .strip_prefix('/')
                 .unwrap_or_default()
                 .to_string();
-            let spec = self.suggestions[self.suggestion_index.min(self.suggestions.len() - 1)];
+            let spec =
+                self.suggestions[self.suggestion_index.min(self.suggestions.len() - 1)].clone();
             // An exactly-typed command always runs as typed; otherwise Enter
             // completes the highlighted suggestion first.
-            let exact = COMMANDS.iter().any(|command| command.name == typed);
+            let exact = COMMANDS.iter().any(|command| command.name == typed)
+                || self.custom_commands.iter().any(|c| c.name == typed);
             if !exact && typed != spec.name {
                 let takes_args = spec.takes_args;
                 self.accept_suggestion();
@@ -1085,28 +1156,118 @@ impl App {
                 Some(AppAction::Command(command))
             }
             Some(Err(message)) => {
-                self.push_history(&input);
-                self.clear_input();
-                self.notice(message);
-                None
-            }
-            None => {
-                if self.status.busy {
-                    // Rejected input never ran; do not record it in history.
-                    self.notice("the agent is busy — wait for the current turn to finish");
-                    return None;
+                let word = input
+                    .trim_start()
+                    .strip_prefix('/')
+                    .unwrap_or_default()
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or_default();
+                // A known builtin with bad arguments keeps its usage notice;
+                // custom commands and unknown `/words` go to the model (the
+                // custom expansion happens in `submit_prompt`).
+                if is_builtin_command(word) {
+                    self.push_history(&input);
+                    self.clear_input();
+                    self.notice(message);
+                    None
+                } else {
+                    self.submit_prompt(input)
                 }
-                if self.rebuilding.is_some() {
-                    self.notice("the agent is rebuilding — try again in a moment");
-                    return None;
-                }
-                self.push_history(&input);
-                self.clear_input();
-                self.transcript.push(TranscriptEntry::User(input.clone()));
-                self.scroll = 0;
-                Some(AppAction::Submit(input))
             }
+            None => self.submit_prompt(input),
         }
+    }
+
+    /// Submit `input` as a user prompt: record it verbatim in history and
+    /// the transcript, hand the preprocessed form (custom-command and `@file`
+    /// expansion) to the agent.
+    fn submit_prompt(&mut self, input: String) -> Option<AppAction> {
+        if self.status.busy {
+            // Rejected input never ran; do not record it in history.
+            self.notice("the agent is busy — wait for the current turn to finish");
+            return None;
+        }
+        if self.rebuilding.is_some() {
+            self.notice("the agent is rebuilding — try again in a moment");
+            return None;
+        }
+        let expanded =
+            crate::commands::preprocess(&input, &self.custom_commands, &self.project_root);
+        self.push_history(&input);
+        self.clear_input();
+        self.transcript.push(TranscriptEntry::User(input));
+        self.scroll = 0;
+        Some(AppAction::Submit(expanded))
+    }
+
+    /// Minimal Tab path-completion for `@path` tokens: complete the token
+    /// under the cursor from its directory listing (longest common prefix;
+    /// a unique directory match gains a trailing `/`).
+    fn complete_at_path(&mut self) {
+        let chars: Vec<char> = self.input.chars().collect();
+        let mut start = self.cursor.min(chars.len());
+        while start > 0 && !chars[start - 1].is_whitespace() {
+            start -= 1;
+        }
+        let token: String = chars[start..self.cursor.min(chars.len())].iter().collect();
+        let Some(partial) = token.strip_prefix('@') else {
+            return;
+        };
+        if partial.starts_with('@') {
+            return;
+        }
+        // Split the partial path into the directory to list and the name
+        // prefix to match.
+        let (dir_part, prefix) = match partial.rfind('/') {
+            Some(slash) => (&partial[..=slash], &partial[slash + 1..]),
+            None => ("", partial),
+        };
+        let expanded = shellexpand::tilde(dir_part);
+        let dir_path = Path::new(expanded.as_ref());
+        let dir = if dir_path.is_absolute() {
+            dir_path.to_path_buf()
+        } else {
+            self.project_root.join(dir_path)
+        };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return;
+        };
+        let mut matches: Vec<(String, bool)> = entries
+            .flatten()
+            .filter_map(|entry| {
+                let name = entry.file_name().to_str()?.to_string();
+                let is_dir = entry.file_type().ok()?.is_dir();
+                name.starts_with(prefix).then_some((name, is_dir))
+            })
+            .collect();
+        matches.sort();
+        let completion = match matches.as_slice() {
+            [] => return,
+            [(name, is_dir)] => {
+                let mut full = name.clone();
+                if *is_dir {
+                    full.push('/');
+                }
+                full
+            }
+            many => {
+                let mut common = many[0].0.clone();
+                for (name, _) in &many[1..] {
+                    let shared = common
+                        .char_indices()
+                        .zip(name.chars())
+                        .take_while(|((_, a), b)| a == b)
+                        .count();
+                    common = common.chars().take(shared).collect();
+                }
+                common
+            }
+        };
+        if completion.len() <= prefix.len() {
+            return;
+        }
+        self.insert_str(&completion[prefix.len()..]);
     }
 
     /// Keys while the plan-review modal is open. Review state: `y`/Enter
@@ -1789,6 +1950,8 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<()> {
     let genie_max_steps = config.max_steps;
 
     let mut app = App::new(config);
+    app.project_root = project_root.clone();
+    app.custom_commands = crate::commands::load(&project_root);
     if let Some(prompt) = cli.prompt.clone() {
         app.set_input(prompt);
     }
@@ -2321,6 +2484,7 @@ impl CommandContext<'_> {
             return;
         }
         *self.skills = load_skill_roots();
+        self.app.custom_commands = crate::commands::load(self.project_root);
         let mut manager = self.manager.lock().await;
         match McpConfig::load(self.mcp_path) {
             Ok(mcp_config) => {
@@ -2854,7 +3018,7 @@ mod tests {
     fn slash_filters_suggestions_by_prefix() {
         let mut app = app();
         type_str(&mut app, "/mo");
-        let names: Vec<&str> = app.suggestions.iter().map(|s| s.name).collect();
+        let names: Vec<&str> = app.suggestions.iter().map(|s| s.name.as_str()).collect();
         // Prefix matches first, then substring matches ("me*mo*ry").
         assert_eq!(names, ["model", "mode", "memory"]);
         assert_eq!(app.input_mode, InputMode::Command);
@@ -2933,6 +3097,124 @@ mod tests {
             action,
             Some(AppAction::Command(SlashCommand::Mode(None)))
         ));
+    }
+
+    fn custom(name: &str, template: &str, description: Option<&str>) -> CustomCommand {
+        CustomCommand {
+            name: name.to_string(),
+            description: description.map(str::to_string),
+            template: template.to_string(),
+            path: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn custom_commands_appear_in_suggestions_after_builtins() {
+        let mut app = app();
+        app.custom_commands = vec![custom(
+            "models-report",
+            "Report on $ARGUMENTS",
+            Some("report"),
+        )];
+        type_str(&mut app, "/mo");
+        let names: Vec<&str> = app.suggestions.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, ["model", "mode", "models-report", "memory"]);
+        let spec = &app.suggestions[2];
+        assert_eq!(spec.description, "report");
+        assert!(spec.takes_args);
+    }
+
+    #[test]
+    fn typed_custom_command_submits_the_expanded_prompt() {
+        let mut app = app();
+        app.custom_commands = vec![custom("review", "Review $1 with care.", None)];
+        type_str(&mut app, "/review src/app.rs");
+        let action = press(&mut app, KeyCode::Enter);
+        let Some(AppAction::Submit(prompt)) = action else {
+            panic!("expected a submit, got {action:?}");
+        };
+        assert_eq!(prompt, "Review src/app.rs with care.");
+        // The transcript shows what the user actually typed.
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptEntry::User(text)) if text == "/review src/app.rs"
+        ));
+    }
+
+    #[test]
+    fn unknown_slash_command_passes_through_as_a_prompt() {
+        let mut app = app();
+        type_str(&mut app, "/frobnicate the build");
+        let action = press(&mut app, KeyCode::Enter);
+        assert!(matches!(
+            action,
+            Some(AppAction::Submit(prompt)) if prompt == "/frobnicate the build"
+        ));
+    }
+
+    #[test]
+    fn builtin_command_with_bad_args_keeps_its_usage_notice() {
+        let mut app = app();
+        type_str(&mut app, "/mode warlock");
+        let action = press(&mut app, KeyCode::Enter);
+        assert!(action.is_none());
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptEntry::Notice(text)) if text.contains("unknown mode")
+        ));
+    }
+
+    #[test]
+    fn submit_expands_at_file_references() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("ctx.txt"), "the context\n").unwrap();
+        let mut app = app();
+        app.project_root = tmp.path().to_path_buf();
+        type_str(&mut app, "use @ctx.txt here");
+        let action = press(&mut app, KeyCode::Enter);
+        let Some(AppAction::Submit(prompt)) = action else {
+            panic!("expected a submit, got {action:?}");
+        };
+        assert!(prompt.contains("the context"), "got: {prompt}");
+        // The transcript keeps the compact form.
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptEntry::User(text)) if text == "use @ctx.txt here"
+        ));
+    }
+
+    #[test]
+    fn tab_completes_at_paths_from_the_directory_listing() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("readme.md"), "x").unwrap();
+        std::fs::create_dir(tmp.path().join("reach")).unwrap();
+        let mut app = app();
+        app.project_root = tmp.path().to_path_buf();
+
+        // Common prefix of readme.md / reach.
+        type_str(&mut app, "see @re");
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(app.input, "see @rea");
+
+        // Unique file completes fully.
+        type_str(&mut app, "d");
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(app.input, "see @readme.md");
+    }
+
+    #[test]
+    fn tab_completes_unique_directory_with_a_trailing_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("sources")).unwrap();
+        std::fs::write(tmp.path().join("sources").join("inner.rs"), "x").unwrap();
+        let mut app = app();
+        app.project_root = tmp.path().to_path_buf();
+        type_str(&mut app, "@so");
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(app.input, "@sources/");
+        type_str(&mut app, "in");
+        press(&mut app, KeyCode::Tab);
+        assert_eq!(app.input, "@sources/inner.rs");
     }
 
     #[test]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,566 @@
+//! Per-file copy-on-write checkpoints under `<project>/.wizard/checkpoints/`.
+//!
+//! Before an `Edit`-class tool runs, the dispatcher (and the subagent loop)
+//! snapshot the target file's current content. `/rewind` in the TUI and the
+//! perpetual `rollback_failed_cycles` option restore those before-states.
+//!
+//! This is deliberately *not* shadow-git: the repo Wizard runs in may be
+//! edited concurrently by other processes, so checkpoints only ever touch
+//! files Wizard itself modified. Layout:
+//!
+//! ```text
+//! .wizard/checkpoints/index.jsonl   one SnapshotRecord per line
+//! .wizard/checkpoints/<turn>/<n>.snap   copied file contents
+//! ```
+//!
+//! Every operation is best-effort from the agent's point of view: a failed
+//! snapshot must never fail the tool call (see [`snapshot_edit_target`]).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::tools::{ToolAccess, ToolContext, registry::ToolRegistry};
+
+/// One line of `index.jsonl`: a before-state captured for one file in one
+/// turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotRecord {
+    /// Turn the snapshot belongs to.
+    pub turn: u64,
+    /// Tool whose call triggered the snapshot (`write_file`, `edit_file`).
+    pub tool: String,
+    /// The real target file path (absolute).
+    pub path: PathBuf,
+    /// Snap file path relative to the checkpoints root
+    /// (`<turn>/<n>.snap`); empty when `existed_before` is false.
+    pub snap: String,
+    /// False when the tool was about to create a new file — rewinding then
+    /// deletes it instead of restoring content.
+    pub existed_before: bool,
+}
+
+/// A turn and the files it snapshotted (for the `/rewind` picker).
+#[derive(Debug, Clone)]
+pub struct TurnFiles {
+    pub turn: u64,
+    pub files: Vec<PathBuf>,
+}
+
+/// Copy-on-write snapshot store for one project. Cheap to share behind an
+/// `Arc`; all methods take `&self`.
+#[derive(Debug)]
+pub struct CheckpointStore {
+    /// `<project>/.wizard/checkpoints`.
+    root: PathBuf,
+    /// Number of most recent turns [`gc`](Self::gc) keeps.
+    keep_turns: usize,
+    /// The turn currently executing; bumped by [`begin_turn`](Self::begin_turn).
+    current_turn: AtomicU64,
+    /// `(turn, path)` pairs already snapshotted — the first snapshot of a
+    /// path within a turn wins (it is the turn's before-state). Also
+    /// serializes index file writes.
+    seen: Mutex<HashSet<(u64, PathBuf)>>,
+}
+
+impl CheckpointStore {
+    /// Open (or lazily create) the store for `project_root`. Never fails:
+    /// a corrupt or missing index just starts the turn counter at the
+    /// highest readable turn (or zero).
+    pub fn open(project_root: &Path, keep_turns: usize) -> Self {
+        let root = project_root.join(".wizard").join("checkpoints");
+        let max_turn = read_index(&root.join("index.jsonl"))
+            .iter()
+            .map(|record| record.turn)
+            .max()
+            .unwrap_or(0);
+        Self {
+            root,
+            keep_turns,
+            current_turn: AtomicU64::new(max_turn),
+            seen: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// The turn currently executing (0 before the first
+    /// [`begin_turn`](Self::begin_turn)).
+    pub fn current_turn(&self) -> u64 {
+        self.current_turn.load(Ordering::SeqCst)
+    }
+
+    /// Start a new turn and return its id. Turn ids increase monotonically
+    /// across sessions of a project (seeded from the persisted index).
+    pub fn begin_turn(&self) -> u64 {
+        let turn = self.current_turn.fetch_add(1, Ordering::SeqCst) + 1;
+        // Dedup keys carry the turn id, so old entries are dead weight only.
+        self.seen.lock().unwrap().clear();
+        turn
+    }
+
+    fn index_path(&self) -> PathBuf {
+        self.root.join("index.jsonl")
+    }
+
+    /// Snapshot `target`'s current content as `turn`'s before-state. The
+    /// first snapshot of a path within a turn wins; later calls are skipped
+    /// (returns `Ok(false)`). A missing target records
+    /// `existed_before = false` so rewind deletes the file.
+    pub fn snapshot(&self, turn: u64, tool: &str, target: &Path) -> Result<bool> {
+        let mut seen = self.seen.lock().unwrap();
+        if !seen.insert((turn, target.to_path_buf())) {
+            return Ok(false);
+        }
+        let record = if target.exists() {
+            let turn_dir = self.root.join(turn.to_string());
+            std::fs::create_dir_all(&turn_dir)
+                .with_context(|| format!("creating {}", turn_dir.display()))?;
+            let n = std::fs::read_dir(&turn_dir)
+                .map(|dir| dir.count())
+                .unwrap_or(0);
+            let snap = format!("{turn}/{n}.snap");
+            std::fs::copy(target, self.root.join(&snap))
+                .with_context(|| format!("snapshotting {} to {snap}", target.display()))?;
+            SnapshotRecord {
+                turn,
+                tool: tool.to_string(),
+                path: target.to_path_buf(),
+                snap,
+                existed_before: true,
+            }
+        } else {
+            SnapshotRecord {
+                turn,
+                tool: tool.to_string(),
+                path: target.to_path_buf(),
+                snap: String::new(),
+                existed_before: false,
+            }
+        };
+        self.append_record(&record)?;
+        Ok(true)
+    }
+
+    /// Restore the before-states of one turn and prune its records.
+    /// Returns the restored file paths.
+    pub fn restore_turn(&self, turn: u64) -> Result<Vec<PathBuf>> {
+        self.restore_where(|t| t == turn)
+    }
+
+    /// Restore the before-states of `turn` and every later turn (the
+    /// `/rewind` and cycle-rollback operation): the earliest snapshot of
+    /// each path wins, so files return to their state just before `turn`
+    /// started. Restored turns are pruned from the index. Returns the
+    /// restored file paths.
+    pub fn restore_turns_from(&self, turn: u64) -> Result<Vec<PathBuf>> {
+        self.restore_where(|t| t >= turn)
+    }
+
+    fn restore_where(&self, matches: impl Fn(u64) -> bool) -> Result<Vec<PathBuf>> {
+        let mut seen = self.seen.lock().unwrap();
+        let records = read_index(&self.index_path());
+
+        // Index lines are appended in execution order, so the first matching
+        // record per path is that path's earliest (true) before-state.
+        let mut chosen: HashMap<&Path, &SnapshotRecord> = HashMap::new();
+        for record in records.iter().filter(|record| matches(record.turn)) {
+            chosen.entry(record.path.as_path()).or_insert(record);
+        }
+
+        let mut restored: Vec<PathBuf> = Vec::new();
+        for (path, record) in &chosen {
+            if record.existed_before {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating {}", parent.display()))?;
+                }
+                std::fs::copy(self.root.join(&record.snap), path)
+                    .with_context(|| format!("restoring {}", path.display()))?;
+            } else {
+                match std::fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => {
+                        return Err(err).with_context(|| format!("deleting {}", path.display()));
+                    }
+                }
+            }
+            restored.push(path.to_path_buf());
+        }
+        restored.sort();
+
+        // Prune the rewound turns: their history no longer exists.
+        let dropped: BTreeSet<u64> = records
+            .iter()
+            .filter(|record| matches(record.turn))
+            .map(|record| record.turn)
+            .collect();
+        if !dropped.is_empty() {
+            let keep: Vec<&SnapshotRecord> = records
+                .iter()
+                .filter(|record| !matches(record.turn))
+                .collect();
+            self.rewrite_index(&keep)?;
+            for turn in &dropped {
+                let _ = std::fs::remove_dir_all(self.root.join(turn.to_string()));
+            }
+            seen.retain(|(turn, _)| !matches(*turn));
+        }
+        Ok(restored)
+    }
+
+    /// Drop snapshots of all but the most recent `keep_turns` turns.
+    /// Returns the number of turns dropped. Cheap when there is nothing to
+    /// do (one index read).
+    pub fn gc(&self) -> Result<usize> {
+        let _seen = self.seen.lock().unwrap();
+        let records = read_index(&self.index_path());
+        let turns: BTreeSet<u64> = records.iter().map(|record| record.turn).collect();
+        if turns.len() <= self.keep_turns {
+            return Ok(0);
+        }
+        let cutoff = turns
+            .iter()
+            .rev()
+            .nth(self.keep_turns.saturating_sub(1))
+            .copied()
+            .filter(|_| self.keep_turns > 0);
+        let dropped: Vec<u64> = match cutoff {
+            Some(cutoff) => turns
+                .iter()
+                .copied()
+                .filter(|turn| *turn < cutoff)
+                .collect(),
+            None => turns.iter().copied().collect(),
+        };
+        let keep: Vec<&SnapshotRecord> = records
+            .iter()
+            .filter(|record| !dropped.contains(&record.turn))
+            .collect();
+        self.rewrite_index(&keep)?;
+        for turn in &dropped {
+            let _ = std::fs::remove_dir_all(self.root.join(turn.to_string()));
+        }
+        Ok(dropped.len())
+    }
+
+    /// The most recent `limit` snapshotted turns and the files each touched,
+    /// newest first (for the `/rewind` picker).
+    pub fn recent_turns(&self, limit: usize) -> Vec<TurnFiles> {
+        let records = read_index(&self.index_path());
+        let mut by_turn: BTreeMap<u64, Vec<PathBuf>> = BTreeMap::new();
+        for record in records {
+            by_turn.entry(record.turn).or_default().push(record.path);
+        }
+        by_turn
+            .into_iter()
+            .rev()
+            .take(limit)
+            .map(|(turn, files)| TurnFiles { turn, files })
+            .collect()
+    }
+
+    fn append_record(&self, record: &SnapshotRecord) -> Result<()> {
+        std::fs::create_dir_all(&self.root)
+            .with_context(|| format!("creating {}", self.root.display()))?;
+        let path = self.index_path();
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("opening {}", path.display()))?;
+        let line = serde_json::to_string(record).context("serializing snapshot record")?;
+        writeln!(file, "{line}").with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    fn rewrite_index(&self, records: &[&SnapshotRecord]) -> Result<()> {
+        std::fs::create_dir_all(&self.root)
+            .with_context(|| format!("creating {}", self.root.display()))?;
+        let mut text = String::new();
+        for record in records {
+            text.push_str(&serde_json::to_string(record).context("serializing snapshot record")?);
+            text.push('\n');
+        }
+        let path = self.index_path();
+        let tmp = self.root.join("index.jsonl.tmp");
+        std::fs::write(&tmp, text).with_context(|| format!("writing {}", tmp.display()))?;
+        std::fs::rename(&tmp, &path).with_context(|| format!("replacing {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Load all readable records of `index` (corrupt lines are skipped).
+fn read_index(index: &Path) -> Vec<SnapshotRecord> {
+    let Ok(file) = std::fs::File::open(index) else {
+        return Vec::new();
+    };
+    let mut records = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<SnapshotRecord>(&line) {
+            Ok(record) => records.push(record),
+            Err(err) => tracing::warn!("skipping corrupt checkpoint index line: {err}"),
+        }
+    }
+    records
+}
+
+/// Checkpoint seam shared by the dispatcher and the subagent loop: when
+/// `name` is an `Edit`-class tool, snapshot its target file (resolved from
+/// the `path` argument, after pre-hooks have had their chance to rewrite it)
+/// under the store's current turn. Never fails the tool call — snapshot
+/// errors are logged and execution proceeds.
+pub fn snapshot_edit_target(registry: &ToolRegistry, name: &str, args: &Value, ctx: &ToolContext) {
+    let Some(store) = &ctx.checkpoints else {
+        return;
+    };
+    if registry
+        .get(name)
+        .is_none_or(|tool| tool.access() != ToolAccess::Edit)
+    {
+        return;
+    }
+    let Some(path) = args.get("path").and_then(Value::as_str) else {
+        return;
+    };
+    let target = crate::tools::resolve_path(ctx, path);
+    if let Err(err) = store.snapshot(store.current_turn(), name, &target) {
+        tracing::warn!(
+            "checkpoint snapshot of {} failed: {err:#}",
+            target.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Temp project dir removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let dir =
+                std::env::temp_dir().join(format!("wizard-ckpt-test-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).expect("write file");
+    }
+
+    fn read(path: &Path) -> String {
+        std::fs::read_to_string(path).expect("read file")
+    }
+
+    #[test]
+    fn snapshot_restore_roundtrip() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("notes.txt");
+        write(&file, "before");
+
+        let turn = store.begin_turn();
+        assert!(store.snapshot(turn, "write_file", &file).unwrap());
+        write(&file, "after");
+
+        let restored = store.restore_turn(turn).unwrap();
+        assert_eq!(restored, vec![file.clone()]);
+        assert_eq!(read(&file), "before");
+    }
+
+    #[test]
+    fn new_file_is_deleted_on_restore() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("created.txt");
+
+        let turn = store.begin_turn();
+        assert!(store.snapshot(turn, "write_file", &file).unwrap());
+        write(&file, "fresh content");
+
+        store.restore_turn(turn).unwrap();
+        assert!(!file.exists(), "rewind deletes a file that did not exist");
+    }
+
+    #[test]
+    fn duplicate_snapshot_within_a_turn_is_skipped() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("notes.txt");
+        write(&file, "v1");
+
+        let turn = store.begin_turn();
+        assert!(store.snapshot(turn, "write_file", &file).unwrap());
+        write(&file, "v2");
+        // Second write of the same path within the turn: first wins.
+        assert!(!store.snapshot(turn, "edit_file", &file).unwrap());
+        write(&file, "v3");
+
+        store.restore_turn(turn).unwrap();
+        assert_eq!(
+            read(&file),
+            "v1",
+            "the turn's before-state is the first snapshot"
+        );
+    }
+
+    #[test]
+    fn restore_turns_from_earliest_snapshot_wins_across_turns() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("notes.txt");
+        write(&file, "A");
+
+        let turn1 = store.begin_turn();
+        store.snapshot(turn1, "write_file", &file).unwrap();
+        write(&file, "B");
+        let turn2 = store.begin_turn();
+        store.snapshot(turn2, "write_file", &file).unwrap();
+        write(&file, "C");
+
+        let restored = store.restore_turns_from(turn1).unwrap();
+        assert_eq!(restored, vec![file.clone()]);
+        assert_eq!(read(&file), "A", "earliest before-state wins across turns");
+    }
+
+    #[test]
+    fn restore_turns_from_a_later_turn_keeps_earlier_state() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("notes.txt");
+        write(&file, "A");
+
+        let turn1 = store.begin_turn();
+        store.snapshot(turn1, "write_file", &file).unwrap();
+        write(&file, "B");
+        let turn2 = store.begin_turn();
+        store.snapshot(turn2, "write_file", &file).unwrap();
+        write(&file, "C");
+
+        store.restore_turns_from(turn2).unwrap();
+        assert_eq!(read(&file), "B", "only the later turn is rewound");
+        // Turn 1's snapshot survives the prune and is still restorable.
+        store.restore_turns_from(turn1).unwrap();
+        assert_eq!(read(&file), "A");
+    }
+
+    #[test]
+    fn restore_prunes_records_and_snap_dirs() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let file = tmp.0.join("notes.txt");
+        write(&file, "A");
+
+        let turn = store.begin_turn();
+        store.snapshot(turn, "write_file", &file).unwrap();
+        store.restore_turns_from(turn).unwrap();
+
+        assert!(store.recent_turns(10).is_empty(), "rewound turn is pruned");
+        assert!(
+            !tmp.0
+                .join(".wizard/checkpoints")
+                .join(turn.to_string())
+                .exists(),
+            "snap dir is removed"
+        );
+        // The same path can be snapshotted again in the same turn after a
+        // rewind (the dedup entry was pruned with the records).
+        assert!(store.snapshot(turn, "write_file", &file).unwrap());
+    }
+
+    #[test]
+    fn gc_keeps_the_last_n_turns() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 2);
+        let file = tmp.0.join("notes.txt");
+        for i in 0..5 {
+            write(&file, &format!("v{i}"));
+            let turn = store.begin_turn();
+            store.snapshot(turn, "write_file", &file).unwrap();
+        }
+
+        assert_eq!(store.gc().unwrap(), 3);
+        let recent = store.recent_turns(10);
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].turn, 5);
+        assert_eq!(recent[1].turn, 4);
+        for turn in 1..=3u64 {
+            assert!(
+                !tmp.0
+                    .join(".wizard/checkpoints")
+                    .join(turn.to_string())
+                    .exists(),
+                "gc removed turn {turn}'s snap dir"
+            );
+        }
+        // Nothing further to drop.
+        assert_eq!(store.gc().unwrap(), 0);
+    }
+
+    #[test]
+    fn recent_turns_lists_files_newest_first() {
+        let tmp = TempDir::new();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        let a = tmp.0.join("a.txt");
+        let b = tmp.0.join("b.txt");
+        write(&a, "a");
+
+        let turn1 = store.begin_turn();
+        store.snapshot(turn1, "write_file", &a).unwrap();
+        let turn2 = store.begin_turn();
+        store.snapshot(turn2, "write_file", &a).unwrap();
+        store.snapshot(turn2, "write_file", &b).unwrap();
+
+        let recent = store.recent_turns(10);
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].turn, turn2);
+        assert_eq!(recent[0].files, vec![a.clone(), b.clone()]);
+        assert_eq!(recent[1].turn, turn1);
+    }
+
+    #[test]
+    fn open_resumes_the_turn_counter_from_the_index() {
+        let tmp = TempDir::new();
+        let file = tmp.0.join("notes.txt");
+        write(&file, "x");
+        {
+            let store = CheckpointStore::open(&tmp.0, 50);
+            let turn = store.begin_turn();
+            assert_eq!(turn, 1);
+            store.snapshot(turn, "write_file", &file).unwrap();
+        }
+        let store = CheckpointStore::open(&tmp.0, 50);
+        assert_eq!(store.current_turn(), 1);
+        assert_eq!(store.begin_turn(), 2, "turn ids continue across sessions");
+    }
+
+    #[test]
+    fn corrupt_index_lines_are_skipped() {
+        let tmp = TempDir::new();
+        let dir = tmp.0.join(".wizard/checkpoints");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.jsonl"), "{not json\n\n").unwrap();
+        let store = CheckpointStore::open(&tmp.0, 50);
+        assert_eq!(store.current_turn(), 0);
+        assert!(store.recent_turns(10).is_empty());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,69 @@ pub enum Command {
     /// hooks, writable state dirs, checkpoints. Exits 0 when no check
     /// failed.
     Doctor,
+
+    /// Manage scheduled runs (~/.wizard/schedule.toml): cron entries the
+    /// `wizard scheduler` daemon fires as headless wizard runs.
+    Schedule {
+        #[command(subcommand)]
+        cmd: ScheduleCmd,
+    },
+
+    /// Run the scheduler daemon in the foreground: reload
+    /// ~/.wizard/schedule.toml each pass and fire due entries as headless
+    /// wizard child processes. Daemonize externally (e.g. systemd); see
+    /// docs/scheduler.md.
+    Scheduler,
+}
+
+/// `wizard schedule` subcommands. Like bench, these are self-contained:
+/// they edit `~/.wizard/schedule.toml` directly and never load
+/// `~/.wizard/config.toml` or trigger onboarding.
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum ScheduleCmd {
+    /// Add an entry; validates the cron expression and prints the next
+    /// fire time.
+    Add {
+        /// Unique entry name; `[a-zA-Z0-9_-]+` only.
+        name: String,
+
+        /// Standard 5-field cron expression (minute hour day month weekday),
+        /// evaluated in local time.
+        #[arg(long)]
+        cron: String,
+
+        /// Task prompt handed to the spawned headless wizard run.
+        #[arg(long)]
+        prompt: String,
+
+        /// Directory the run executes in (must exist).
+        #[arg(long)]
+        cwd: PathBuf,
+
+        /// Wall-clock cap in hours for the spawned run.
+        #[arg(long)]
+        max_hours: Option<f64>,
+
+        /// Run mode for the job: `sovereign` (default) or `continuous`.
+        #[arg(long, default_value = "sovereign")]
+        mode: String,
+    },
+
+    /// List entries with their next fire times.
+    List,
+
+    /// Remove an entry by name.
+    Remove {
+        /// Entry name as shown by `wizard schedule list`.
+        name: String,
+    },
+
+    /// Run one entry's job immediately in the foreground (same child
+    /// command the daemon would spawn); exits with the child's exit code.
+    Run {
+        /// Entry name as shown by `wizard schedule list`.
+        name: String,
+    },
 }
 
 /// `wizard bench` subcommands. Self-contained: no flag here depends on the
@@ -347,6 +410,83 @@ mod tests {
     fn doctor_parses_as_a_subcommand() {
         let cli = parse(&["doctor"]).expect("doctor parses");
         assert!(matches!(cli.command, Some(Command::Doctor)));
+    }
+
+    #[test]
+    fn scheduler_parses_as_a_subcommand() {
+        let cli = parse(&["scheduler"]).expect("scheduler parses");
+        assert!(matches!(cli.command, Some(Command::Scheduler)));
+    }
+
+    #[test]
+    fn schedule_add_parses_with_defaults() {
+        let cli = parse(&[
+            "schedule",
+            "add",
+            "nightly",
+            "--cron",
+            "0 3 * * *",
+            "--prompt",
+            "tidy up",
+            "--cwd",
+            "/tmp/proj",
+        ])
+        .expect("schedule add parses");
+        let Some(Command::Schedule {
+            cmd:
+                ScheduleCmd::Add {
+                    name,
+                    cron,
+                    prompt,
+                    cwd,
+                    max_hours,
+                    mode,
+                },
+        }) = cli.command
+        else {
+            panic!("expected schedule add");
+        };
+        assert_eq!(name, "nightly");
+        assert_eq!(cron, "0 3 * * *");
+        assert_eq!(prompt, "tidy up");
+        assert_eq!(cwd, PathBuf::from("/tmp/proj"));
+        assert_eq!(max_hours, None);
+        assert_eq!(mode, "sovereign");
+    }
+
+    #[test]
+    fn schedule_add_requires_cron_prompt_and_cwd() {
+        let err = parse(&["schedule", "add", "nightly"]).expect_err("missing args rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn schedule_list_remove_and_run_parse() {
+        let cli = parse(&["schedule", "list"]).expect("schedule list parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Schedule {
+                cmd: ScheduleCmd::List
+            })
+        ));
+
+        let cli = parse(&["schedule", "remove", "nightly"]).expect("schedule remove parses");
+        let Some(Command::Schedule {
+            cmd: ScheduleCmd::Remove { name },
+        }) = cli.command
+        else {
+            panic!("expected schedule remove");
+        };
+        assert_eq!(name, "nightly");
+
+        let cli = parse(&["schedule", "run", "nightly"]).expect("schedule run parses");
+        let Some(Command::Schedule {
+            cmd: ScheduleCmd::Run { name },
+        }) = cli.command
+        else {
+            panic!("expected schedule run");
+        };
+        assert_eq!(name, "nightly");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,13 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub auto: bool,
 
+    /// Start in plan mode: the agent investigates with read-only tools and
+    /// presents a plan via the exit_plan tool before executing. The TUI asks
+    /// for approval; headless runs and the gateway auto-approve, giving a
+    /// natural plan-then-execute turn.
+    #[arg(long)]
+    pub plan: bool,
+
     /// Time limit in hours for a sovereign-mode run.
     #[arg(long)]
     pub max_hours: Option<f64>,
@@ -221,6 +228,7 @@ mod tests {
         assert!(!cli.evolve);
         assert!(!cli.deep);
         assert!(!cli.auto);
+        assert!(!cli.plan);
         assert_eq!(cli.max_hours, None);
         assert_eq!(cli.loop_limit, None);
         assert!(!cli.continuous);
@@ -249,6 +257,7 @@ mod tests {
             "-p",
             "add tests",
             "--auto",
+            "--plan",
             "--max-hours",
             "1.5",
             "--loop",
@@ -264,6 +273,7 @@ mod tests {
         assert_eq!(cli.mode, Some(Mode::Sovereign));
         assert_eq!(cli.prompt.as_deref(), Some("add tests"));
         assert!(cli.auto);
+        assert!(cli.plan);
         assert_eq!(cli.max_hours, Some(1.5));
         assert_eq!(cli.loop_limit, Some(10));
         assert!(cli.continuous);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,13 @@ pub struct Cli {
     #[arg(long)]
     pub continuous: bool,
 
+    /// Output format for headless (sovereign `-p`) runs: `text` streams
+    /// human-readable output (default), `json` emits one final JSON summary
+    /// object, `stream-json` emits one JSON object per line as events
+    /// arrive. Ignored by the TUI and the gateway.
+    #[arg(long, value_enum, default_value_t)]
+    pub output_format: crate::output::OutputFormat,
+
     /// Project root override (defaults to the current directory).
     #[arg(long)]
     pub cwd: Option<PathBuf>,
@@ -232,6 +239,7 @@ mod tests {
         assert_eq!(cli.max_hours, None);
         assert_eq!(cli.loop_limit, None);
         assert!(!cli.continuous);
+        assert_eq!(cli.output_format, crate::output::OutputFormat::Text);
         assert_eq!(cli.cwd, None);
         assert!(!cli.resume);
         assert!(!cli.onboard);
@@ -307,6 +315,21 @@ mod tests {
     fn deep_requires_evolve() {
         let err = parse(&["--deep"]).expect_err("--deep alone must be rejected");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn output_format_parses_all_values() {
+        use crate::output::OutputFormat;
+        for (raw, expected) in [
+            ("text", OutputFormat::Text),
+            ("json", OutputFormat::Json),
+            ("stream-json", OutputFormat::StreamJson),
+        ] {
+            let cli = parse(&["--output-format", raw]).expect("format parses");
+            assert_eq!(cli.output_format, expected);
+        }
+        let err = parse(&["--output-format", "yaml"]).expect_err("unknown format rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,9 +34,9 @@ pub struct Cli {
     #[arg(long)]
     pub publish: bool,
 
-    /// Force auto-approve for this run (already the default; useful when
-    /// config has `auto_approve = false` to restore bypass behavior).
-    #[arg(long)]
+    /// Deprecated: approval gating was removed and every tool call executes
+    /// directly. Accepted for compatibility and ignored.
+    #[arg(long, hide = true)]
     pub auto: bool,
 
     /// Time limit in hours for a sovereign-mode run.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,11 @@ pub enum Command {
         #[command(subcommand)]
         cmd: BenchCmd,
     },
+
+    /// Diagnose the environment: config, providers, MCP servers, tools,
+    /// hooks, writable state dirs, checkpoints. Exits 0 when no check
+    /// failed.
+    Doctor,
 }
 
 /// `wizard bench` subcommands. Self-contained: no flag here depends on the
@@ -336,6 +341,12 @@ mod tests {
     fn rejects_unknown_mode() {
         let err = parse(&["--mode", "warlock"]).expect_err("unknown mode must be rejected");
         assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn doctor_parses_as_a_subcommand() {
+        let cli = parse(&["doctor"]).expect("doctor parses");
+        assert!(matches!(cli.command, Some(Command::Doctor)));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,40 @@ pub enum Command {
     /// wizard child processes. Daemonize externally (e.g. systemd); see
     /// docs/scheduler.md.
     Scheduler,
+
+    /// Fleet mode: decompose a mission into independent tasks and run them
+    /// as parallel headless workers, each in its own git worktree, then
+    /// merge the fleet branches back. See docs/fleet.md.
+    Fleet {
+        #[command(subcommand)]
+        cmd: FleetCmd,
+    },
+}
+
+/// `wizard fleet` subcommands. `run` loads config (the coordinator drives a
+/// real agent for planning and synthesis); `status` and `stop` only touch
+/// the project's `.wizard/fleet/` directory.
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum FleetCmd {
+    /// Plan the mission, spawn up to N parallel workers over git worktrees,
+    /// supervise them, then synthesize (merge the fleet branches).
+    Run {
+        /// Number of parallel workers.
+        #[arg(short = 'n', long = "workers", value_name = "N")]
+        n: usize,
+
+        /// Mission prompt, decomposed into independent tasks by a planning
+        /// turn.
+        #[arg(short, long)]
+        prompt: String,
+    },
+
+    /// Show the fleet state: mission, status, and a per-task table.
+    Status,
+
+    /// Ask a running fleet to wind down (writes the stop sentinel; the
+    /// coordinator kills its workers on the next supervision tick).
+    Stop,
 }
 
 /// `wizard schedule` subcommands. Like bench, these are self-contained:
@@ -487,6 +521,55 @@ mod tests {
             panic!("expected schedule run");
         };
         assert_eq!(name, "nightly");
+    }
+
+    #[test]
+    fn fleet_run_parses_workers_and_prompt() {
+        let cli = parse(&["fleet", "run", "-n", "3", "-p", "improve coverage"])
+            .expect("fleet run parses");
+        let Some(Command::Fleet {
+            cmd: FleetCmd::Run { n, prompt },
+        }) = cli.command
+        else {
+            panic!("expected fleet run");
+        };
+        assert_eq!(n, 3);
+        assert_eq!(prompt, "improve coverage");
+
+        let cli =
+            parse(&["fleet", "run", "--workers", "2", "--prompt", "x"]).expect("long forms parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fleet {
+                cmd: FleetCmd::Run { n: 2, .. }
+            })
+        ));
+    }
+
+    #[test]
+    fn fleet_run_requires_workers_and_prompt() {
+        let err = parse(&["fleet", "run", "-p", "x"]).expect_err("missing -n rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        let err = parse(&["fleet", "run", "-n", "2"]).expect_err("missing -p rejected");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn fleet_status_and_stop_parse() {
+        let cli = parse(&["fleet", "status"]).expect("fleet status parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fleet {
+                cmd: FleetCmd::Status
+            })
+        ));
+        let cli = parse(&["fleet", "stop"]).expect("fleet stop parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fleet {
+                cmd: FleetCmd::Stop
+            })
+        ));
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,505 @@
+//! Custom slash commands and `@file` references.
+//!
+//! Custom commands are markdown files in `~/.wizard/commands/` and
+//! `<project>/.wizard/commands/` (project files shadow global ones on a name
+//! collision). The file stem is the command name; an optional `---`-fenced
+//! frontmatter block (the same convention as skills) may carry a
+//! `description` shown in the TUI suggestion popup. The body is a prompt
+//! template: `$ARGUMENTS` expands to everything typed after the command name
+//! and `$1`..`$9` to the whitespace-split positional arguments (missing
+//! positions expand to the empty string).
+//!
+//! `@path` tokens in user input expand to the referenced file's contents in a
+//! fenced code block. Both the TUI (`App::submit`) and headless `-p` runs go
+//! through the same [`preprocess`] pipeline, so a prompt behaves identically
+//! on every surface.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+
+/// One loaded custom command.
+#[derive(Debug, Clone)]
+pub struct CustomCommand {
+    /// Command name (the file stem): `/name` invokes it.
+    pub name: String,
+    /// Frontmatter `description`, shown in the suggestion popup.
+    pub description: Option<String>,
+    /// Prompt template with `$ARGUMENTS` / `$1`..`$9` placeholders.
+    pub template: String,
+    /// File it was loaded from.
+    pub path: PathBuf,
+}
+
+impl CustomCommand {
+    /// Whether the template references any argument placeholder — drives the
+    /// `[args]` hint and Enter-to-complete behavior in the TUI.
+    pub fn expects_args(&self) -> bool {
+        let bytes = self.template.as_bytes();
+        self.template.match_indices('$').any(|(i, _)| {
+            let rest = &bytes[i + 1..];
+            rest.starts_with(b"ARGUMENTS")
+                || rest.first().is_some_and(|b| (b'1'..=b'9').contains(b))
+        })
+    }
+}
+
+/// Load custom commands from the canonical roots: `~/.wizard/commands/`,
+/// then `<project>/.wizard/commands/` (project shadows global).
+pub fn load(project_root: &Path) -> Vec<CustomCommand> {
+    let mut dirs = Vec::new();
+    match Config::wizard_dir() {
+        Ok(dir) => dirs.push(dir.join("commands")),
+        Err(err) => tracing::warn!("could not resolve ~/.wizard for commands: {err}"),
+    }
+    dirs.push(project_root.join(".wizard").join("commands"));
+    load_from_dirs(&dirs)
+}
+
+/// Load `*.md` commands from `dirs` in order; later directories shadow
+/// earlier ones on a name collision. Missing directories are skipped;
+/// unreadable files are logged and skipped. The result is sorted by name.
+pub fn load_from_dirs(dirs: &[PathBuf]) -> Vec<CustomCommand> {
+    let mut by_name: std::collections::BTreeMap<String, CustomCommand> =
+        std::collections::BTreeMap::new();
+    for dir in dirs {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                tracing::warn!("could not read {}: {err}", dir.display());
+                continue;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let raw = match std::fs::read_to_string(&path) {
+                Ok(raw) => raw,
+                Err(err) => {
+                    tracing::warn!("could not read {}: {err}", path.display());
+                    continue;
+                }
+            };
+            let (meta, body) = crate::skills::split_frontmatter(&raw);
+            by_name.insert(
+                name.to_string(),
+                CustomCommand {
+                    name: name.to_string(),
+                    description: meta.description,
+                    template: body,
+                    path,
+                },
+            );
+        }
+    }
+    by_name.into_values().collect()
+}
+
+/// Expand `$ARGUMENTS` and `$1`..`$9` in `template`. A single pass over the
+/// template, so placeholder-like text inside the arguments themselves is
+/// never re-expanded.
+pub fn expand_template(template: &str, args: &str) -> String {
+    let args = args.trim();
+    let positional: Vec<&str> = args.split_whitespace().collect();
+    let mut out = String::with_capacity(template.len() + args.len());
+    let mut rest = template;
+    while let Some(at) = rest.find('$') {
+        out.push_str(&rest[..at]);
+        let after = &rest[at + 1..];
+        if let Some(tail) = after.strip_prefix("ARGUMENTS") {
+            out.push_str(args);
+            rest = tail;
+        } else if let Some(digit) = after.chars().next().filter(|c| ('1'..='9').contains(c)) {
+            let index = digit as usize - '1' as usize;
+            if let Some(arg) = positional.get(index) {
+                out.push_str(arg);
+            }
+            rest = &after[1..];
+        } else {
+            out.push('$');
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// If `input` is `/name [args...]` for one of `commands`, expand its
+/// template. `None` when the input is not a custom-command invocation.
+pub fn expand_custom(input: &str, commands: &[CustomCommand]) -> Option<String> {
+    let rest = input.trim().strip_prefix('/')?;
+    let (name, args) = rest.split_once(char::is_whitespace).unwrap_or((rest, ""));
+    let command = commands.iter().find(|command| command.name == name)?;
+    Some(expand_template(&command.template, args))
+}
+
+/// Byte cap applied to one `@file` expansion.
+pub const MAX_FILE_REF_BYTES: usize = 50_000;
+
+/// Extensions treated as images. Wizard has no vision path yet, so these
+/// expand to a note instead of file contents.
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp"];
+
+/// Expand `@path` tokens in `input` to fenced code blocks with the file's
+/// contents (capped at [`MAX_FILE_REF_BYTES`], with a truncation note).
+///
+/// A token expands only when `@` starts a whitespace-delimited token and the
+/// rest resolves to an existing file (relative to `project_root`, absolute,
+/// or `~/`-prefixed). Everything else — `@@escaped` tokens, email-like
+/// `user@host`, `@missing-paths` — passes through unchanged. Image files
+/// become a note: there is no vision path to attach them to.
+pub fn expand_file_refs(input: &str, project_root: &Path) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while !rest.is_empty() {
+        // Copy leading whitespace verbatim, then take one token.
+        let token_start = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..token_start]);
+        rest = &rest[token_start..];
+        if rest.is_empty() {
+            break;
+        }
+        let token_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let token = &rest[..token_end];
+        match expand_token(token, project_root) {
+            Some(expanded) => out.push_str(&expanded),
+            None => out.push_str(token),
+        }
+        rest = &rest[token_end..];
+    }
+    out
+}
+
+/// Expand one whitespace-delimited token, or `None` to pass it through.
+fn expand_token(token: &str, project_root: &Path) -> Option<String> {
+    let path_part = token.strip_prefix('@')?;
+    // `@@path` is the escape hatch and a lone `@` is not a reference.
+    if path_part.is_empty() || path_part.starts_with('@') {
+        return None;
+    }
+    let path = resolve(path_part, project_root);
+    if !path.is_file() {
+        return None;
+    }
+    let extension = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if extension.is_some_and(|ext| IMAGE_EXTENSIONS.contains(&ext.as_str())) {
+        return Some(format!(
+            "[image {path_part} could not be attached: this build has no vision support]"
+        ));
+    }
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        // Unreadable / non-UTF-8: leave the token for the model to act on.
+        Err(_) => return None,
+    };
+    let (content, truncated) = cap_bytes(&raw, MAX_FILE_REF_BYTES);
+    let fence = fence_for(content);
+    let mut block = format!("{fence}{path_part}\n{content}");
+    if !content.ends_with('\n') {
+        block.push('\n');
+    }
+    if truncated {
+        block.push_str("… [truncated at 50KB]\n");
+    }
+    block.push_str(&fence);
+    Some(block)
+}
+
+/// Resolve a `@`-reference against the project root, expanding a leading `~`.
+fn resolve(path: &str, project_root: &Path) -> PathBuf {
+    let expanded = shellexpand::tilde(path);
+    let candidate = Path::new(expanded.as_ref());
+    if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        project_root.join(candidate)
+    }
+}
+
+/// Truncate to at most `max` bytes on a char boundary. Returns the slice and
+/// whether anything was dropped.
+fn cap_bytes(raw: &str, max: usize) -> (&str, bool) {
+    if raw.len() <= max {
+        return (raw, false);
+    }
+    let mut cut = max;
+    while cut > 0 && !raw.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    (&raw[..cut], true)
+}
+
+/// A backtick fence one longer than the longest run inside `content`
+/// (minimum three), so embedded fences cannot break the block.
+fn fence_for(content: &str) -> String {
+    let mut longest = 0usize;
+    let mut run = 0usize;
+    for c in content.chars() {
+        if c == '`' {
+            run += 1;
+            longest = longest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    "`".repeat((longest + 1).max(3))
+}
+
+/// The one shared preprocessing pipeline for user prompts: expand a custom
+/// `/command` invocation (when `input` is one), then `@file` references.
+/// Used by both the TUI submit path and headless `-p` runs.
+pub fn preprocess(input: &str, commands: &[CustomCommand], project_root: &Path) -> String {
+    let expanded = expand_custom(input, commands).unwrap_or_else(|| input.to_string());
+    expand_file_refs(&expanded, project_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    // --- loading ---
+
+    #[test]
+    fn loads_commands_from_md_files_with_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(
+            &dir,
+            "review.md",
+            "---\ndescription: review the diff\n---\nReview this: $ARGUMENTS",
+        );
+        write(&dir, "notes.txt", "not a command");
+        let commands = load_from_dirs(&[dir]);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "review");
+        assert_eq!(commands[0].description.as_deref(), Some("review the diff"));
+        assert_eq!(commands[0].template, "Review this: $ARGUMENTS");
+        assert!(commands[0].expects_args());
+    }
+
+    #[test]
+    fn command_without_frontmatter_has_no_description() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("commands");
+        write(&dir, "ship.md", "Commit and push everything.");
+        let commands = load_from_dirs(&[dir]);
+        assert_eq!(commands[0].name, "ship");
+        assert_eq!(commands[0].description, None);
+        assert!(!commands[0].expects_args());
+    }
+
+    #[test]
+    fn project_commands_shadow_global_on_name_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global");
+        let project = tmp.path().join("project");
+        write(&global, "deploy.md", "global deploy");
+        write(&global, "lint.md", "global lint");
+        write(&project, "deploy.md", "project deploy");
+        let commands = load_from_dirs(&[global, project]);
+        assert_eq!(commands.len(), 2);
+        let deploy = commands.iter().find(|c| c.name == "deploy").unwrap();
+        assert_eq!(deploy.template, "project deploy");
+        assert!(commands.iter().any(|c| c.name == "lint"));
+    }
+
+    #[test]
+    fn missing_directories_load_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let commands = load_from_dirs(&[tmp.path().join("absent")]);
+        assert!(commands.is_empty());
+    }
+
+    // --- template expansion ---
+
+    #[test]
+    fn arguments_placeholder_takes_everything_after_the_name() {
+        assert_eq!(
+            expand_template("Fix: $ARGUMENTS", "the login bug now"),
+            "Fix: the login bug now"
+        );
+    }
+
+    #[test]
+    fn positional_placeholders_split_on_whitespace() {
+        assert_eq!(
+            expand_template("from $1 to $2 ($ARGUMENTS)", "main release"),
+            "from main to release (main release)"
+        );
+    }
+
+    #[test]
+    fn missing_positionals_expand_to_empty() {
+        assert_eq!(expand_template("a=$1 b=$2 c=$3", "only"), "a=only b= c=");
+    }
+
+    #[test]
+    fn dollar_in_arguments_is_not_reexpanded() {
+        assert_eq!(expand_template("run $1", "$2"), "run $2");
+        assert_eq!(
+            expand_template("say $ARGUMENTS", "$1 literal"),
+            "say $1 literal"
+        );
+    }
+
+    #[test]
+    fn bare_dollar_and_unknown_placeholders_pass_through() {
+        assert_eq!(
+            expand_template("price $0 and $x end$", "y"),
+            "price $0 and $x end$"
+        );
+    }
+
+    #[test]
+    fn expand_custom_matches_by_name() {
+        let commands = vec![CustomCommand {
+            name: "review".into(),
+            description: None,
+            template: "Review $ARGUMENTS carefully.".into(),
+            path: PathBuf::new(),
+        }];
+        assert_eq!(
+            expand_custom("/review src/app.rs", &commands).as_deref(),
+            Some("Review src/app.rs carefully.")
+        );
+        assert_eq!(expand_custom("/other x", &commands), None);
+        assert_eq!(expand_custom("not a command", &commands), None);
+    }
+
+    // --- @file references ---
+
+    #[test]
+    fn existing_file_expands_to_a_fenced_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("notes.md"), "hello world\n").unwrap();
+        let out = expand_file_refs("see @notes.md please", tmp.path());
+        assert_eq!(out, "see ```notes.md\nhello world\n``` please");
+    }
+
+    #[test]
+    fn missing_file_token_passes_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = expand_file_refs("see @missing.md please", tmp.path());
+        assert_eq!(out, "see @missing.md please");
+    }
+
+    #[test]
+    fn double_at_escapes_and_emails_pass_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("real.md"), "x").unwrap();
+        let out = expand_file_refs("@@real.md and user@host.com and a lone @", tmp.path());
+        assert_eq!(out, "@@real.md and user@host.com and a lone @");
+    }
+
+    #[test]
+    fn oversized_file_is_capped_with_a_truncation_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        let big = "x".repeat(MAX_FILE_REF_BYTES + 1000);
+        std::fs::write(tmp.path().join("big.txt"), &big).unwrap();
+        let out = expand_file_refs("@big.txt", tmp.path());
+        assert!(out.contains("… [truncated at 50KB]"));
+        assert!(out.len() < big.len() + 200);
+    }
+
+    #[test]
+    fn tilde_paths_resolve_against_home() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let name = format!("wizard-atref-test-{}.txt", std::process::id());
+        let path = home.join(&name);
+        std::fs::write(&path, "tilde ok").unwrap();
+        let out = expand_file_refs(&format!("@~/{name}"), Path::new("/nonexistent-root"));
+        std::fs::remove_file(&path).unwrap();
+        assert!(out.contains("tilde ok"), "got: {out}");
+    }
+
+    #[test]
+    fn absolute_paths_resolve_as_is() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("abs.txt");
+        std::fs::write(&file, "absolute").unwrap();
+        let input = format!("@{}", file.display());
+        let out = expand_file_refs(&input, Path::new("/elsewhere"));
+        assert!(out.contains("absolute"));
+    }
+
+    #[test]
+    fn image_extensions_become_a_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("shot.png"), [0x89u8, b'P']).unwrap();
+        let out = expand_file_refs("look at @shot.png", tmp.path());
+        assert_eq!(
+            out,
+            "look at [image shot.png could not be attached: this build has no vision support]"
+        );
+    }
+
+    #[test]
+    fn directories_pass_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("subdir")).unwrap();
+        let out = expand_file_refs("@subdir", tmp.path());
+        assert_eq!(out, "@subdir");
+    }
+
+    #[test]
+    fn embedded_fences_get_a_longer_fence() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("doc.md"), "```rust\ncode\n```\n").unwrap();
+        let out = expand_file_refs("@doc.md", tmp.path());
+        assert!(out.starts_with("````doc.md\n"), "got: {out}");
+        assert!(out.ends_with("````"), "got: {out}");
+    }
+
+    #[test]
+    fn multiline_input_preserves_whitespace() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("f.txt"), "F").unwrap();
+        let out = expand_file_refs("line one\n  @f.txt\nline three", tmp.path());
+        assert_eq!(out, "line one\n  ```f.txt\nF\n```\nline three");
+    }
+
+    // --- the shared pipeline ---
+
+    #[test]
+    fn preprocess_expands_commands_then_file_refs() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("ctx.txt"), "context").unwrap();
+        let commands = vec![CustomCommand {
+            name: "with-ctx".into(),
+            description: None,
+            template: "Use @ctx.txt for $ARGUMENTS".into(),
+            path: PathBuf::new(),
+        }];
+        let out = preprocess("/with-ctx the task", &commands, tmp.path());
+        assert!(out.contains("context"), "got: {out}");
+        assert!(out.ends_with("for the task"), "got: {out}");
+    }
+
+    #[test]
+    fn preprocess_passes_plain_prompts_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            preprocess("just a prompt", &[], tmp.path()),
+            "just a prompt"
+        );
+        assert_eq!(preprocess("/unknown cmd", &[], tmp.path()), "/unknown cmd");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,29 @@ impl Default for CheckpointConfig {
     }
 }
 
+/// Fleet-mode settings (`[fleet]` in `config.toml`); see `wizard fleet`
+/// and docs/fleet.md.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FleetConfig {
+    /// Per-worker wall-clock cap in minutes; the coordinator kills a child
+    /// past this (default 30).
+    pub max_minutes: u64,
+    /// Run the synthesis turn (an in-process agent merges the fleet
+    /// branches) once all workers finish. `false` skips the merge and just
+    /// prints the branch list and results table (default true).
+    pub synthesize: bool,
+}
+
+impl Default for FleetConfig {
+    fn default() -> Self {
+        Self {
+            max_minutes: 30,
+            synthesize: true,
+        }
+    }
+}
+
 /// A named LLM provider. Cloud keys are never stored here — only the name of
 /// the environment variable holding the key (`api_key_env`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -460,6 +483,9 @@ pub struct Config {
     /// Per-file checkpoint settings (snapshots powering `/rewind`).
     #[serde(default)]
     pub checkpoints: CheckpointConfig,
+    /// Fleet-mode settings (`wizard fleet`).
+    #[serde(default)]
+    pub fleet: FleetConfig,
 }
 
 impl Default for Config {
@@ -486,6 +512,7 @@ impl Default for Config {
             ui: UiConfig::default(),
             web: WebConfig::default(),
             checkpoints: CheckpointConfig::default(),
+            fleet: FleetConfig::default(),
         }
     }
 }
@@ -754,6 +781,8 @@ mod tests {
         assert_eq!(config.compact_threshold_bytes, 48_000);
         assert!(!config.rollback_failed_cycles);
         assert_eq!(config.checkpoints.keep_turns, 50);
+        assert_eq!(config.fleet.max_minutes, 30);
+        assert!(config.fleet.synthesize);
     }
 
     #[test]
@@ -762,6 +791,18 @@ mod tests {
         assert_eq!(config.checkpoints.keep_turns, 7);
         let config: Config = toml::from_str("rollback_failed_cycles = true").expect("valid toml");
         assert!(config.rollback_failed_cycles);
+    }
+
+    #[test]
+    fn fleet_section_parses_with_partial_keys() {
+        let config: Config =
+            toml::from_str("[fleet]\nmax_minutes = 10\nsynthesize = false").expect("valid toml");
+        assert_eq!(config.fleet.max_minutes, 10);
+        assert!(!config.fleet.synthesize);
+
+        let config: Config = toml::from_str("[fleet]\nmax_minutes = 90").expect("valid toml");
+        assert_eq!(config.fleet.max_minutes, 90);
+        assert!(config.fleet.synthesize, "missing key takes the default");
     }
 
     #[test]
@@ -827,6 +868,10 @@ mod tests {
                 search_api_key_env: Some("BRAVE_API_KEY".to_string()),
             },
             checkpoints: CheckpointConfig { keep_turns: 12 },
+            fleet: FleetConfig {
+                max_minutes: 45,
+                synthesize: false,
+            },
         };
         let raw = toml::to_string_pretty(&original).expect("serialize");
         let parsed: Config = toml::from_str(&raw).expect("parse back");
@@ -864,6 +909,7 @@ mod tests {
             original.rollback_failed_cycles
         );
         assert_eq!(parsed.checkpoints, original.checkpoints);
+        assert_eq!(parsed.fleet, original.fleet);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,6 +548,12 @@ impl Config {
         Ok(Self::wizard_dir()?.join("logs"))
     }
 
+    /// `~/.wizard/schedule.toml` — cron schedule entries
+    /// (`crate::schedule`).
+    pub fn schedule_path() -> Result<PathBuf> {
+        Ok(Self::wizard_dir()?.join("schedule.toml"))
+    }
+
     /// Create the `~/.wizard` directory tree (sessions, tools, skills, logs)
     /// if it does not exist yet. Idempotent; called on every load so a fresh
     /// install is usable without running the installer.

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,9 +349,10 @@ pub struct Config {
     pub gguf_path: Option<String>,
     /// Default personality mode.
     pub mode: Mode,
-    /// Bypass per-action confirmation prompts. Default true: genie bypasses
-    /// permissions. Set false to restore the y/n gate for tools that request
-    /// approval.
+    /// Deprecated: approval gating was removed and every tool call executes
+    /// directly. Still parsed so old config files load; ignored (a startup
+    /// warning is printed when set to `false`) and never written back.
+    #[serde(skip_serializing)]
     pub auto_approve: bool,
     /// Agent loop limit per turn (genie). Sovereign uses its own default
     /// unless this is explicitly raised above it.
@@ -617,8 +618,8 @@ impl Config {
     }
 
     /// Apply CLI flag overrides on top of file/env config for this run.
-    /// CLI mode wins; `--auto` forces `auto_approve`; sovereign mode raises
-    /// `max_steps` to its default if the configured value is lower.
+    /// CLI mode wins; sovereign mode raises `max_steps` to its default if
+    /// the configured value is lower.
     pub fn apply_cli(&mut self, cli: &Cli) {
         if let Some(mode) = cli.mode {
             self.mode = mode;
@@ -626,9 +627,6 @@ impl Config {
         if cli.continuous {
             self.mode = Mode::Sovereign;
             self.continuous = true;
-        }
-        if cli.auto || self.mode == Mode::Sovereign {
-            self.auto_approve = true;
         }
         if self.mode == Mode::Sovereign && self.max_steps < Mode::Sovereign.default_max_steps() {
             self.max_steps = Mode::Sovereign.default_max_steps();
@@ -655,7 +653,6 @@ mod tests {
         assert_eq!(config.llamacpp_host, "http://127.0.0.1:8080");
         assert!(config.gguf_path.is_none());
         assert_eq!(config.mode, Mode::Genie);
-        assert!(config.auto_approve);
         assert_eq!(config.max_steps, 25);
         assert!(!config.continuous);
         assert_eq!(config.retry_base_secs, 5);
@@ -723,7 +720,6 @@ mod tests {
         assert_eq!(parsed.llamacpp_host, original.llamacpp_host);
         assert_eq!(parsed.gguf_path, original.gguf_path);
         assert_eq!(parsed.mode, original.mode);
-        assert_eq!(parsed.auto_approve, original.auto_approve);
         assert_eq!(parsed.max_steps, original.max_steps);
         assert_eq!(parsed.continuous, original.continuous);
         assert_eq!(parsed.retry_base_secs, original.retry_base_secs);
@@ -1155,7 +1151,6 @@ mod tests {
         let mut config = Config::default();
         config.apply_cli(&cli(&["--mode", "sovereign"]));
         assert_eq!(config.mode, Mode::Sovereign);
-        assert!(config.auto_approve, "sovereign implies auto-approve");
         assert_eq!(config.max_steps, 100, "sovereign raises the step budget");
     }
 
@@ -1165,7 +1160,6 @@ mod tests {
         config.apply_cli(&cli(&["--continuous"]));
         assert_eq!(config.mode, Mode::Sovereign);
         assert!(config.continuous);
-        assert!(config.auto_approve);
         assert_eq!(config.max_steps, 100);
     }
 
@@ -1180,15 +1174,22 @@ mod tests {
     }
 
     #[test]
-    fn auto_flag_forces_auto_approve_in_genie() {
-        let mut config = Config {
-            auto_approve: false, // start from the opt-in gated posture
-            ..Config::default()
-        };
+    fn deprecated_auto_flag_is_accepted_and_ignored() {
+        let mut config = Config::default();
         config.apply_cli(&cli(&["--auto"]));
         assert_eq!(config.mode, Mode::Genie);
-        assert!(config.auto_approve);
         assert_eq!(config.max_steps, 25, "genie keeps its budget");
+    }
+
+    #[test]
+    fn deprecated_auto_approve_key_still_parses_and_is_not_written_back() {
+        let config: Config = toml::from_str("auto_approve = false").expect("old key parses");
+        assert!(!config.auto_approve);
+        let raw = toml::to_string_pretty(&config).expect("serialize");
+        assert!(
+            !raw.contains("auto_approve"),
+            "deprecated key is not written back: {raw}"
+        );
     }
 
     #[test]
@@ -1196,18 +1197,16 @@ mod tests {
         let mut config = Config::default();
         config.apply_cli(&cli(&[]));
         assert_eq!(config.mode, Mode::Genie);
-        assert!(config.auto_approve);
         assert_eq!(config.max_steps, 25);
     }
 
     #[test]
-    fn config_sovereign_mode_implies_auto_approve_without_flags() {
+    fn config_sovereign_mode_raises_max_steps_without_flags() {
         let mut config = Config {
             mode: Mode::Sovereign,
             ..Config::default()
         };
         config.apply_cli(&cli(&[]));
-        assert!(config.auto_approve);
         assert_eq!(config.max_steps, 100);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,6 +230,13 @@ pub struct ProviderConfig {
     /// `llama-server` itself.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gguf_path: Option<String>,
+    /// Optional input-token price in USD per million tokens, for `/cost`
+    /// estimates. Unset = no cost computed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd_per_mtok_in: Option<f64>,
+    /// Optional output-token price in USD per million tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd_per_mtok_out: Option<f64>,
 }
 
 impl ProviderConfig {
@@ -546,6 +553,8 @@ impl Config {
             model: self.model.clone(),
             api_key_env: None,
             gguf_path: self.gguf_path.clone(),
+            usd_per_mtok_in: None,
+            usd_per_mtok_out: None,
         }
     }
 
@@ -718,6 +727,8 @@ mod tests {
                 model: "gpt-4o".to_string(),
                 api_key_env: Some("OPENAI_API_KEY".to_string()),
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             }],
             active_provider: Some("openai".to_string()),
             gateway: GatewayConfig {
@@ -877,6 +888,8 @@ mod tests {
                 model: "qwen3-8b".to_string(),
                 api_key_env: None,
                 gguf_path: Some("/home/u/.wizard/models/qwen3-8b-q4_k_m.gguf".to_string()),
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             }],
             active_provider: Some("local".to_string()),
             ..Config::default()
@@ -905,6 +918,8 @@ mod tests {
                     model: "grok-4.3".to_string(),
                     api_key_env: Some("XAI_API_KEY".to_string()),
                     gguf_path: None,
+                    usd_per_mtok_in: None,
+                    usd_per_mtok_out: None,
                 },
                 ProviderConfig {
                     name: "xai-account".to_string(),
@@ -913,6 +928,8 @@ mod tests {
                     model: "grok-4.3".to_string(),
                     api_key_env: None,
                     gguf_path: None,
+                    usd_per_mtok_in: None,
+                    usd_per_mtok_out: None,
                 },
             ],
             active_provider: Some("xai-account".to_string()),
@@ -943,6 +960,8 @@ mod tests {
                 model: "openrouter/auto".to_string(),
                 api_key_env: Some("OPENROUTER_API_KEY".to_string()),
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             }],
             active_provider: Some("openrouter".to_string()),
             ..Config::default()
@@ -957,6 +976,35 @@ mod tests {
             Some("OPENROUTER_API_KEY")
         );
         assert_eq!(parsed.active().kind, ProviderKind::OpenRouter);
+    }
+
+    #[test]
+    fn provider_cost_rates_parse_and_round_trip() {
+        let raw = "\
+[[providers]]
+name = \"claude\"
+kind = \"anthropic\"
+base_url = \"https://api.anthropic.com\"
+model = \"claude-fable-5\"
+api_key_env = \"ANTHROPIC_API_KEY\"
+usd_per_mtok_in = 3.0
+usd_per_mtok_out = 15.0
+";
+        let config: Config = toml::from_str(raw).expect("valid toml");
+        let provider = &config.providers[0];
+        assert_eq!(provider.usd_per_mtok_in, Some(3.0));
+        assert_eq!(provider.usd_per_mtok_out, Some(15.0));
+
+        let serialized = toml::to_string_pretty(&config).expect("serialize");
+        let parsed: Config = toml::from_str(&serialized).expect("parse back");
+        assert_eq!(parsed.providers[0].usd_per_mtok_in, Some(3.0));
+        assert_eq!(parsed.providers[0].usd_per_mtok_out, Some(15.0));
+
+        // Unset rates stay absent on the wire.
+        let bare: Config = toml::from_str("model = \"m\"").expect("valid toml");
+        assert_eq!(bare.active().usd_per_mtok_in, None);
+        let serialized = toml::to_string_pretty(&bare).expect("serialize");
+        assert!(!serialized.contains("usd_per_mtok"), "{serialized}");
     }
 
     #[test]
@@ -990,6 +1038,8 @@ mod tests {
                 model: "qwen3.6:27b".to_string(),
                 api_key_env: None,
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             },
             ProviderConfig {
                 name: "claude".to_string(),
@@ -998,6 +1048,8 @@ mod tests {
                 model: "claude-fable-5".to_string(),
                 api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             },
         ];
 
@@ -1037,6 +1089,8 @@ mod tests {
                 model: "gpt-4o".to_string(),
                 api_key_env: Some("OPENAI_API_KEY".to_string()),
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             }],
             active_provider: Some("openai".to_string()),
             ..Config::default()
@@ -1122,6 +1176,8 @@ mod tests {
                 model: "qwen3-8b".to_string(),
                 api_key_env: None,
                 gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
             }],
             active_provider: Some("local".to_string()),
             ..Config::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -360,6 +360,13 @@ pub struct Config {
     /// Perpetual sovereign operation: keep working/self-directing/self-improving
     /// until stopped.
     pub continuous: bool,
+    /// Start every session in plan mode (the `--plan` flag sets this for one
+    /// run): the agent investigates with read-only tools and presents a plan
+    /// via `exit_plan` before executing. Headless runs auto-approve the plan.
+    pub plan_first: bool,
+    /// Continuous mode: re-enter plan mode at the top of every cycle, so each
+    /// cycle plans read-only before acting.
+    pub plan_each_cycle: bool,
     /// Base seconds for exponential backoff when the LLM server is unreachable
     /// or rate-limited.
     pub retry_base_secs: u64,
@@ -398,6 +405,8 @@ impl Default for Config {
             auto_approve: true,
             max_steps: 25,
             continuous: false,
+            plan_first: false,
+            plan_each_cycle: false,
             retry_base_secs: 5,
             retry_max_secs: 300,
             cycle_pause_secs: 0,
@@ -628,6 +637,9 @@ impl Config {
             self.mode = Mode::Sovereign;
             self.continuous = true;
         }
+        if cli.plan {
+            self.plan_first = true;
+        }
         if self.mode == Mode::Sovereign && self.max_steps < Mode::Sovereign.default_max_steps() {
             self.max_steps = Mode::Sovereign.default_max_steps();
         }
@@ -655,6 +667,8 @@ mod tests {
         assert_eq!(config.mode, Mode::Genie);
         assert_eq!(config.max_steps, 25);
         assert!(!config.continuous);
+        assert!(!config.plan_first);
+        assert!(!config.plan_each_cycle);
         assert_eq!(config.retry_base_secs, 5);
         assert_eq!(config.retry_max_secs, 300);
         assert_eq!(config.cycle_pause_secs, 0);
@@ -691,6 +705,8 @@ mod tests {
             auto_approve: true,
             max_steps: 200,
             continuous: true,
+            plan_first: true,
+            plan_each_cycle: true,
             retry_base_secs: 10,
             retry_max_secs: 600,
             cycle_pause_secs: 30,
@@ -722,6 +738,8 @@ mod tests {
         assert_eq!(parsed.mode, original.mode);
         assert_eq!(parsed.max_steps, original.max_steps);
         assert_eq!(parsed.continuous, original.continuous);
+        assert_eq!(parsed.plan_first, original.plan_first);
+        assert_eq!(parsed.plan_each_cycle, original.plan_each_cycle);
         assert_eq!(parsed.retry_base_secs, original.retry_base_secs);
         assert_eq!(parsed.retry_max_secs, original.retry_max_secs);
         assert_eq!(parsed.cycle_pause_secs, original.cycle_pause_secs);
@@ -1152,6 +1170,24 @@ mod tests {
         config.apply_cli(&cli(&["--mode", "sovereign"]));
         assert_eq!(config.mode, Mode::Sovereign);
         assert_eq!(config.max_steps, 100, "sovereign raises the step budget");
+    }
+
+    #[test]
+    fn plan_flag_sets_plan_first() {
+        let mut config = Config::default();
+        assert!(!config.plan_first);
+        assert!(!config.plan_each_cycle);
+        config.apply_cli(&cli(&["--plan"]));
+        assert!(config.plan_first);
+        assert!(!config.plan_each_cycle, "--plan never affects cycles");
+
+        // The flag only sets, never clears, the config value.
+        let mut config = Config {
+            plan_first: true,
+            ..Config::default()
+        };
+        config.apply_cli(&cli(&[]));
+        assert!(config.plan_first);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,39 @@ fn splitmix64(seed: u64) -> u64 {
     x ^ (x >> 31)
 }
 
+/// Settings for the native web tools (`[web]` in `config.toml`): `web_fetch`
+/// response caps, the SSRF guard escape hatch, and `web_search` backend
+/// selection. Search API keys are never stored here — only the name of the
+/// environment variable holding the key (`search_api_key_env`), read at call
+/// time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WebConfig {
+    /// Byte cap on a `web_fetch` response body (default 100_000).
+    pub fetch_max_bytes: usize,
+    /// Allow fetches that resolve to localhost / private address ranges
+    /// (default false). The SSRF guard is on unless this is set.
+    pub allow_local: bool,
+    /// `web_search` backend: `"duckduckgo"` (default, no key),
+    /// `"brave"`, or `"tavily"`.
+    pub search_backend: String,
+    /// Name of the env var holding the search API key (brave/tavily); the
+    /// key itself is never persisted and is read at call time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_api_key_env: Option<String>,
+}
+
+impl Default for WebConfig {
+    fn default() -> Self {
+        Self {
+            fetch_max_bytes: 100_000,
+            allow_local: false,
+            search_backend: "duckduckgo".to_string(),
+            search_api_key_env: None,
+        }
+    }
+}
+
 /// A named LLM provider. Cloud keys are never stored here — only the name of
 /// the environment variable holding the key (`api_key_env`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -399,6 +432,9 @@ pub struct Config {
     /// Cosmetic TUI settings (spinner verbs).
     #[serde(default)]
     pub ui: UiConfig,
+    /// Native web tool settings (`web_fetch` / `web_search`).
+    #[serde(default)]
+    pub web: WebConfig,
 }
 
 impl Default for Config {
@@ -422,6 +458,7 @@ impl Default for Config {
             active_provider: None,
             gateway: GatewayConfig::default(),
             ui: UiConfig::default(),
+            web: WebConfig::default(),
         }
     }
 }
@@ -739,6 +776,12 @@ mod tests {
             ui: UiConfig {
                 spinner_verbs: vec!["Pondering".to_string(), "Musing".to_string()],
             },
+            web: WebConfig {
+                fetch_max_bytes: 250_000,
+                allow_local: true,
+                search_backend: "brave".to_string(),
+                search_api_key_env: Some("BRAVE_API_KEY".to_string()),
+            },
         };
         let raw = toml::to_string_pretty(&original).expect("serialize");
         let parsed: Config = toml::from_str(&raw).expect("parse back");
@@ -770,6 +813,31 @@ mod tests {
         assert_eq!(parsed.gateway.token_env.as_deref(), Some("MY_BOT_TOKEN"));
         assert_eq!(parsed.gateway.allowed_chat_ids, vec![42, -100123]);
         assert_eq!(parsed.ui, original.ui);
+        assert_eq!(parsed.web, original.web);
+    }
+
+    #[test]
+    fn web_defaults_when_section_missing() {
+        let config: Config = toml::from_str("model = \"m\"").expect("valid toml");
+        assert_eq!(config.web, WebConfig::default());
+        assert_eq!(config.web.fetch_max_bytes, 100_000);
+        assert!(!config.web.allow_local);
+        assert_eq!(config.web.search_backend, "duckduckgo");
+        assert!(config.web.search_api_key_env.is_none());
+    }
+
+    #[test]
+    fn web_section_parses_partial_keys() {
+        let config: Config = toml::from_str(
+            "[web]\nsearch_backend = \"tavily\"\nsearch_api_key_env = \"TAVILY_API_KEY\"",
+        )
+        .expect("valid toml");
+        assert_eq!(config.web.search_backend, "tavily");
+        assert_eq!(
+            config.web.search_api_key_env.as_deref(),
+            Some("TAVILY_API_KEY")
+        );
+        assert_eq!(config.web.fetch_max_bytes, 100_000, "missing keys default");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,24 @@ impl Default for WebConfig {
     }
 }
 
+/// Per-file checkpoint settings (`[checkpoints]` in `config.toml`).
+/// Snapshots of files edited by Wizard land under
+/// `<project>/.wizard/checkpoints/` and power `/rewind` and the perpetual
+/// `rollback_failed_cycles` option.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CheckpointConfig {
+    /// Number of most recent turns whose snapshots are kept; older turns are
+    /// garbage-collected at session start (default 50).
+    pub keep_turns: usize,
+}
+
+impl Default for CheckpointConfig {
+    fn default() -> Self {
+        Self { keep_turns: 50 }
+    }
+}
+
 /// A named LLM provider. Cloud keys are never stored here — only the name of
 /// the environment variable holding the key (`api_key_env`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -407,6 +425,10 @@ pub struct Config {
     /// Continuous mode: re-enter plan mode at the top of every cycle, so each
     /// cycle plans read-only before acting.
     pub plan_each_cycle: bool,
+    /// Continuous mode: when a cycle ends in a circuit breaker or a hard
+    /// error, restore that cycle's file checkpoints before moving on (the
+    /// rollback is noted in `mission.toml`). Default false.
+    pub rollback_failed_cycles: bool,
     /// Base seconds for exponential backoff when the LLM server is unreachable
     /// or rate-limited.
     pub retry_base_secs: u64,
@@ -435,6 +457,9 @@ pub struct Config {
     /// Native web tool settings (`web_fetch` / `web_search`).
     #[serde(default)]
     pub web: WebConfig,
+    /// Per-file checkpoint settings (snapshots powering `/rewind`).
+    #[serde(default)]
+    pub checkpoints: CheckpointConfig,
 }
 
 impl Default for Config {
@@ -450,6 +475,7 @@ impl Default for Config {
             continuous: false,
             plan_first: false,
             plan_each_cycle: false,
+            rollback_failed_cycles: false,
             retry_base_secs: 5,
             retry_max_secs: 300,
             cycle_pause_secs: 0,
@@ -459,6 +485,7 @@ impl Default for Config {
             gateway: GatewayConfig::default(),
             ui: UiConfig::default(),
             web: WebConfig::default(),
+            checkpoints: CheckpointConfig::default(),
         }
     }
 }
@@ -719,6 +746,16 @@ mod tests {
         assert_eq!(config.retry_max_secs, 300);
         assert_eq!(config.cycle_pause_secs, 0);
         assert_eq!(config.compact_threshold_bytes, 48_000);
+        assert!(!config.rollback_failed_cycles);
+        assert_eq!(config.checkpoints.keep_turns, 50);
+    }
+
+    #[test]
+    fn checkpoints_section_parses() {
+        let config: Config = toml::from_str("[checkpoints]\nkeep_turns = 7").expect("valid toml");
+        assert_eq!(config.checkpoints.keep_turns, 7);
+        let config: Config = toml::from_str("rollback_failed_cycles = true").expect("valid toml");
+        assert!(config.rollback_failed_cycles);
     }
 
     #[test]
@@ -753,6 +790,7 @@ mod tests {
             continuous: true,
             plan_first: true,
             plan_each_cycle: true,
+            rollback_failed_cycles: true,
             retry_base_secs: 10,
             retry_max_secs: 600,
             cycle_pause_secs: 30,
@@ -782,6 +820,7 @@ mod tests {
                 search_backend: "brave".to_string(),
                 search_api_key_env: Some("BRAVE_API_KEY".to_string()),
             },
+            checkpoints: CheckpointConfig { keep_turns: 12 },
         };
         let raw = toml::to_string_pretty(&original).expect("serialize");
         let parsed: Config = toml::from_str(&raw).expect("parse back");
@@ -814,6 +853,11 @@ mod tests {
         assert_eq!(parsed.gateway.allowed_chat_ids, vec![42, -100123]);
         assert_eq!(parsed.ui, original.ui);
         assert_eq!(parsed.web, original.web);
+        assert_eq!(
+            parsed.rollback_failed_cycles,
+            original.rollback_failed_cycles
+        );
+        assert_eq!(parsed.checkpoints, original.checkpoints);
     }
 
     #[test]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,15 +1,20 @@
 //! Tool-call dispatch pipeline.
 //!
 //! Every tool call in every mode (TUI, headless, gateway) funnels through
-//! [`Dispatcher::dispatch`]. The pipeline runs in stages so upcoming
-//! features slot in between them, in order: plan-mode gate → pre-tool hooks
-//! → checkpoint snapshot → execute → post-tool hooks → failure bookkeeping.
+//! [`Dispatcher::dispatch`]. The pipeline runs in stages, in order: pre-tool
+//! hooks (may rewrite arguments or block) → execute → post-tool hooks (may
+//! append context) → failure bookkeeping. The remaining seams — the
+//! plan-mode gate before the pre-hooks and the checkpoint snapshot after
+//! them — slot in here when they land.
+
+use std::sync::Arc;
 
 use serde_json::Value;
 use tokio::sync::mpsc;
 
 use crate::agent::{AgentEvent, DoneReason, emit, normalize_args};
 use crate::config::Mode;
+use crate::hooks::{HookEngine, PreToolUse};
 use crate::llm::ToolCall;
 use crate::tools::{ToolContext, ToolOutput, registry::ToolRegistry};
 
@@ -27,6 +32,8 @@ const TOOL_FAILURE_TRIP: u32 = 8;
 /// registry and the failure counters feeding the circuit breakers.
 pub struct Dispatcher {
     registry: ToolRegistry,
+    /// Lifecycle hooks, shared with the agent and the subagent spawner.
+    hooks: Arc<HookEngine>,
     /// Sovereign runs add the identical-failure circuit breaker.
     mode: Mode,
     /// Signature of the last failing tool call and how many consecutive
@@ -61,9 +68,10 @@ impl DispatchOutcome {
 }
 
 impl Dispatcher {
-    pub fn new(registry: ToolRegistry, mode: Mode) -> Self {
+    pub fn new(registry: ToolRegistry, mode: Mode, hooks: Arc<HookEngine>) -> Self {
         Self {
             registry,
+            hooks,
             mode,
             failure_streak: None,
             tool_failures: ToolFailureCounter::default(),
@@ -99,11 +107,40 @@ impl Dispatcher {
         events: &mpsc::Sender<AgentEvent>,
     ) -> DispatchOutcome {
         let name = call.function.name.clone();
-        let args = normalize_args(&call.function.arguments);
+        let mut args = normalize_args(&call.function.arguments);
 
-        let Some(output) = self.execute(&name, args.clone(), ctx, events).await else {
+        // Pre-tool hooks: may rewrite the arguments or veto the call. A veto
+        // feeds back to the model as an ordinary tool error (not fatal), so
+        // the failure breakers cover repeated blocked calls too.
+        match self
+            .hooks
+            .pre_tool_use(&name, &args, self.mode, Some(events))
+            .await
+        {
+            PreToolUse::Continue(updated) => {
+                if let Some(updated) = updated {
+                    args = updated;
+                }
+            }
+            PreToolUse::Block(reason) => {
+                let output = ToolOutput::error(format!("blocked by pre_tool_use hook: {reason}"));
+                return self.bookkeep(&name, &args, output, events).await;
+            }
+        }
+
+        let Some(mut output) = self.execute(&name, args.clone(), ctx, events).await else {
             return DispatchOutcome::stopped();
         };
+
+        // Post-tool hooks: stdout becomes extra context on the tool result.
+        if let Some(extra) = self
+            .hooks
+            .post_tool_use(&name, &args, self.mode, Some(events))
+            .await
+        {
+            crate::hooks::append_context(&mut output.content, &extra);
+        }
+
         self.bookkeep(&name, &args, output, events).await
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -3,9 +3,9 @@
 //! Every tool call in every mode (TUI, headless, gateway) funnels through
 //! [`Dispatcher::dispatch`]. The pipeline runs in stages, in order:
 //! plan-mode gate (blocks non-read-only tools while planning) → pre-tool
-//! hooks (may rewrite arguments or block) → execute → post-tool hooks (may
-//! append context) → failure bookkeeping. The remaining seam — the
-//! checkpoint snapshot after the pre-hooks — slots in here when it lands.
+//! hooks (may rewrite arguments or block) → checkpoint snapshot of
+//! `Edit`-class targets (best-effort, never blocks the call) → execute →
+//! post-tool hooks (may append context) → failure bookkeeping.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -174,6 +174,11 @@ impl Dispatcher {
                 return self.bookkeep(&name, &args, output, events).await;
             }
         }
+
+        // Checkpoint stage: snapshot the target of an Edit-class tool so the
+        // turn can be rewound. Runs after the pre-hooks (which may have
+        // rewritten the path) and never fails the call.
+        crate::checkpoint::snapshot_edit_target(&self.registry, &name, &args, ctx);
 
         let Some(mut output) = self.execute(&name, args.clone(), ctx, events).await else {
             return DispatchOutcome::stopped();

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,13 +1,14 @@
 //! Tool-call dispatch pipeline.
 //!
 //! Every tool call in every mode (TUI, headless, gateway) funnels through
-//! [`Dispatcher::dispatch`]. The pipeline runs in stages, in order: pre-tool
+//! [`Dispatcher::dispatch`]. The pipeline runs in stages, in order:
+//! plan-mode gate (blocks non-read-only tools while planning) → pre-tool
 //! hooks (may rewrite arguments or block) → execute → post-tool hooks (may
-//! append context) → failure bookkeeping. The remaining seams — the
-//! plan-mode gate before the pre-hooks and the checkpoint snapshot after
-//! them — slot in here when they land.
+//! append context) → failure bookkeeping. The remaining seam — the
+//! checkpoint snapshot after the pre-hooks — slots in here when it lands.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -16,7 +17,8 @@ use crate::agent::{AgentEvent, DoneReason, emit, normalize_args};
 use crate::config::Mode;
 use crate::hooks::{HookEngine, PreToolUse};
 use crate::llm::ToolCall;
-use crate::tools::{ToolContext, ToolOutput, registry::ToolRegistry};
+use crate::tools::plan::EXIT_PLAN_TOOL_NAME;
+use crate::tools::{ToolAccess, ToolContext, ToolOutput, registry::ToolRegistry};
 
 /// Consecutive identical failures that trip the sovereign circuit breaker.
 const CIRCUIT_BREAKER_LIMIT: u32 = 3;
@@ -36,6 +38,10 @@ pub struct Dispatcher {
     hooks: Arc<HookEngine>,
     /// Sovereign runs add the identical-failure circuit breaker.
     mode: Mode,
+    /// Plan-mode flag, shared with the agent (`/plan`, `--plan`) and the
+    /// `exit_plan` tool (cleared on approval). While set, only read-only
+    /// tools and `exit_plan` may run.
+    plan_mode: Arc<AtomicBool>,
     /// Signature of the last failing tool call and how many consecutive
     /// times it has failed identically (sovereign only).
     failure_streak: Option<(String, u32)>,
@@ -68,11 +74,17 @@ impl DispatchOutcome {
 }
 
 impl Dispatcher {
-    pub fn new(registry: ToolRegistry, mode: Mode, hooks: Arc<HookEngine>) -> Self {
+    pub fn new(
+        registry: ToolRegistry,
+        mode: Mode,
+        hooks: Arc<HookEngine>,
+        plan_mode: Arc<AtomicBool>,
+    ) -> Self {
         Self {
             registry,
             hooks,
             mode,
+            plan_mode,
             failure_streak: None,
             tool_failures: ToolFailureCounter::default(),
         }
@@ -108,6 +120,41 @@ impl Dispatcher {
     ) -> DispatchOutcome {
         let name = call.function.name.clone();
         let mut args = normalize_args(&call.function.arguments);
+
+        // Plan-mode gate, first stage: while planning, only read-only tools
+        // and exit_plan may run. The block feeds back to the model as an
+        // ordinary tool error but is exempt from the failure breakers — a
+        // model probing for write access mid-plan must not end the turn.
+        // Unknown tools fall through so the real "unknown tool" error
+        // surfaces instead.
+        if self.plan_mode.load(Ordering::SeqCst)
+            && name != EXIT_PLAN_TOOL_NAME
+            && self
+                .registry
+                .get(&name)
+                .is_some_and(|tool| tool.access() != ToolAccess::ReadOnly)
+        {
+            let output = ToolOutput::error(
+                "blocked by plan mode: only read-only tools are allowed; finish your plan \
+                 and call exit_plan",
+            );
+            if !emit(
+                events,
+                AgentEvent::ToolFinished {
+                    name,
+                    output: output.clone(),
+                },
+            )
+            .await
+            {
+                return DispatchOutcome::stopped();
+            }
+            return DispatchOutcome {
+                output: Some(output),
+                nudge: None,
+                done: None,
+            };
+        }
 
         // Pre-tool hooks: may rewrite the arguments or veto the call. A veto
         // feeds back to the model as an ordinary tool error (not fatal), so
@@ -164,7 +211,11 @@ impl Dispatcher {
         {
             return None;
         }
-        Some(match self.registry.execute(name, args, ctx).await {
+        // Tools run with the turn's event channel in their context, so a
+        // tool that converses with the surface (exit_plan's approval
+        // round-trip) can reach it.
+        let ctx = ctx.with_events(events.clone());
+        Some(match self.registry.execute(name, args, &ctx).await {
             Ok(output) => output,
             Err(err) => ToolOutput::error(err.to_string()),
         })

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,330 @@
+//! Tool-call dispatch pipeline.
+//!
+//! Every tool call in every mode (TUI, headless, gateway) funnels through
+//! [`Dispatcher::dispatch`]. The pipeline runs in stages so upcoming
+//! features slot in between them, in order: plan-mode gate → pre-tool hooks
+//! → checkpoint snapshot → execute → post-tool hooks → failure bookkeeping.
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::agent::{AgentEvent, DoneReason, emit, normalize_args};
+use crate::config::Mode;
+use crate::llm::ToolCall;
+use crate::tools::{ToolContext, ToolOutput, registry::ToolRegistry};
+
+/// Consecutive identical failures that trip the sovereign circuit breaker.
+const CIRCUIT_BREAKER_LIMIT: u32 = 3;
+
+/// Consecutive failures of one tool (any args) before the model is nudged
+/// to change approach.
+const TOOL_FAILURE_NUDGE: u32 = 5;
+/// Consecutive failures of one tool (any args) before the turn ends with
+/// [`DoneReason::CircuitBreaker`].
+const TOOL_FAILURE_TRIP: u32 = 8;
+
+/// Runs the tool-call pipeline and owns its per-session state: the tool
+/// registry and the failure counters feeding the circuit breakers.
+pub struct Dispatcher {
+    registry: ToolRegistry,
+    /// Sovereign runs add the identical-failure circuit breaker.
+    mode: Mode,
+    /// Signature of the last failing tool call and how many consecutive
+    /// times it has failed identically (sovereign only).
+    failure_streak: Option<(String, u32)>,
+    /// Per-tool consecutive-failure counts (args ignored).
+    tool_failures: ToolFailureCounter,
+}
+
+/// What [`Dispatcher::dispatch`] tells the agent loop to do after one call.
+#[derive(Debug)]
+pub struct DispatchOutcome {
+    /// Tool result to feed back to the model. `None` when the turn ended
+    /// before a result could be reported (event receiver gone).
+    pub output: Option<ToolOutput>,
+    /// System-message nudge to inject after the feedback (repeated failures
+    /// of one tool).
+    pub nudge: Option<String>,
+    /// Set when the turn must end early (UI gone, circuit breaker).
+    pub done: Option<DoneReason>,
+}
+
+impl DispatchOutcome {
+    /// The event receiver is gone: stop the turn without feedback.
+    fn stopped() -> Self {
+        Self {
+            output: None,
+            nudge: None,
+            done: Some(DoneReason::Stopped),
+        }
+    }
+}
+
+impl Dispatcher {
+    pub fn new(registry: ToolRegistry, mode: Mode) -> Self {
+        Self {
+            registry,
+            mode,
+            failure_streak: None,
+            tool_failures: ToolFailureCounter::default(),
+        }
+    }
+
+    /// The registered tools (for specs and lookups).
+    pub fn registry(&self) -> &ToolRegistry {
+        &self.registry
+    }
+
+    /// Swap the tool registry (after `/reload` or `/evolve`).
+    pub fn set_registry(&mut self, registry: ToolRegistry) {
+        self.registry = registry;
+    }
+
+    /// Track a mode switch (the identical-failure breaker is sovereign-only).
+    pub fn set_mode(&mut self, mode: Mode) {
+        self.mode = mode;
+    }
+
+    /// Forget all failure state (`/clear`).
+    pub fn reset_failures(&mut self) {
+        self.failure_streak = None;
+        self.tool_failures.reset();
+    }
+
+    /// Run one tool call through the pipeline.
+    pub async fn dispatch(
+        &mut self,
+        call: &ToolCall,
+        ctx: &ToolContext,
+        events: &mpsc::Sender<AgentEvent>,
+    ) -> DispatchOutcome {
+        let name = call.function.name.clone();
+        let args = normalize_args(&call.function.arguments);
+
+        let Some(output) = self.execute(&name, args.clone(), ctx, events).await else {
+            return DispatchOutcome::stopped();
+        };
+        self.bookkeep(&name, &args, output, events).await
+    }
+
+    /// Execute stage: announce the call and run the tool. `None` when the
+    /// event receiver is gone and the turn must stop.
+    async fn execute(
+        &self,
+        name: &str,
+        args: Value,
+        ctx: &ToolContext,
+        events: &mpsc::Sender<AgentEvent>,
+    ) -> Option<ToolOutput> {
+        if !emit(
+            events,
+            AgentEvent::ToolStarted {
+                name: name.to_string(),
+                args: args.clone(),
+            },
+        )
+        .await
+        {
+            return None;
+        }
+        Some(match self.registry.execute(name, args, ctx).await {
+            Ok(output) => output,
+            Err(err) => ToolOutput::error(err.to_string()),
+        })
+    }
+
+    /// Failure-bookkeeping stage: report the result and update both circuit
+    /// breakers.
+    async fn bookkeep(
+        &mut self,
+        name: &str,
+        args: &Value,
+        output: ToolOutput,
+        events: &mpsc::Sender<AgentEvent>,
+    ) -> DispatchOutcome {
+        if !emit(
+            events,
+            AgentEvent::ToolFinished {
+                name: name.to_string(),
+                output: output.clone(),
+            },
+        )
+        .await
+        {
+            return DispatchOutcome::stopped();
+        }
+
+        let breaker_tripped = self.track_failure(name, args, &output);
+        let failure_action = self.tool_failures.record(name, output.is_error);
+
+        if breaker_tripped {
+            let _ = emit(
+                events,
+                AgentEvent::Error(format!(
+                    "circuit breaker: '{name}' failed identically {CIRCUIT_BREAKER_LIMIT} times in a row"
+                )),
+            )
+            .await;
+            return DispatchOutcome {
+                output: Some(output),
+                nudge: None,
+                done: Some(DoneReason::CircuitBreaker),
+            };
+        }
+        match failure_action {
+            FailureAction::Continue => DispatchOutcome {
+                output: Some(output),
+                nudge: None,
+                done: None,
+            },
+            FailureAction::Nudge => DispatchOutcome {
+                output: Some(output),
+                nudge: Some(format!(
+                    "Repeated failures with tool '{name}' ({TOOL_FAILURE_NUDGE} in a row) — \
+                     stop retrying it and change approach."
+                )),
+                done: None,
+            },
+            FailureAction::Trip => {
+                let _ = emit(
+                    events,
+                    AgentEvent::Error(format!(
+                        "circuit breaker: '{name}' failed {TOOL_FAILURE_TRIP} times in a row"
+                    )),
+                )
+                .await;
+                DispatchOutcome {
+                    output: Some(output),
+                    nudge: None,
+                    done: Some(DoneReason::CircuitBreaker),
+                }
+            }
+        }
+    }
+
+    /// Update identical-failure circuit-breaker state (sovereign only).
+    /// Returns true when the breaker trips.
+    fn track_failure(&mut self, name: &str, args: &Value, output: &ToolOutput) -> bool {
+        if self.mode != Mode::Sovereign {
+            return false;
+        }
+        if !output.is_error {
+            self.failure_streak = None;
+            return false;
+        }
+        let signature = format!("{name}\u{1}{args}\u{1}{}", output.content);
+        let count = match &self.failure_streak {
+            Some((last, count)) if *last == signature => count + 1,
+            _ => 1,
+        };
+        self.failure_streak = Some((signature, count));
+        count >= CIRCUIT_BREAKER_LIMIT
+    }
+}
+
+/// What [`ToolFailureCounter::record`] says to do after a tool result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailureAction {
+    Continue,
+    /// Inject a system nudge telling the model to stop retrying the tool.
+    Nudge,
+    /// End the turn via the circuit breaker.
+    Trip,
+}
+
+/// Per-tool-name consecutive-failure counter, independent of arguments
+/// (catches models that jitter args to dodge the identical-failure
+/// breaker). A success of a tool resets that tool's count.
+#[derive(Debug, Default)]
+struct ToolFailureCounter {
+    counts: std::collections::HashMap<String, u32>,
+}
+
+impl ToolFailureCounter {
+    /// Record one tool result and return the action it warrants.
+    fn record(&mut self, name: &str, failed: bool) -> FailureAction {
+        if !failed {
+            self.counts.remove(name);
+            return FailureAction::Continue;
+        }
+        let count = self.counts.entry(name.to_string()).or_insert(0);
+        *count += 1;
+        match *count {
+            TOOL_FAILURE_NUDGE => FailureAction::Nudge,
+            count if count >= TOOL_FAILURE_TRIP => FailureAction::Trip,
+            _ => FailureAction::Continue,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.counts.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_failures_nudge_then_trip() {
+        let mut counter = ToolFailureCounter::default();
+        for i in 1..TOOL_FAILURE_NUDGE {
+            assert_eq!(
+                counter.record("execute", true),
+                FailureAction::Continue,
+                "failure {i}"
+            );
+        }
+        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
+        for i in TOOL_FAILURE_NUDGE + 1..TOOL_FAILURE_TRIP {
+            assert_eq!(
+                counter.record("execute", true),
+                FailureAction::Continue,
+                "failure {i}"
+            );
+        }
+        assert_eq!(counter.record("execute", true), FailureAction::Trip);
+    }
+
+    #[test]
+    fn tool_failures_reset_on_success_of_that_tool() {
+        let mut counter = ToolFailureCounter::default();
+        for _ in 0..TOOL_FAILURE_NUDGE - 1 {
+            counter.record("execute", true);
+        }
+        assert_eq!(counter.record("execute", false), FailureAction::Continue);
+        // The streak starts over after the success.
+        for i in 1..TOOL_FAILURE_NUDGE {
+            assert_eq!(
+                counter.record("execute", true),
+                FailureAction::Continue,
+                "failure {i}"
+            );
+        }
+        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
+    }
+
+    #[test]
+    fn tool_failures_count_per_tool_name() {
+        let mut counter = ToolFailureCounter::default();
+        for _ in 0..TOOL_FAILURE_NUDGE - 1 {
+            counter.record("execute", true);
+            counter.record("write_file", true);
+        }
+        // Each tool reaches the nudge threshold independently; a success of
+        // one tool does not reset the other.
+        counter.record("write_file", false);
+        assert_eq!(counter.record("execute", true), FailureAction::Nudge);
+        assert_eq!(counter.record("write_file", true), FailureAction::Continue);
+    }
+
+    #[test]
+    fn tool_failures_reset_clears_all_counts() {
+        let mut counter = ToolFailureCounter::default();
+        for _ in 0..TOOL_FAILURE_TRIP {
+            counter.record("execute", true);
+        }
+        counter.reset();
+        assert_eq!(counter.record("execute", true), FailureAction::Continue);
+    }
+}

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,456 @@
+//! Environment diagnostics: `wizard doctor` (CLI) and `/doctor` (TUI).
+//!
+//! Runs a battery of checks — config parses, providers reachable, MCP
+//! servers handshake, tools registered, hooks parse, state directories
+//! writable, checkpoint index sane — and prints one `✓` / `✗` / `–` line
+//! per check. Network probes are capped at [`PROBE_TIMEOUT`] so doctor can
+//! never hang. The CLI exits 0 when nothing failed, 1 otherwise; skipped
+//! (`–`) checks are not failures.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::config::{Config, ProviderConfig};
+use crate::tools::registry::ToolRegistry;
+
+/// Cap on every network probe (provider health, MCP handshake).
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Outcome of one check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// `✓` — works.
+    Pass,
+    /// `✗` — broken; the doctor run exits 1.
+    Fail,
+    /// `–` — not applicable / nothing to check (missing optional file,
+    /// unset API key).
+    Skip,
+}
+
+/// One check result: a label, an outcome, and a short detail.
+#[derive(Debug, Clone)]
+pub struct Check {
+    pub label: String,
+    pub status: Status,
+    pub detail: String,
+}
+
+impl Check {
+    fn pass(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Pass,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Fail,
+            detail: detail.into(),
+        }
+    }
+
+    fn skip(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Skip,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Render checks as aligned report lines.
+pub fn render(checks: &[Check]) -> String {
+    let width = checks
+        .iter()
+        .map(|check| check.label.chars().count())
+        .max()
+        .unwrap_or(0);
+    checks
+        .iter()
+        .map(|check| {
+            let mark = match check.status {
+                Status::Pass => "✓",
+                Status::Fail => "✗",
+                Status::Skip => "–",
+            };
+            format!("{mark} {:<width$}  {}", check.label, check.detail)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// True when any check failed (drives the exit code).
+pub fn has_failures(checks: &[Check]) -> bool {
+    checks.iter().any(|check| check.status == Status::Fail)
+}
+
+// ---------------------------------------------------------------------------
+// pure checks (unit-tested)
+// ---------------------------------------------------------------------------
+
+/// `config.toml` parses. A missing file is fine: defaults apply.
+pub fn check_config_file(path: &Path) -> Check {
+    let label = "config";
+    match std::fs::read_to_string(path) {
+        Ok(raw) => match toml::from_str::<Config>(&raw) {
+            Ok(_) => Check::pass(label, format!("{} parses", path.display())),
+            Err(err) => Check::fail(label, format!("{}: {err}", path.display())),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Check::skip(label, format!("{} absent (defaults apply)", path.display()))
+        }
+        Err(err) => Check::fail(label, format!("{}: {err}", path.display())),
+    }
+}
+
+/// One `hooks.toml` parses. Missing file means no hooks — fine.
+pub fn check_hooks_file(label: &str, path: &Path) -> Check {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => match crate::hooks::parse(&raw) {
+            Ok(hooks) => Check::pass(
+                label,
+                format!("{} hook(s) in {}", hooks.len(), path.display()),
+            ),
+            Err(err) => Check::fail(label, format!("{}: {err}", path.display())),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Check::skip(label, format!("{} absent (no hooks)", path.display()))
+        }
+        Err(err) => Check::fail(label, format!("{}: {err}", path.display())),
+    }
+}
+
+/// `dir` exists (created if needed) and accepts a probe file.
+pub fn check_writable(label: &str, dir: &Path) -> Check {
+    if let Err(err) = std::fs::create_dir_all(dir) {
+        return Check::fail(label, format!("cannot create {}: {err}", dir.display()));
+    }
+    let probe = dir.join(format!(".doctor-probe-{}", std::process::id()));
+    match std::fs::write(&probe, b"ok") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+            Check::pass(label, format!("{} writable", dir.display()))
+        }
+        Err(err) => Check::fail(label, format!("{} not writable: {err}", dir.display())),
+    }
+}
+
+/// The checkpoint index parses, and every snapshot directory under
+/// `.wizard/checkpoints/` belongs to an indexed turn (stale directories are
+/// left over from interrupted rewinds/gc and are reported but harmless).
+pub fn check_checkpoints(project_root: &Path) -> Check {
+    let label = "checkpoints";
+    let root = project_root.join(".wizard").join("checkpoints");
+    let index = root.join("index.jsonl");
+    let raw = match std::fs::read_to_string(&index) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Check::skip(label, "no checkpoint index yet".to_string());
+        }
+        Err(err) => return Check::fail(label, format!("{}: {err}", index.display())),
+    };
+    let mut turns = std::collections::BTreeSet::new();
+    let mut records = 0usize;
+    let mut corrupt = 0usize;
+    for line in raw.lines().filter(|line| !line.trim().is_empty()) {
+        match serde_json::from_str::<crate::checkpoint::SnapshotRecord>(line) {
+            Ok(record) => {
+                turns.insert(record.turn);
+                records += 1;
+            }
+            Err(_) => corrupt += 1,
+        }
+    }
+    if corrupt > 0 {
+        return Check::fail(
+            label,
+            format!("{corrupt} corrupt line(s) in {}", index.display()),
+        );
+    }
+    // Numeric subdirectories not referenced by any index record are stale.
+    let stale = std::fs::read_dir(&root)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .filter_map(|entry| entry.file_name().to_str()?.parse::<u64>().ok())
+                .filter(|turn| !turns.contains(turn))
+                .count()
+        })
+        .unwrap_or(0);
+    let mut detail = format!("{records} snapshot(s) across {} turn(s)", turns.len());
+    if stale > 0 {
+        detail.push_str(&format!(", {stale} stale snap dir(s)"));
+    }
+    Check::pass(label, detail)
+}
+
+/// The native tool set is compiled in and registered.
+pub fn check_native_tools() -> Check {
+    let count = ToolRegistry::with_native_tools().len();
+    if count == 0 {
+        Check::fail("native tools", "no native tools registered")
+    } else {
+        Check::pass("native tools", format!("{count} tools registered"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// network checks (probe with timeout; never exercised by unit tests)
+// ---------------------------------------------------------------------------
+
+/// One configured provider answers its health probe within
+/// [`PROBE_TIMEOUT`]. Skipped when its API key env var is not set.
+async fn check_provider(provider: &ProviderConfig) -> Check {
+    let label = format!("provider {}", provider.name);
+    if let Some(env) = &provider.api_key_env
+        && !std::env::var(env).is_ok_and(|value| !value.trim().is_empty())
+    {
+        return Check::skip(label, format!("${env} not set"));
+    }
+    let client = match provider.build() {
+        Ok(client) => client,
+        Err(err) => return Check::fail(label, format!("build failed: {err:#}")),
+    };
+    match tokio::time::timeout(PROBE_TIMEOUT, client.health()).await {
+        Ok(Ok(())) => Check::pass(
+            label,
+            format!("{} ({}) reachable", client.label(), provider.model),
+        ),
+        Ok(Err(err)) => Check::fail(label, format!("{err:#}")),
+        Err(_) => Check::fail(
+            label,
+            format!("no answer within {}s", PROBE_TIMEOUT.as_secs()),
+        ),
+    }
+}
+
+/// Every `[[server]]` in `mcp.toml` spawns and completes the MCP handshake
+/// within [`PROBE_TIMEOUT`].
+async fn check_mcp_servers(path: &Path) -> Vec<Check> {
+    let config = match crate::mcp::McpConfig::load(path) {
+        Ok(config) => config,
+        Err(err) => return vec![Check::fail("mcp", format!("{err:#}"))],
+    };
+    if config.servers.is_empty() {
+        return vec![Check::skip("mcp", "no MCP servers configured")];
+    }
+    let mut checks = Vec::new();
+    for server in config.servers {
+        let label = format!("mcp {}", server.name);
+        let check =
+            match tokio::time::timeout(PROBE_TIMEOUT, crate::mcp::McpConnection::connect(server))
+                .await
+            {
+                Ok(Ok(connection)) => {
+                    let detail =
+                        match tokio::time::timeout(PROBE_TIMEOUT, connection.list_tools()).await {
+                            Ok(Ok(tools)) => format!("handshake ok, {} tool(s)", tools.len()),
+                            _ => "handshake ok".to_string(),
+                        };
+                    Check::pass(label, detail)
+                }
+                Ok(Err(err)) => Check::fail(label, format!("{err:#}")),
+                Err(_) => Check::fail(
+                    label,
+                    format!("no handshake within {}s", PROBE_TIMEOUT.as_secs()),
+                ),
+            };
+        checks.push(check);
+    }
+    checks
+}
+
+// ---------------------------------------------------------------------------
+// assembly
+// ---------------------------------------------------------------------------
+
+/// Run the full battery for `project_root`.
+pub async fn run_checks(project_root: &Path) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // Config first: later checks reuse it when it loads.
+    let config_path = Config::path().unwrap_or_else(|_| PathBuf::from("~/.wizard/config.toml"));
+    checks.push(check_config_file(&config_path));
+
+    match Config::load() {
+        Ok(config) => {
+            // The synthesized local default counts when nothing is
+            // configured explicitly.
+            let providers = if config.providers.is_empty() {
+                vec![config.active()]
+            } else {
+                config.providers.clone()
+            };
+            for provider in &providers {
+                checks.push(check_provider(provider).await);
+            }
+        }
+        Err(err) => checks.push(Check::fail(
+            "providers",
+            format!("config unusable: {err:#}"),
+        )),
+    }
+
+    if let Ok(path) = Config::mcp_config_path() {
+        checks.extend(check_mcp_servers(&path).await);
+    }
+
+    checks.push(check_native_tools());
+
+    if let Ok(dir) = Config::wizard_dir() {
+        checks.push(check_hooks_file("hooks (global)", &dir.join("hooks.toml")));
+        checks.push(check_writable("~/.wizard", &dir));
+    }
+    checks.push(check_hooks_file(
+        "hooks (project)",
+        &project_root.join(".wizard").join("hooks.toml"),
+    ));
+    checks.push(check_writable(
+        "project .wizard",
+        &project_root.join(".wizard"),
+    ));
+    if let Ok(dir) = Config::sessions_dir() {
+        checks.push(check_writable("sessions", &dir));
+    }
+    checks.push(check_checkpoints(project_root));
+
+    checks
+}
+
+/// `wizard doctor`: print the report, exit 0 when nothing failed.
+pub async fn run() -> Result<i32> {
+    let project_root = std::env::current_dir()?;
+    let checks = run_checks(&project_root).await;
+    println!("{}", render(&checks));
+    Ok(if has_failures(&checks) { 1 } else { 0 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_check_passes_skips_and_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let check = check_config_file(&path);
+        assert_eq!(check.status, Status::Skip);
+
+        std::fs::write(&path, "mode = \"sovereign\"\n").unwrap();
+        let check = check_config_file(&path);
+        assert_eq!(check.status, Status::Pass, "{}", check.detail);
+
+        std::fs::write(&path, "mode = [broken\n").unwrap();
+        let check = check_config_file(&path);
+        assert_eq!(check.status, Status::Fail);
+    }
+
+    #[test]
+    fn hooks_check_passes_skips_and_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("hooks.toml");
+
+        assert_eq!(check_hooks_file("hooks", &path).status, Status::Skip);
+
+        std::fs::write(
+            &path,
+            "[[hooks]]\nevent = \"pre_tool_use\"\ncommand = \"true\"\n",
+        )
+        .unwrap();
+        let check = check_hooks_file("hooks", &path);
+        assert_eq!(check.status, Status::Pass);
+        assert!(check.detail.contains("1 hook(s)"), "{}", check.detail);
+
+        std::fs::write(&path, "[[hooks]]\nevent = \"no_such_event\"\n").unwrap();
+        assert_eq!(check_hooks_file("hooks", &path).status, Status::Fail);
+    }
+
+    #[test]
+    fn writable_check_creates_and_probes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("fresh").join("nested");
+        let check = check_writable("dir", &dir);
+        assert_eq!(check.status, Status::Pass, "{}", check.detail);
+        assert!(dir.is_dir(), "directory was created");
+        // The probe file is cleaned up.
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn checkpoints_check_reports_records_and_stale_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // No index yet: skip.
+        assert_eq!(check_checkpoints(tmp.path()).status, Status::Skip);
+
+        let root = tmp.path().join(".wizard").join("checkpoints");
+        std::fs::create_dir_all(root.join("3")).unwrap();
+        std::fs::create_dir_all(root.join("9")).unwrap(); // stale: not indexed
+        let record = serde_json::json!({
+            "turn": 3,
+            "tool": "write_file",
+            "path": "/tmp/x",
+            "snap": "3/0.snap",
+            "existed_before": true,
+        });
+        std::fs::write(root.join("index.jsonl"), format!("{record}\n")).unwrap();
+
+        let check = check_checkpoints(tmp.path());
+        assert_eq!(check.status, Status::Pass, "{}", check.detail);
+        assert!(check.detail.contains("1 snapshot(s)"), "{}", check.detail);
+        assert!(check.detail.contains("1 stale"), "{}", check.detail);
+
+        // Corrupt index lines fail the check.
+        std::fs::write(root.join("index.jsonl"), "not json\n").unwrap();
+        assert_eq!(check_checkpoints(tmp.path()).status, Status::Fail);
+    }
+
+    #[test]
+    fn native_tools_check_counts_the_registry() {
+        let check = check_native_tools();
+        assert_eq!(check.status, Status::Pass);
+        let count = ToolRegistry::with_native_tools().len();
+        assert!(check.detail.contains(&count.to_string()));
+    }
+
+    #[test]
+    fn render_marks_and_aligns() {
+        let checks = vec![
+            Check::pass("ok", "fine"),
+            Check::fail("broken-thing", "nope"),
+            Check::skip("na", "nothing to do"),
+        ];
+        let report = render(&checks);
+        let lines: Vec<&str> = report.lines().collect();
+        assert!(lines[0].starts_with("✓ ok"));
+        assert!(lines[1].starts_with("✗ broken-thing"));
+        assert!(lines[2].starts_with("– na"));
+        assert!(has_failures(&checks));
+        assert!(!has_failures(&[Check::pass("a", ""), Check::skip("b", "")]));
+    }
+
+    #[tokio::test]
+    async fn provider_check_skips_when_the_key_env_is_unset() {
+        let provider = ProviderConfig {
+            name: "cloud".to_string(),
+            kind: crate::config::ProviderKind::Openai,
+            base_url: "https://example.invalid/v1".to_string(),
+            model: "gpt-test".to_string(),
+            api_key_env: Some("WIZARD_DOCTOR_TEST_KEY_THAT_IS_NEVER_SET".to_string()),
+            gguf_path: None,
+            usd_per_mtok_in: None,
+            usd_per_mtok_out: None,
+        };
+        let check = check_provider(&provider).await;
+        assert_eq!(check.status, Status::Skip);
+        assert!(check.detail.contains("not set"));
+    }
+}

--- a/src/evolve/mod.rs
+++ b/src/evolve/mod.rs
@@ -80,8 +80,6 @@ pub struct EvolveRequest {
     /// Natural-language description of the capability to add.
     pub description: String,
     pub tier: EvolveTier,
-    /// Skip the approval step (sovereign mode / `--auto`).
-    pub auto_approve: bool,
 }
 
 /// What an evolution produced.
@@ -113,7 +111,8 @@ pub enum EvolveOutcome {
         reason: String,
         outcome: Box<EvolveOutcome>,
     },
-    /// The user denied the proposed change.
+    /// The user denied the proposed change. Historical: approval gating was
+    /// removed; kept so old `evolution.jsonl` records still deserialize.
     Denied,
 }
 
@@ -319,10 +318,6 @@ impl Evolver {
             proposal.channel().label(),
             proposal_summary(&proposal)
         ));
-
-        if !request.auto_approve && !confirm("Apply this change?")? {
-            return Ok(EvolveOutcome::Denied);
-        }
 
         let outcome = self.apply_proposal(proposal)?;
         self.status(
@@ -534,12 +529,6 @@ impl Evolver {
         let diff = self.propose_diff(&request.description, &source_dir).await?;
         if self.verbose {
             println!("\n{diff}");
-        }
-
-        if !request.auto_approve && !confirm("Apply this diff and rebuild Wizard?")? {
-            let outcome = EvolveOutcome::Denied;
-            self.log_event(request, EvolveTier::Deep, &outcome, Some(diff), None)?;
-            return Ok(outcome);
         }
 
         self.apply_diff(&source_dir, &diff)?;
@@ -947,10 +936,7 @@ pub async fn run_publish_cli(config: Config, cli: Cli) -> Result<()> {
         (!p.is_empty()).then_some(p)
     });
 
-    let req = PublishRequest {
-        branch,
-        auto_approve: config.auto_approve || cli.auto,
-    };
+    let req = PublishRequest { branch };
 
     let outcome = publish::publish(&config, req, true).await?;
     println!("Fork:    {}", outcome.fork_url);
@@ -974,13 +960,7 @@ pub async fn run_cli(config: Config, cli: Cli) -> Result<()> {
     } else {
         EvolveTier::Runtime
     };
-    let request = EvolveRequest {
-        description,
-        tier,
-        // `Config::apply_cli` already folded `--auto`/sovereign in, but the
-        // CLI flag is honored here too in case the caller skipped that.
-        auto_approve: config.auto_approve || cli.auto,
-    };
+    let request = EvolveRequest { description, tier };
 
     let mut evolver = Evolver::new(config).with_verbose(true);
     let outcome = evolver.run(request).await?;
@@ -1039,24 +1019,7 @@ fn print_outcome(outcome: &EvolveOutcome) {
     }
 }
 
-/// Blocking y/N confirmation on the terminal. Refuses (rather than hangs)
-/// when stdin is not a TTY — pass `--auto` for unattended runs.
-fn confirm(question: &str) -> Result<bool> {
-    let stdin = std::io::stdin();
-    if !stdin.is_terminal() {
-        bail!(
-            "approval required but stdin is not a terminal; re-run with --auto to skip confirmation"
-        );
-    }
-    print!("{question} [y/N] ");
-    std::io::stdout().flush().context("flushing stdout")?;
-    let mut line = String::new();
-    stdin.read_line(&mut line).context("reading confirmation")?;
-    let answer = line.trim().to_ascii_lowercase();
-    Ok(answer == "y" || answer == "yes")
-}
-
-/// Human-readable proposal preview for the approval gate.
+/// Human-readable proposal preview printed before the change is applied.
 fn proposal_summary(proposal: &ChannelProposal) -> String {
     match proposal {
         ChannelProposal::Skill(skill) => format!(

--- a/src/evolve/publish.rs
+++ b/src/evolve/publish.rs
@@ -21,8 +21,6 @@ const UPSTREAM_SLUG: &str = "teddytennant/wizard";
 pub struct PublishRequest {
     /// Branch to push to on the fork (default `"main"` when `None`).
     pub branch: Option<String>,
-    /// Skip the approval prompt (sovereign / `--auto`).
-    pub auto_approve: bool,
 }
 
 /// Result of a successful publish.

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -1,0 +1,1798 @@
+//! `wizard fleet` — parallel sovereign workers over git worktrees.
+//!
+//! `fleet run -n <N> -p "<mission>"` runs one in-process planning turn that
+//! decomposes the mission into independent tasks, then spawns up to N
+//! headless `wizard --mode sovereign` children, each in its own git worktree
+//! on its own `fleet/<i>-<slug>` branch. The coordinator claims tasks for
+//! workers (atomic rename from `queue/` into `claimed/`), supervises the
+//! children (watchdog, heartbeat, stop sentinel, ctrl-c), records one result
+//! JSON per task, and finally runs an in-process synthesis turn that merges
+//! the fleet branches back into the current branch.
+//!
+//! Project-local layout (rooted at the current directory):
+//! - `.wizard/fleet/fleet.toml` — mission, worker count, status, child pids
+//! - `.wizard/fleet/queue/<id>.json` — tasks not yet claimed
+//! - `.wizard/fleet/claimed/<id>.json` — tasks claimed by a worker slot
+//! - `.wizard/fleet/results/<id>.json` — one result per finished task
+//! - `.wizard/fleet/worktrees/<i>` — per-slot git worktree (removed at end)
+//! - `.wizard/fleet/logs/<id>.stdout|stderr` — raw child output
+//! - `.wizard/fleet/heartbeat` — unix timestamp, touched every tick
+//! - `.wizard/fleet/stop` — sentinel written by `fleet stop`
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::agent::{Agent, AgentEvent, PlanVerdict, build_headless_agent};
+use crate::bench::git;
+use crate::cli::FleetCmd;
+use crate::config::Config;
+
+/// Supervision tick: reap children, enforce the watchdog, claim tasks,
+/// check the stop sentinel, touch the heartbeat.
+const TICK: Duration = Duration::from_secs(1);
+
+/// Max length of the mission slug used in branch names.
+const SLUG_MAX: usize = 24;
+
+/// Max length of a sanitized task id (it becomes a file and result name).
+const ID_MAX: usize = 40;
+
+// ---------------------------------------------------------------------------
+// On-disk layout
+// ---------------------------------------------------------------------------
+
+/// Paths of one project's fleet state, rooted at `<project>/.wizard/fleet`.
+#[derive(Debug, Clone)]
+pub struct FleetDirs {
+    root: PathBuf,
+}
+
+impl FleetDirs {
+    pub fn new(project_root: &Path) -> Self {
+        Self {
+            root: project_root.join(".wizard").join("fleet"),
+        }
+    }
+
+    pub fn queue(&self) -> PathBuf {
+        self.root.join("queue")
+    }
+
+    pub fn claimed(&self) -> PathBuf {
+        self.root.join("claimed")
+    }
+
+    pub fn results(&self) -> PathBuf {
+        self.root.join("results")
+    }
+
+    pub fn worktrees(&self) -> PathBuf {
+        self.root.join("worktrees")
+    }
+
+    pub fn logs(&self) -> PathBuf {
+        self.root.join("logs")
+    }
+
+    pub fn state_path(&self) -> PathBuf {
+        self.root.join("fleet.toml")
+    }
+
+    pub fn stop_path(&self) -> PathBuf {
+        self.root.join("stop")
+    }
+
+    pub fn heartbeat_path(&self) -> PathBuf {
+        self.root.join("heartbeat")
+    }
+
+    /// Create the whole directory tree (idempotent).
+    pub fn ensure(&self) -> Result<()> {
+        for dir in [
+            self.root.clone(),
+            self.queue(),
+            self.claimed(),
+            self.results(),
+            self.worktrees(),
+            self.logs(),
+        ] {
+            std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        }
+        Ok(())
+    }
+
+    /// True when `fleet stop` has requested a wind-down.
+    pub fn stop_requested(&self) -> bool {
+        self.stop_path().exists()
+    }
+}
+
+/// One unit of work produced by the planning turn (`queue/<id>.json`).
+/// Deserialization is liberal: only `prompt` is required; missing ids and
+/// titles are filled in by [`finalize_tasks`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTask {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub files_hint: Vec<String>,
+}
+
+/// Contents of `fleet.toml` — the coordinator's persisted state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetState {
+    /// The mission text handed to `fleet run -p`.
+    pub mission: String,
+    /// Requested worker count (`-n`).
+    pub workers: usize,
+    /// RFC 3339 start time.
+    pub started: String,
+    /// planning | running | synthesizing | done | stopped
+    pub status: String,
+    /// Pids of currently running children (empty once the fleet ends).
+    #[serde(default)]
+    pub pids: Vec<u32>,
+}
+
+/// One finished task (`results/<id>.json`): exit code, branch, and the
+/// child's parsed `--output-format json` summary when stdout parsed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskResult {
+    pub task_id: String,
+    pub title: String,
+    pub branch: String,
+    /// Child exit code; `None` on signal death or a watchdog/stop kill.
+    pub exit: Option<i32>,
+    /// True when the watchdog killed the child past `[fleet] max_minutes`.
+    #[serde(default)]
+    pub timed_out: bool,
+    /// The child's final JSON summary object, when stdout parsed as JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<Value>,
+}
+
+/// Save `fleet.toml`, creating parents as needed.
+pub fn save_state(path: &Path, state: &FleetState) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let text = toml::to_string_pretty(state).context("serializing fleet state")?;
+    std::fs::write(path, text).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Load `fleet.toml`; `None` when no fleet has ever run here.
+pub fn load_state(path: &Path) -> Result<Option<FleetState>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).context(format!("reading {}", path.display())),
+    };
+    toml::from_str(&text)
+        .map(Some)
+        .with_context(|| format!("parsing {}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers: slugs, ids, task-list parsing
+// ---------------------------------------------------------------------------
+
+/// Lowercase kebab-case of `text`, capped at `max_len`: runs of
+/// non-alphanumerics collapse into single dashes.
+fn kebab(text: &str, max_len: usize) -> String {
+    let mut out = String::new();
+    for word in text
+        .to_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+    {
+        let sep = usize::from(!out.is_empty());
+        if out.len() + sep + word.len() > max_len {
+            // A long first word still yields something usable.
+            if out.is_empty() {
+                out.push_str(&word[..max_len]);
+            }
+            break;
+        }
+        if sep == 1 {
+            out.push('-');
+        }
+        out.push_str(word);
+    }
+    out
+}
+
+/// Short branch-name slug derived from the mission text (`fleet` when the
+/// mission has no usable characters).
+pub fn slug(mission: &str) -> String {
+    let s = kebab(mission, SLUG_MAX);
+    if s.is_empty() { "fleet".to_string() } else { s }
+}
+
+/// Path-safe task id (may come back empty; [`finalize_tasks`] falls back).
+fn sanitize_id(raw: &str) -> String {
+    kebab(raw, ID_MAX)
+}
+
+/// Length (in bytes) of the balanced JSON value starting at the first byte
+/// of `s` (which must be `[` or `{`), honoring strings and escapes. `None`
+/// when the brackets never balance.
+fn balanced_end(s: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_str = false;
+    let mut escape = false;
+    for (i, c) in s.char_indices() {
+        if in_str {
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == '"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => in_str = true,
+            '[' | '{' => depth += 1,
+            ']' | '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i + c.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Interpret one parsed JSON value as a task list: an array of task
+/// objects, an object with a `tasks` array, or a single task object.
+fn tasks_from_value(value: Value) -> Result<Vec<FleetTask>> {
+    let items = match value {
+        Value::Array(items) => items,
+        Value::Object(mut map) => match map.remove("tasks") {
+            Some(Value::Array(items)) => items,
+            Some(_) => bail!("\"tasks\" is not an array"),
+            None => vec![Value::Object(map)],
+        },
+        _ => bail!("expected a JSON array of task objects"),
+    };
+    let tasks: Vec<FleetTask> = items
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<Result<_, _>>()
+        .context("every task object needs at least a \"prompt\" string")?;
+    if tasks.is_empty() {
+        bail!("the task list is empty");
+    }
+    Ok(tasks)
+}
+
+/// Liberal task-list extraction from a model reply: scan for every balanced
+/// JSON array/object (so fenced or prose-wrapped JSON works), return the
+/// first one that yields a non-empty task list.
+pub fn parse_tasks(text: &str) -> Result<Vec<FleetTask>> {
+    let mut last_err: Option<anyhow::Error> = None;
+    for (i, c) in text.char_indices() {
+        if c != '[' && c != '{' {
+            continue;
+        }
+        let Some(len) = balanced_end(&text[i..]) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&text[i..i + len]) else {
+            continue;
+        };
+        match tasks_from_value(value) {
+            Ok(tasks) => return Ok(tasks),
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(last_err
+        .unwrap_or_else(|| anyhow::anyhow!("no JSON task list found in the planning response")))
+}
+
+/// Normalize a parsed task list: drop empty prompts, sanitize and
+/// de-duplicate ids (deriving them from titles when absent), backfill
+/// titles, and cap at `max_tasks`.
+pub fn finalize_tasks(tasks: Vec<FleetTask>, max_tasks: usize) -> Result<Vec<FleetTask>> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+    for (i, mut task) in tasks.into_iter().enumerate() {
+        if task.prompt.trim().is_empty() {
+            continue;
+        }
+        let mut id = sanitize_id(&task.id);
+        if id.is_empty() {
+            id = sanitize_id(&task.title);
+        }
+        if id.is_empty() {
+            id = format!("task-{}", i + 1);
+        }
+        let mut unique = id.clone();
+        let mut suffix = 2;
+        while !seen.insert(unique.clone()) {
+            unique = format!("{id}-{suffix}");
+            suffix += 1;
+        }
+        task.id = unique;
+        if task.title.trim().is_empty() {
+            task.title = task.id.clone();
+        }
+        out.push(task);
+        if out.len() == max_tasks {
+            break;
+        }
+    }
+    if out.is_empty() {
+        bail!("mission decomposition produced no usable tasks");
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+/// The planning turn's prompt: decompose the mission into independent tasks
+/// and answer with strict JSON.
+pub fn plan_prompt(mission: &str, max_tasks: usize) -> String {
+    format!(
+        "You are the coordinator of a fleet of autonomous agents that will work in \
+         parallel, each in its own isolated git worktree of this repository.\n\n\
+         Mission:\n\n{mission}\n\n\
+         Decompose the mission into at most {max_tasks} INDEPENDENT tasks. The tasks run \
+         concurrently with no shared state, so no task may depend on another task's \
+         output, and two tasks should not edit the same files. Prefer fewer, \
+         well-scoped tasks over many overlapping ones.\n\n\
+         Respond with ONLY a JSON array — no prose, no code fence — one object per task:\n\
+         [{{\"id\": \"short-kebab-case-id\", \"title\": \"one line\", \
+         \"prompt\": \"full self-contained instructions for the worker\", \
+         \"files_hint\": [\"paths/likely/touched\"]}}]"
+    )
+}
+
+/// Follow-up prompt when the first planning reply did not parse.
+pub fn retry_prompt(error: &str) -> String {
+    format!(
+        "Your previous reply could not be parsed as a task list ({error}). Reply again \
+         with ONLY the JSON array of task objects — no prose, no code fence, no keys \
+         other than id, title, prompt, files_hint."
+    )
+}
+
+/// Wrap a task prompt with the worker's standing instructions.
+pub fn worker_prompt(task: &FleetTask) -> String {
+    let mut p = format!(
+        "You are one worker in a fleet of agents working in parallel toward a larger \
+         mission. Your task:\n\n{}\n",
+        task.prompt
+    );
+    if !task.files_hint.is_empty() {
+        let _ = writeln!(p, "\nLikely relevant files: {}", task.files_hint.join(", "));
+    }
+    p.push_str(
+        "\nWhen the task is done, commit your changes with a descriptive message \
+         (git add the files you touched, then git commit). Do not push. Never commit \
+         anything under .wizard/.",
+    );
+    p
+}
+
+/// The synthesis turn's prompt: results + branch list + merge instructions.
+/// Runs in the MAIN repository checkout, never a worktree.
+pub fn synthesis_prompt(mission: &str, results: &[TaskResult]) -> String {
+    let mut p = format!(
+        "You are the fleet coordinator. The mission was:\n\n{mission}\n\n\
+         {} worker task(s) ran in isolated git worktrees; each committed its work to \
+         its own branch. Results:\n\n",
+        results.len()
+    );
+    for result in results {
+        let outcome = describe_exit(result);
+        let summary = result
+            .summary
+            .as_ref()
+            .and_then(|value| value["result"].as_str())
+            .map(|text| truncate_chars(text, 600))
+            .unwrap_or_else(|| "(no summary)".to_string());
+        let _ = writeln!(
+            p,
+            "- task '{}' ({}) — branch {}, {outcome}\n  {summary}",
+            result.task_id, result.title, result.branch
+        );
+    }
+    p.push_str(
+        "\nMerge each branch listed above into the CURRENT branch, one at a time \
+         (`git merge <branch>` — you are in the main checkout of the repository, not a \
+         worktree). If a merge conflicts and the resolution is trivial, resolve it and \
+         complete the merge; otherwise run `git merge --abort`, leave that branch \
+         unmerged, and move on to the next one. Never force anything, never rewrite \
+         history, never delete branches. Finish with a short report: which branches \
+         merged cleanly and which were left unmerged and why.",
+    );
+    p
+}
+
+/// "exit 0" / "killed (timeout)" / "killed" for one task result.
+fn describe_exit(result: &TaskResult) -> String {
+    match result.exit {
+        Some(code) => format!("exit {code}"),
+        None if result.timed_out => "killed (timeout)".to_string(),
+        None => "killed".to_string(),
+    }
+}
+
+/// First `max` characters of `text` (with an ellipsis when truncated).
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        text.to_string()
+    } else {
+        let mut s: String = text.chars().take(max).collect();
+        s.push('…');
+        s
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Workers: argv, claiming, spawning
+// ---------------------------------------------------------------------------
+
+/// Argv (after the binary itself) of one worker child: a headless sovereign
+/// run in the slot's worktree emitting one final JSON summary on stdout.
+pub fn worker_args(prompt: &str, worktree: &Path) -> Vec<String> {
+    vec![
+        "--mode".to_string(),
+        "sovereign".to_string(),
+        "-p".to_string(),
+        prompt.to_string(),
+        "--cwd".to_string(),
+        worktree.display().to_string(),
+        "--output-format".to_string(),
+        "json".to_string(),
+    ]
+}
+
+/// Atomically claim the next queued task: rename `queue/<id>.json` into
+/// `claimed/` (rename is atomic within a filesystem, so when two claimants
+/// race, exactly one wins; the loser sees `NotFound` and moves on). `None`
+/// when the queue is empty.
+pub fn claim_next(queue: &Path, claimed: &Path) -> Result<Option<FleetTask>> {
+    let mut names: Vec<_> = match std::fs::read_dir(queue) {
+        Ok(entries) => entries
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.file_name())
+            .filter(|name| name.to_string_lossy().ends_with(".json"))
+            .collect(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).context(format!("reading {}", queue.display())),
+    };
+    names.sort();
+    for name in names {
+        let from = queue.join(&name);
+        let to = claimed.join(&name);
+        match std::fs::rename(&from, &to) {
+            Ok(()) => {
+                let raw = std::fs::read_to_string(&to)
+                    .with_context(|| format!("reading {}", to.display()))?;
+                let task: FleetTask = serde_json::from_str(&raw)
+                    .with_context(|| format!("parsing {}", to.display()))?;
+                return Ok(Some(task));
+            }
+            // Another claimant renamed it first — try the next one.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).context(format!("claiming {}", from.display()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// True when no `.json` task files remain in `queue` (a missing dir counts
+/// as empty).
+pub fn queue_is_empty(queue: &Path) -> Result<bool> {
+    match std::fs::read_dir(queue) {
+        Ok(mut entries) => Ok(!entries
+            .any(|entry| entry.is_ok_and(|e| e.file_name().to_string_lossy().ends_with(".json")))),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(err).context(format!("reading {}", queue.display())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Supervisor tick (pure) + the real loop around it
+// ---------------------------------------------------------------------------
+
+/// Observed state of one worker slot at the top of a supervision tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotStatus {
+    /// No child running.
+    Idle,
+    /// Child running and within its time budget.
+    Running,
+    /// Child has exited and awaits reaping.
+    Exited,
+    /// Child running past `[fleet] max_minutes` — kill it.
+    Overdue,
+}
+
+/// What the supervision loop should do this tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TickAction {
+    /// Stop sentinel present: kill every child and mark the fleet stopped.
+    StopAll,
+    /// Record this slot's exited child as a result and free the slot.
+    Reap(usize),
+    /// Kill this slot's overdue child (recorded as timed out).
+    Kill(usize),
+    /// Claim the next queued task and spawn a child in this slot.
+    Spawn(usize),
+    /// Queue empty and every slot idle: the fleet is finished.
+    AllDone,
+}
+
+/// Pure tick logic: given the slot states, queue emptiness, and the stop
+/// sentinel, decide the actions. The real loop feeds in observations and
+/// executes whatever comes back; tests drive this directly.
+pub fn tick(slots: &[SlotStatus], queue_empty: bool, stop_requested: bool) -> Vec<TickAction> {
+    if stop_requested {
+        return vec![TickAction::StopAll];
+    }
+    let mut actions = Vec::new();
+    for (i, status) in slots.iter().enumerate() {
+        match status {
+            SlotStatus::Exited => actions.push(TickAction::Reap(i)),
+            SlotStatus::Overdue => actions.push(TickAction::Kill(i)),
+            SlotStatus::Idle if !queue_empty => actions.push(TickAction::Spawn(i)),
+            SlotStatus::Idle | SlotStatus::Running => {}
+        }
+    }
+    if actions.is_empty() && queue_empty && slots.iter().all(|s| *s == SlotStatus::Idle) {
+        actions.push(TickAction::AllDone);
+    }
+    actions
+}
+
+/// One worker slot: a reusable worktree + branch, optionally running a child.
+struct Slot {
+    worktree: PathBuf,
+    branch: String,
+    running: Option<Worker>,
+}
+
+/// A spawned worker child and what it is working on.
+struct Worker {
+    task: FleetTask,
+    child: tokio::process::Child,
+    started: Instant,
+    stdout_path: PathBuf,
+    /// Exit code observed by `try_wait` (set when status is `Exited`).
+    exit: Option<i32>,
+}
+
+/// Spawn one worker child in `worktree`: direct argv (no shell), cwd set
+/// both ways, `WIZARD_FLEET=1`, stdout/stderr captured to log files,
+/// `kill_on_drop` as the teardown backstop.
+fn spawn_worker(task: FleetTask, worktree: &Path, dirs: &FleetDirs) -> Result<Worker> {
+    let exe = std::env::current_exe().context("locating the wizard binary for the worker")?;
+    let stdout_path = dirs.logs().join(format!("{}.stdout", task.id));
+    let stderr_path = dirs.logs().join(format!("{}.stderr", task.id));
+    let stdout = std::fs::File::create(&stdout_path)
+        .with_context(|| format!("creating {}", stdout_path.display()))?;
+    let stderr = std::fs::File::create(&stderr_path)
+        .with_context(|| format!("creating {}", stderr_path.display()))?;
+    let prompt = worker_prompt(&task);
+    let child = tokio::process::Command::new(exe)
+        .args(worker_args(&prompt, worktree))
+        .current_dir(worktree)
+        .env("WIZARD_FLEET", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("spawning worker for task '{}'", task.id))?;
+    Ok(Worker {
+        task,
+        child,
+        started: Instant::now(),
+        stdout_path,
+        exit: None,
+    })
+}
+
+/// Write `results/<task-id>.json` for one finished (or killed) worker:
+/// exit code, branch, and the child's parsed JSON summary when stdout
+/// parsed.
+fn write_result(
+    dirs: &FleetDirs,
+    task: &FleetTask,
+    branch: &str,
+    exit: Option<i32>,
+    timed_out: bool,
+    stdout_path: &Path,
+) -> Result<TaskResult> {
+    let summary = std::fs::read_to_string(stdout_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(raw.trim()).ok());
+    let result = TaskResult {
+        task_id: task.id.clone(),
+        title: task.title.clone(),
+        branch: branch.to_string(),
+        exit,
+        timed_out,
+        summary,
+    };
+    let path = dirs.results().join(format!("{}.json", task.id));
+    let text = serde_json::to_string_pretty(&result).context("serializing task result")?;
+    std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    Ok(result)
+}
+
+/// Touch the heartbeat file with the current unix timestamp (best-effort).
+fn touch_heartbeat(dirs: &FleetDirs) {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs());
+    let _ = std::fs::write(dirs.heartbeat_path(), format!("{ts}\n"));
+}
+
+/// Kill every running child and record killed-task results. Used by the
+/// stop sentinel and ctrl-c paths.
+async fn stop_all(slots: &mut [Slot], dirs: &FleetDirs) {
+    for slot in slots.iter_mut() {
+        if let Some(mut worker) = slot.running.take() {
+            worker.child.kill().await.ok();
+            println!("✗ killed task '{}' on shutdown", worker.task.id);
+            if let Err(err) = write_result(
+                dirs,
+                &worker.task,
+                &slot.branch,
+                None,
+                false,
+                &worker.stdout_path,
+            ) {
+                tracing::warn!("could not record killed task result: {err:#}");
+            }
+        }
+    }
+}
+
+/// The real supervision loop around [`tick`]. Returns `true` when the queue
+/// drained and every child finished, `false` on a stop (sentinel or ctrl-c).
+async fn supervise(
+    dirs: &FleetDirs,
+    slots: &mut [Slot],
+    state: &mut FleetState,
+    max_minutes: u64,
+) -> Result<bool> {
+    let max_age = Duration::from_secs(max_minutes.saturating_mul(60));
+    loop {
+        touch_heartbeat(dirs);
+
+        // Observe: child exits, watchdog deadlines.
+        let mut statuses = Vec::with_capacity(slots.len());
+        for slot in slots.iter_mut() {
+            let status = match slot.running.as_mut() {
+                None => SlotStatus::Idle,
+                Some(worker) => match worker.child.try_wait() {
+                    Ok(Some(exit)) => {
+                        // `code()` is None on signal death — recorded as a
+                        // failure, exactly like the headless exit-code map.
+                        worker.exit = exit.code();
+                        SlotStatus::Exited
+                    }
+                    Ok(None) if worker.started.elapsed() >= max_age => SlotStatus::Overdue,
+                    Ok(None) => SlotStatus::Running,
+                    Err(err) => {
+                        tracing::warn!("try_wait failed for '{}': {err}", worker.task.id);
+                        worker.exit = None;
+                        SlotStatus::Exited
+                    }
+                },
+            };
+            statuses.push(status);
+        }
+
+        // Decide + act.
+        let actions = tick(
+            &statuses,
+            queue_is_empty(&dirs.queue())?,
+            dirs.stop_requested(),
+        );
+        for action in actions {
+            match action {
+                TickAction::StopAll => {
+                    println!("fleet: stop requested — winding down");
+                    stop_all(slots, dirs).await;
+                    return Ok(false);
+                }
+                TickAction::Reap(i) => {
+                    let slot = &mut slots[i];
+                    if let Some(worker) = slot.running.take() {
+                        let result = write_result(
+                            dirs,
+                            &worker.task,
+                            &slot.branch,
+                            worker.exit,
+                            false,
+                            &worker.stdout_path,
+                        )?;
+                        println!(
+                            "← task '{}' finished ({}) on {}",
+                            worker.task.id,
+                            describe_exit(&result),
+                            slot.branch
+                        );
+                    }
+                }
+                TickAction::Kill(i) => {
+                    let slot = &mut slots[i];
+                    if let Some(mut worker) = slot.running.take() {
+                        worker.child.kill().await.ok();
+                        write_result(
+                            dirs,
+                            &worker.task,
+                            &slot.branch,
+                            None,
+                            true,
+                            &worker.stdout_path,
+                        )?;
+                        println!(
+                            "⏱ task '{}' exceeded {max_minutes} min — killed",
+                            worker.task.id
+                        );
+                    }
+                }
+                TickAction::Spawn(i) => {
+                    if let Some(task) = claim_next(&dirs.queue(), &dirs.claimed())? {
+                        let slot = &mut slots[i];
+                        let worker = spawn_worker(task, &slot.worktree, dirs)?;
+                        println!(
+                            "→ task '{}' ({}) started on {}",
+                            worker.task.id, worker.task.title, slot.branch
+                        );
+                        slot.running = Some(worker);
+                    }
+                }
+                TickAction::AllDone => return Ok(true),
+            }
+        }
+
+        // Persist the live pid set when it changed.
+        let pids: Vec<u32> = slots
+            .iter()
+            .filter_map(|slot| slot.running.as_ref().and_then(|w| w.child.id()))
+            .collect();
+        if pids != state.pids {
+            state.pids = pids;
+            save_state(&dirs.state_path(), state)?;
+        }
+
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                result.context("listening for ctrl-c")?;
+                println!("\nfleet: interrupt — winding down");
+                stop_all(slots, dirs).await;
+                return Ok(false);
+            }
+            () = tokio::time::sleep(TICK) => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Planning / synthesis turns (in-process headless agent)
+// ---------------------------------------------------------------------------
+
+/// Run one agent turn and return the assistant's collected text. Deltas and
+/// tool one-liners stream to stdout so `fleet run` reads like a normal
+/// headless run; plans (if any) are auto-approved.
+async fn run_collect_text(agent: &mut Agent, prompt: &str) -> Result<String> {
+    let (tx, mut rx) = mpsc::channel::<AgentEvent>(256);
+    let collector = tokio::spawn(async move {
+        let mut text = String::new();
+        while let Some(event) = rx.recv().await {
+            match event {
+                AgentEvent::TextDelta(delta) => {
+                    print!("{delta}");
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    text.push_str(&delta);
+                }
+                AgentEvent::ToolStarted { name, .. } => println!("\n→ {name}"),
+                AgentEvent::ToolFinished { name, output } => {
+                    let status = if output.is_error { "error" } else { "ok" };
+                    println!("← {name} [{status}]");
+                }
+                AgentEvent::Error(message) => eprintln!("\nwizard error: {message}"),
+                AgentEvent::PlanReady { respond, .. } => {
+                    let _ = respond.send(PlanVerdict::approve());
+                }
+                _ => {}
+            }
+        }
+        text
+    });
+    let turn = agent.run_turn(prompt, tx).await;
+    let text = collector.await.context("output collector panicked")?;
+    println!();
+    turn?;
+    Ok(text)
+}
+
+/// The planning turn: ask the model to decompose `mission` into at most
+/// `max_tasks` independent tasks, parse liberally, retry once on a parse
+/// failure (the retry prompt quotes the parse error back at the model).
+pub async fn decompose(
+    agent: &mut Agent,
+    mission: &str,
+    max_tasks: usize,
+) -> Result<Vec<FleetTask>> {
+    let text = run_collect_text(agent, &plan_prompt(mission, max_tasks)).await?;
+    let tasks = match parse_tasks(&text) {
+        Ok(tasks) => tasks,
+        Err(err) => {
+            let text = run_collect_text(agent, &retry_prompt(&format!("{err:#}"))).await?;
+            parse_tasks(&text)
+                .context("the planning turn produced no parsable task list, even after a retry")?
+        }
+    };
+    finalize_tasks(tasks, max_tasks)
+}
+
+// ---------------------------------------------------------------------------
+// Worktrees
+// ---------------------------------------------------------------------------
+
+/// `git switch -c <branch>` inside `worktree`.
+async fn create_branch(worktree: &Path, branch: &str) -> Result<()> {
+    let output = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(["switch", "-c", branch])
+        .output()
+        .await
+        .context("running git switch -c")?;
+    if !output.status.success() {
+        bail!(
+            "git switch -c {branch} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Create worker slot `index`: a worktree at `.wizard/fleet/worktrees/<i>`
+/// on branch `fleet/<i>-<slug>` (with a timestamp suffix when a previous
+/// run already took that name — old branches are never touched).
+async fn setup_slot(
+    root: &Path,
+    dirs: &FleetDirs,
+    index: usize,
+    mission_slug: &str,
+) -> Result<Slot> {
+    let dest = dirs.worktrees().join(index.to_string());
+    if dest.exists() {
+        git::worktree_remove(root, &dest).await;
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+    git::worktree_add(root, &dest, "HEAD")
+        .await
+        .with_context(|| format!("creating worktree for worker {index}"))?;
+    let base = format!("fleet/{index}-{mission_slug}");
+    let branch = match create_branch(&dest, &base).await {
+        Ok(()) => base,
+        Err(_taken) => {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |elapsed| elapsed.as_secs());
+            let fallback = format!("{base}-{ts}");
+            create_branch(&dest, &fallback).await?;
+            fallback
+        }
+    };
+    Ok(Slot {
+        worktree: dest,
+        branch,
+        running: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Status table
+// ---------------------------------------------------------------------------
+
+/// One line of `fleet status`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusRow {
+    pub id: String,
+    pub title: String,
+    /// queued | running | done
+    pub state: String,
+    /// "-" while not finished; exit code / "timeout" / "killed" after.
+    pub exit: String,
+    /// "-" until the task lands on a branch.
+    pub branch: String,
+}
+
+/// Read every parsable task file in `dir` (missing dir = none).
+fn read_tasks_dir(dir: &Path) -> Result<Vec<FleetTask>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err).context(format!("reading {}", dir.display())),
+    };
+    let mut tasks = Vec::new();
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(anyhow::Error::from)
+            .and_then(|raw| serde_json::from_str::<FleetTask>(&raw).map_err(Into::into))
+        {
+            Ok(task) => tasks.push(task),
+            Err(err) => tracing::warn!("skipping unreadable task {}: {err:#}", path.display()),
+        }
+    }
+    Ok(tasks)
+}
+
+/// Read every parsable result file, sorted by task id.
+pub fn load_results(dirs: &FleetDirs) -> Result<Vec<TaskResult>> {
+    let entries = match std::fs::read_dir(dirs.results()) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err).context(format!("reading {}", dirs.results().display())),
+    };
+    let mut results = Vec::new();
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(anyhow::Error::from)
+            .and_then(|raw| serde_json::from_str::<TaskResult>(&raw).map_err(Into::into))
+        {
+            Ok(result) => results.push(result),
+            Err(err) => tracing::warn!("skipping unreadable result {}: {err:#}", path.display()),
+        }
+    }
+    results.sort_by(|a, b| a.task_id.cmp(&b.task_id));
+    Ok(results)
+}
+
+/// Assemble the status table from the queue/claimed/results directories:
+/// queued tasks, claimed-but-unfinished tasks (running), and finished ones.
+pub fn status_rows(dirs: &FleetDirs) -> Result<Vec<StatusRow>> {
+    let mut rows = Vec::new();
+    for task in read_tasks_dir(&dirs.queue())? {
+        rows.push(StatusRow {
+            id: task.id,
+            title: task.title,
+            state: "queued".to_string(),
+            exit: "-".to_string(),
+            branch: "-".to_string(),
+        });
+    }
+    let results = load_results(dirs)?;
+    let finished: HashSet<&str> = results.iter().map(|r| r.task_id.as_str()).collect();
+    for task in read_tasks_dir(&dirs.claimed())? {
+        if finished.contains(task.id.as_str()) {
+            continue;
+        }
+        rows.push(StatusRow {
+            id: task.id,
+            title: task.title,
+            state: "running".to_string(),
+            exit: "-".to_string(),
+            branch: "-".to_string(),
+        });
+    }
+    for result in results {
+        let exit = match result.exit {
+            Some(code) => code.to_string(),
+            None if result.timed_out => "timeout".to_string(),
+            None => "killed".to_string(),
+        };
+        rows.push(StatusRow {
+            id: result.task_id,
+            title: result.title,
+            state: "done".to_string(),
+            exit,
+            branch: result.branch,
+        });
+    }
+    rows.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(rows)
+}
+
+/// Render the status table (column widths fit the data).
+pub fn render_table(rows: &[StatusRow]) -> String {
+    let id_w = rows.iter().map(|r| r.id.len()).max().unwrap_or(4).max(4);
+    let state_w = rows.iter().map(|r| r.state.len()).max().unwrap_or(5).max(5);
+    let exit_w = rows.iter().map(|r| r.exit.len()).max().unwrap_or(4).max(4);
+    let branch_w = rows
+        .iter()
+        .map(|r| r.branch.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let mut out = format!(
+        "{:<id_w$}  {:<state_w$}  {:<exit_w$}  {:<branch_w$}  title\n",
+        "task", "state", "exit", "branch"
+    );
+    for row in rows {
+        let _ = writeln!(
+            out,
+            "{:<id_w$}  {:<state_w$}  {:<exit_w$}  {:<branch_w$}  {}",
+            row.id, row.state, row.exit, row.branch, row.title
+        );
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry points
+// ---------------------------------------------------------------------------
+
+/// Dispatch a `wizard fleet` subcommand. `run` loads config (it drives a
+/// real agent); `status` and `stop` only touch `.wizard/fleet/`.
+pub async fn run(cmd: FleetCmd) -> Result<i32> {
+    match cmd {
+        FleetCmd::Run { n, prompt } => run_fleet(n, prompt).await,
+        FleetCmd::Status => status_cmd(),
+        FleetCmd::Stop => stop_cmd(),
+    }
+}
+
+/// `wizard fleet status`: fleet.toml + the task table.
+fn status_cmd() -> Result<i32> {
+    let root = std::env::current_dir().context("determining project root")?;
+    let dirs = FleetDirs::new(&root);
+    let Some(state) = load_state(&dirs.state_path())? else {
+        println!("no fleet has run in this project — start one with `wizard fleet run`");
+        return Ok(0);
+    };
+    println!("mission: {}", state.mission);
+    println!(
+        "status:  {} — {} worker(s), started {}",
+        state.status, state.workers, state.started
+    );
+    if !state.pids.is_empty() {
+        println!(
+            "pids:    {}",
+            state
+                .pids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    let rows = status_rows(&dirs)?;
+    if rows.is_empty() {
+        println!("no tasks recorded");
+    } else {
+        println!();
+        print!("{}", render_table(&rows));
+    }
+    Ok(0)
+}
+
+/// `wizard fleet stop`: write the stop sentinel; the coordinator winds down
+/// on its next supervision tick.
+fn stop_cmd() -> Result<i32> {
+    let root = std::env::current_dir().context("determining project root")?;
+    let dirs = FleetDirs::new(&root);
+    std::fs::create_dir_all(dirs.stop_path().parent().expect("stop path has a parent"))
+        .context("creating .wizard/fleet")?;
+    std::fs::write(dirs.stop_path(), "stop\n").context("writing the stop sentinel")?;
+    println!("stop requested — the coordinator winds down on its next tick");
+    Ok(0)
+}
+
+/// Wipe the per-run directories (queue/claimed/results/logs) and any stale
+/// stop sentinel, keeping worktrees/ for [`setup_slot`] to recycle.
+fn reset_run_dirs(dirs: &FleetDirs) -> Result<()> {
+    for dir in [dirs.queue(), dirs.claimed(), dirs.results(), dirs.logs()] {
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    dirs.ensure()?;
+    let _ = std::fs::remove_file(dirs.stop_path());
+    Ok(())
+}
+
+/// `wizard fleet run -n N -p "<mission>"`: plan → spawn → supervise →
+/// synthesize. See the module docs for the lifecycle.
+async fn run_fleet(n: usize, mission: String) -> Result<i32> {
+    if n == 0 {
+        bail!("-n must be at least 1");
+    }
+    let root = std::env::current_dir().context("determining project root")?;
+    git::rev_parse(&root, "HEAD").await.map_err(|err| {
+        anyhow::anyhow!(
+            "fleet requires a git repository with at least one commit \
+             (workers run in git worktrees): {err}"
+        )
+    })?;
+    let config = Config::load()?;
+
+    let dirs = FleetDirs::new(&root);
+    reset_run_dirs(&dirs)?;
+    let mut state = FleetState {
+        mission: mission.clone(),
+        workers: n,
+        started: chrono::Local::now().to_rfc3339(),
+        status: "planning".to_string(),
+        pids: Vec::new(),
+    };
+    save_state(&dirs.state_path(), &state)?;
+
+    // 1. Planning turn (in-process headless agent).
+    println!(
+        "fleet: planning — decomposing the mission into up to {} task(s)…",
+        n * 2
+    );
+    let mut agent = build_headless_agent(&config, &root, false).await?;
+    let tasks = decompose(&mut agent, &mission, n * 2).await?;
+    for task in &tasks {
+        let path = dirs.queue().join(format!("{}.json", task.id));
+        let text = serde_json::to_string_pretty(task).context("serializing task")?;
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    }
+    println!("fleet: {} task(s) queued", tasks.len());
+
+    // 2. Worker slots: one worktree + branch per slot, at most N.
+    let mission_slug = slug(&mission);
+    let slot_count = n.min(tasks.len()).max(1);
+    let mut slots = Vec::with_capacity(slot_count);
+    for index in 0..slot_count {
+        let slot = setup_slot(&root, &dirs, index, &mission_slug).await?;
+        println!(
+            "fleet: worker {index} on branch {} ({})",
+            slot.branch,
+            slot.worktree.display()
+        );
+        slots.push(slot);
+    }
+    state.status = "running".to_string();
+    save_state(&dirs.state_path(), &state)?;
+
+    // 3. Supervision until the queue drains or a stop arrives.
+    let completed = supervise(&dirs, &mut slots, &mut state, config.fleet.max_minutes).await?;
+    let results = load_results(&dirs)?;
+
+    // 4. Synthesis (skipped on stop or `[fleet] synthesize = false`).
+    if completed && config.fleet.synthesize && !results.is_empty() {
+        state.status = "synthesizing".to_string();
+        save_state(&dirs.state_path(), &state)?;
+        println!("\nfleet: synthesizing — merging fleet branches into the current branch…");
+        run_collect_text(&mut agent, &synthesis_prompt(&mission, &results)).await?;
+    } else if completed && !config.fleet.synthesize {
+        println!("\nfleet: synthesis disabled ([fleet] synthesize = false) — branches kept:");
+        for slot in &slots {
+            println!("  {}", slot.branch);
+        }
+    }
+
+    // 5. Teardown: worktrees go, branches stay.
+    for slot in &slots {
+        git::worktree_remove(&root, &slot.worktree).await;
+    }
+    let _ = std::fs::remove_file(dirs.stop_path());
+    state.status = if completed { "done" } else { "stopped" }.to_string();
+    state.pids.clear();
+    save_state(&dirs.state_path(), &state)?;
+
+    println!("\nfleet: {}", state.status);
+    let rows = status_rows(&dirs)?;
+    if !rows.is_empty() {
+        print!("{}", render_table(&rows));
+    }
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    use futures_util::stream;
+
+    use super::*;
+    use crate::agent::session::Session;
+    use crate::hooks::HookEngine;
+    use crate::llm::provider::LlmProvider;
+    use crate::llm::{ChatChunk, ChatMessage, ChatRequest, ChatStream};
+    use crate::tools::registry::ToolRegistry;
+
+    fn task(id: &str, prompt: &str) -> FleetTask {
+        FleetTask {
+            id: id.to_string(),
+            title: format!("title of {id}"),
+            prompt: prompt.to_string(),
+            files_hint: Vec::new(),
+        }
+    }
+
+    // --- parse_tasks ---
+
+    #[test]
+    fn parse_tasks_plain_array() {
+        let tasks = parse_tasks(
+            r#"[{"id":"a","title":"A","prompt":"do a","files_hint":["src/a.rs"]},
+                {"id":"b","title":"B","prompt":"do b"}]"#,
+        )
+        .expect("parses");
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].id, "a");
+        assert_eq!(tasks[0].files_hint, vec!["src/a.rs"]);
+        assert_eq!(tasks[1].files_hint, Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_tasks_fenced_json_with_prose() {
+        let text = "Sure! Here is the decomposition you asked for:\n\n```json\n\
+                    [{\"id\":\"x\",\"title\":\"X\",\"prompt\":\"do x\"}]\n```\n\
+                    Let me know if you need anything else.";
+        let tasks = parse_tasks(text).expect("parses");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "x");
+    }
+
+    #[test]
+    fn parse_tasks_object_with_tasks_key() {
+        let tasks = parse_tasks(r#"{"tasks":[{"prompt":"do it","title":"T"}]}"#).expect("parses");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].prompt, "do it");
+    }
+
+    #[test]
+    fn parse_tasks_single_object_is_one_task() {
+        let tasks = parse_tasks(r#"{"id":"solo","prompt":"just this"}"#).expect("parses");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "solo");
+    }
+
+    #[test]
+    fn parse_tasks_skips_earlier_non_task_json() {
+        // A balanced-but-wrong object precedes the real array.
+        let text = r#"My config is {"mode": "fast"} so the plan is:
+                      [{"id":"real","prompt":"the task"}]"#;
+        let tasks = parse_tasks(text).expect("parses");
+        assert_eq!(tasks[0].id, "real");
+    }
+
+    #[test]
+    fn parse_tasks_handles_brackets_inside_strings() {
+        let text = r#"[{"id":"s","prompt":"watch out for ] and } and \" in strings"}]"#;
+        let tasks = parse_tasks(text).expect("parses");
+        assert!(tasks[0].prompt.contains(']'));
+    }
+
+    #[test]
+    fn parse_tasks_rejects_garbage_and_empty() {
+        assert!(parse_tasks("no json here at all").is_err());
+        assert!(parse_tasks("[]").is_err());
+        assert!(parse_tasks(r#"[{"title":"no prompt"}]"#).is_err());
+        assert!(parse_tasks("[1, 2, 3]").is_err());
+    }
+
+    // --- finalize_tasks ---
+
+    #[test]
+    fn finalize_fills_ids_dedupes_and_caps() {
+        let tasks = vec![
+            FleetTask {
+                id: String::new(),
+                title: "Fix The Parser!".to_string(),
+                prompt: "p1".to_string(),
+                files_hint: Vec::new(),
+            },
+            FleetTask {
+                id: "fix-the-parser".to_string(),
+                title: String::new(),
+                prompt: "p2".to_string(),
+                files_hint: Vec::new(),
+            },
+            FleetTask {
+                id: String::new(),
+                title: String::new(),
+                prompt: "p3".to_string(),
+                files_hint: Vec::new(),
+            },
+            FleetTask {
+                id: "dropped".to_string(),
+                title: "no prompt".to_string(),
+                prompt: "   ".to_string(),
+                files_hint: Vec::new(),
+            },
+            FleetTask {
+                id: "over-cap".to_string(),
+                title: "t".to_string(),
+                prompt: "p5".to_string(),
+                files_hint: Vec::new(),
+            },
+        ];
+        let out = finalize_tasks(tasks, 3).expect("finalizes");
+        assert_eq!(out.len(), 3, "capped at max_tasks");
+        assert_eq!(out[0].id, "fix-the-parser");
+        assert_eq!(out[1].id, "fix-the-parser-2", "duplicate id de-duplicated");
+        assert_eq!(out[1].title, "fix-the-parser-2", "empty title backfilled");
+        assert_eq!(out[2].id, "task-3", "positional fallback id");
+    }
+
+    #[test]
+    fn finalize_rejects_all_empty() {
+        let tasks = vec![task("a", "  ")];
+        assert!(finalize_tasks(tasks, 4).is_err());
+    }
+
+    // --- slug ---
+
+    #[test]
+    fn slug_kebabs_and_caps() {
+        assert_eq!(slug("Fix the HTTP parser"), "fix-the-http-parser");
+        assert_eq!(slug("  weird///chars!!  "), "weird-chars");
+        assert_eq!(slug("!!!"), "fleet");
+        let long = slug("a very long mission statement that keeps going and going");
+        assert!(long.len() <= SLUG_MAX, "{long:?} too long");
+        assert!(!long.ends_with('-'));
+    }
+
+    // --- worker argv / prompt ---
+
+    #[test]
+    fn worker_args_construction() {
+        let args = worker_args("do the thing", Path::new("/tmp/wt/0"));
+        assert_eq!(
+            args,
+            vec![
+                "--mode",
+                "sovereign",
+                "-p",
+                "do the thing",
+                "--cwd",
+                "/tmp/wt/0",
+                "--output-format",
+                "json",
+            ]
+        );
+    }
+
+    #[test]
+    fn worker_prompt_wraps_task_with_commit_instructions() {
+        let mut t = task("a", "refactor the parser");
+        t.files_hint = vec!["src/parser.rs".to_string()];
+        let p = worker_prompt(&t);
+        assert!(p.contains("refactor the parser"));
+        assert!(p.contains("src/parser.rs"));
+        assert!(p.contains("commit your changes"));
+        assert!(p.contains("Do not push"));
+    }
+
+    // --- claiming ---
+
+    #[test]
+    fn claim_moves_task_from_queue_to_claimed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let queue = dir.path().join("queue");
+        let claimed = dir.path().join("claimed");
+        std::fs::create_dir_all(&queue).unwrap();
+        std::fs::create_dir_all(&claimed).unwrap();
+        let t = task("a", "do a");
+        std::fs::write(queue.join("a.json"), serde_json::to_string(&t).unwrap()).unwrap();
+
+        assert!(!queue_is_empty(&queue).unwrap());
+        let got = claim_next(&queue, &claimed)
+            .expect("claims")
+            .expect("a task");
+        assert_eq!(got, t);
+        assert!(queue_is_empty(&queue).unwrap());
+        assert!(claimed.join("a.json").exists());
+        assert!(claim_next(&queue, &claimed).expect("ok").is_none());
+    }
+
+    #[test]
+    fn claim_race_exactly_one_wins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let queue = dir.path().join("queue");
+        let claimed = dir.path().join("claimed");
+        std::fs::create_dir_all(&queue).unwrap();
+        std::fs::create_dir_all(&claimed).unwrap();
+        std::fs::write(
+            queue.join("only.json"),
+            serde_json::to_string(&task("only", "the one task")).unwrap(),
+        )
+        .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let queue = queue.clone();
+                let claimed = claimed.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    claim_next(&queue, &claimed).expect("claim never errors")
+                })
+            })
+            .collect();
+        let wins: Vec<_> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread joins"))
+            .collect();
+        assert_eq!(
+            wins.iter().filter(|w| w.is_some()).count(),
+            1,
+            "exactly one claimant wins: {wins:?}"
+        );
+    }
+
+    #[test]
+    fn claim_on_missing_queue_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            claim_next(&dir.path().join("absent"), &dir.path().join("claimed"))
+                .expect("ok")
+                .is_none()
+        );
+        assert!(queue_is_empty(&dir.path().join("absent")).unwrap());
+    }
+
+    // --- fleet.toml ---
+
+    #[test]
+    fn fleet_state_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fleet.toml");
+        assert!(load_state(&path).expect("missing is None").is_none());
+
+        let state = FleetState {
+            mission: "improve test coverage".to_string(),
+            workers: 3,
+            started: "2026-06-11T10:00:00-04:00".to_string(),
+            status: "running".to_string(),
+            pids: vec![123, 456],
+        };
+        save_state(&path, &state).expect("saves");
+        let loaded = load_state(&path).expect("loads").expect("present");
+        assert_eq!(loaded, state);
+    }
+
+    // --- stop sentinel ---
+
+    #[test]
+    fn stop_sentinel_detection() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dirs = FleetDirs::new(dir.path());
+        dirs.ensure().expect("ensure");
+        assert!(!dirs.stop_requested());
+        std::fs::write(dirs.stop_path(), "stop\n").unwrap();
+        assert!(dirs.stop_requested());
+    }
+
+    // --- tick ---
+
+    #[test]
+    fn tick_stop_overrides_everything() {
+        let slots = [SlotStatus::Running, SlotStatus::Exited, SlotStatus::Idle];
+        assert_eq!(tick(&slots, false, true), vec![TickAction::StopAll]);
+    }
+
+    #[test]
+    fn tick_reaps_kills_and_spawns() {
+        let slots = [
+            SlotStatus::Exited,
+            SlotStatus::Overdue,
+            SlotStatus::Idle,
+            SlotStatus::Running,
+        ];
+        assert_eq!(
+            tick(&slots, false, false),
+            vec![
+                TickAction::Reap(0),
+                TickAction::Kill(1),
+                TickAction::Spawn(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn tick_idle_slots_wait_when_queue_is_empty() {
+        let slots = [SlotStatus::Idle, SlotStatus::Running];
+        assert_eq!(tick(&slots, true, false), Vec::<TickAction>::new());
+    }
+
+    #[test]
+    fn tick_all_done_when_queue_empty_and_all_idle() {
+        let slots = [SlotStatus::Idle, SlotStatus::Idle];
+        assert_eq!(tick(&slots, true, false), vec![TickAction::AllDone]);
+    }
+
+    #[test]
+    fn tick_reaps_before_done_on_empty_queue() {
+        let slots = [SlotStatus::Idle, SlotStatus::Exited];
+        assert_eq!(tick(&slots, true, false), vec![TickAction::Reap(1)]);
+    }
+
+    // --- status table ---
+
+    #[test]
+    fn status_rows_from_synthetic_layout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dirs = FleetDirs::new(dir.path());
+        dirs.ensure().expect("ensure");
+
+        let write_task = |dir: &Path, t: &FleetTask| {
+            std::fs::write(
+                dir.join(format!("{}.json", t.id)),
+                serde_json::to_string(t).unwrap(),
+            )
+            .unwrap();
+        };
+        write_task(&dirs.queue(), &task("c-queued", "later"));
+        write_task(&dirs.claimed(), &task("a-running", "now"));
+        write_task(&dirs.claimed(), &task("b-done", "earlier"));
+        let result = TaskResult {
+            task_id: "b-done".to_string(),
+            title: "title of b-done".to_string(),
+            branch: "fleet/0-mission".to_string(),
+            exit: Some(0),
+            timed_out: false,
+            summary: Some(serde_json::json!({"result": "ok", "reason": "completed"})),
+        };
+        std::fs::write(
+            dirs.results().join("b-done.json"),
+            serde_json::to_string(&result).unwrap(),
+        )
+        .unwrap();
+
+        let rows = status_rows(&dirs).expect("rows");
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            (
+                rows[0].id.as_str(),
+                rows[0].state.as_str(),
+                rows[0].exit.as_str()
+            ),
+            ("a-running", "running", "-")
+        );
+        assert_eq!(
+            (
+                rows[1].id.as_str(),
+                rows[1].state.as_str(),
+                rows[1].exit.as_str()
+            ),
+            ("b-done", "done", "0")
+        );
+        assert_eq!(rows[1].branch, "fleet/0-mission");
+        assert_eq!(
+            (rows[2].id.as_str(), rows[2].state.as_str()),
+            ("c-queued", "queued")
+        );
+
+        let table = render_table(&rows);
+        assert!(table.starts_with("task"));
+        assert_eq!(table.lines().count(), 4, "header + three rows");
+    }
+
+    #[test]
+    fn status_rows_label_killed_and_timeout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dirs = FleetDirs::new(dir.path());
+        dirs.ensure().expect("ensure");
+        for (id, timed_out) in [("killed", false), ("slow", true)] {
+            let result = TaskResult {
+                task_id: id.to_string(),
+                title: id.to_string(),
+                branch: "fleet/0-x".to_string(),
+                exit: None,
+                timed_out,
+                summary: None,
+            };
+            std::fs::write(
+                dirs.results().join(format!("{id}.json")),
+                serde_json::to_string(&result).unwrap(),
+            )
+            .unwrap();
+        }
+        let rows = status_rows(&dirs).expect("rows");
+        assert_eq!(rows[0].exit, "killed");
+        assert_eq!(rows[1].exit, "timeout");
+    }
+
+    // --- planning pipeline with a scripted provider ---
+
+    /// Minimal scripted provider: replays canned chunk sequences, one per
+    /// `chat_stream` call, and counts requests (mirrors the agent-loop test
+    /// harness in `crate::agent`).
+    #[derive(Debug)]
+    struct Scripted {
+        responses: Mutex<VecDeque<Vec<ChatChunk>>>,
+        requests: Mutex<usize>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for Scripted {
+        async fn health(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn supports_native_tools(&self, _model: &str) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn list_models(&self) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn chat_stream(&self, _request: ChatRequest) -> Result<ChatStream> {
+            *self.requests.lock().unwrap() += 1;
+            let chunks = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("scripted response available");
+            Ok(futures_util::StreamExt::boxed(stream::iter(
+                chunks.into_iter().map(Ok),
+            )))
+        }
+
+        async fn context_window(&self, _model: &str) -> Option<u32> {
+            None
+        }
+
+        fn label(&self) -> String {
+            "scripted:fleet-test".to_string()
+        }
+    }
+
+    fn reply(content: &str) -> Vec<ChatChunk> {
+        vec![ChatChunk {
+            message: Some(ChatMessage::assistant(content)),
+            thinking: false,
+            done: true,
+            done_reason: None,
+            eval_count: None,
+            prompt_eval_count: None,
+        }]
+    }
+
+    /// Build an in-process agent over a scripted provider, rooted in `tmp`
+    /// (sessions and the usage log stay inside it).
+    fn scripted_agent(tmp: &Path, responses: Vec<Vec<ChatChunk>>) -> (Agent, Arc<Scripted>) {
+        let provider = Arc::new(Scripted {
+            responses: Mutex::new(responses.into()),
+            requests: Mutex::new(0),
+        });
+        let session = Session::create(&tmp.join("sessions")).expect("create session");
+        let hooks = Arc::new(HookEngine::new(
+            Vec::new(),
+            tmp.to_path_buf(),
+            session.id.clone(),
+        ));
+        let mut agent = Agent::new(
+            Arc::clone(&provider) as Arc<dyn LlmProvider>,
+            ToolRegistry::new(),
+            Config::default(),
+            Vec::new(),
+            tmp.to_path_buf(),
+            session,
+            true,
+            hooks,
+        )
+        .expect("build agent");
+        agent.set_usage_log(Some(tmp.join("usage.jsonl")));
+        (agent, provider)
+    }
+
+    #[tokio::test]
+    async fn decompose_parses_a_canned_task_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut agent, provider) = scripted_agent(
+            dir.path(),
+            vec![reply(
+                "Here you go:\n```json\n[\
+                 {\"id\":\"add-tests\",\"title\":\"Add tests\",\"prompt\":\"add unit tests\",\
+                  \"files_hint\":[\"src/lib.rs\"]},\
+                 {\"id\":\"write-docs\",\"title\":\"Write docs\",\"prompt\":\"document the api\"}\
+                 ]\n```",
+            )],
+        );
+        let tasks = decompose(&mut agent, "improve the project", 4)
+            .await
+            .expect("decomposes");
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].id, "add-tests");
+        assert_eq!(tasks[0].files_hint, vec!["src/lib.rs"]);
+        assert_eq!(tasks[1].id, "write-docs");
+        assert_eq!(*provider.requests.lock().unwrap(), 1, "no retry needed");
+    }
+
+    #[tokio::test]
+    async fn decompose_retries_once_on_unparsable_reply() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut agent, provider) = scripted_agent(
+            dir.path(),
+            vec![
+                reply("I would split this mission into two parts, roughly speaking."),
+                reply(r#"[{"id":"only","title":"Only","prompt":"the single task"}]"#),
+            ],
+        );
+        let tasks = decompose(&mut agent, "do the thing", 4)
+            .await
+            .expect("decomposes on retry");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "only");
+        assert_eq!(*provider.requests.lock().unwrap(), 2, "exactly one retry");
+    }
+
+    #[tokio::test]
+    async fn decompose_fails_after_two_unparsable_replies() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut agent, provider) = scripted_agent(
+            dir.path(),
+            vec![reply("no json, sorry"), reply("still no json")],
+        );
+        let err = decompose(&mut agent, "do the thing", 4)
+            .await
+            .expect_err("gives up after the retry");
+        assert!(err.to_string().contains("retry"), "{err}");
+        assert_eq!(*provider.requests.lock().unwrap(), 2);
+    }
+
+    // --- synthesis prompt ---
+
+    #[test]
+    fn synthesis_prompt_lists_results_and_merge_instructions() {
+        let results = vec![
+            TaskResult {
+                task_id: "a".to_string(),
+                title: "Task A".to_string(),
+                branch: "fleet/0-m".to_string(),
+                exit: Some(0),
+                timed_out: false,
+                summary: Some(serde_json::json!({"result": "did the thing"})),
+            },
+            TaskResult {
+                task_id: "b".to_string(),
+                title: "Task B".to_string(),
+                branch: "fleet/1-m".to_string(),
+                exit: None,
+                timed_out: true,
+                summary: None,
+            },
+        ];
+        let p = synthesis_prompt("the mission", &results);
+        assert!(p.contains("the mission"));
+        assert!(p.contains("fleet/0-m"));
+        assert!(p.contains("did the thing"));
+        assert!(p.contains("killed (timeout)"));
+        assert!(p.contains("git merge"));
+        assert!(p.contains("--abort"));
+        assert!(!p.contains("force-push"), "never instructs force anything");
+    }
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
-use crate::agent::{Agent, AgentEvent, build_headless_agent};
+use crate::agent::{Agent, AgentEvent, PlanVerdict, build_headless_agent};
 use crate::cli::Cli;
 use crate::config::{Config, GatewayKind, Mode};
 
@@ -129,6 +129,11 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
     let mut agent = build_headless_agent(&agent_config, project_root, false)
         .await
         .context("building gateway agent")?;
+    // `plan_first = true`: the first turn plans read-only; the collector in
+    // run_one_turn auto-approves the plan and includes it in the reply.
+    if config.plan_first {
+        agent.set_plan_mode(true);
+    }
 
     // session_start hooks fire once for the whole gateway session.
     fire_session_hooks(&mut agent, true).await;
@@ -174,6 +179,22 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
                     .await
                 {
                     eprintln!("failed to send rejection: {err:#}");
+                }
+                continue;
+            }
+
+            // "/plan" toggles plan mode for subsequent messages, mirroring
+            // the TUI's slash command.
+            if message.text.trim() == "/plan" {
+                let on = !agent.plan_mode();
+                agent.set_plan_mode(on);
+                let confirmation = if on {
+                    "plan mode on — the next task is planned read-only first"
+                } else {
+                    "plan mode off"
+                };
+                if let Err(err) = gateway.send(message.chat_id, confirmation).await {
+                    eprintln!("failed to confirm /plan to {}: {err:#}", message.chat_id);
                 }
                 continue;
             }
@@ -233,6 +254,12 @@ async fn run_one_turn(agent: &mut Agent, text: &str) -> String {
                 AgentEvent::TextDelta(delta) => reply.push_str(&delta),
                 AgentEvent::ToolStarted { name, .. } => tools.push(name),
                 AgentEvent::Error(message) => error = Some(message),
+                AgentEvent::PlanReady { plan, respond } => {
+                    // No human reviews a gateway plan: include it in the
+                    // reply and approve so the turn proceeds to execute.
+                    reply.push_str(&format!("[plan]\n{plan}\n[plan auto-approved]\n\n"));
+                    let _ = respond.send(PlanVerdict::approve());
+                }
                 _ => {}
             }
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -130,6 +130,9 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
         .await
         .context("building gateway agent")?;
 
+    // session_start hooks fire once for the whole gateway session.
+    fire_session_hooks(&mut agent, true).await;
+
     let allowed = config.gateway.allowed_chat_ids.clone();
     println!(
         "wizard gateway ({}) — listening for messages (Ctrl-C to stop)",
@@ -142,7 +145,7 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
             biased;
             _ = tokio::signal::ctrl_c() => {
                 println!("\n[gateway stopped]");
-                return Ok(());
+                break;
             }
             result = gateway.poll() => match result {
                 Ok(messages) => {
@@ -183,6 +186,31 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
                     break;
                 }
             }
+        }
+    }
+
+    fire_session_hooks(&mut agent, false).await;
+    Ok(())
+}
+
+/// Fire the `session_start` (`start = true`) or `session_end` hooks and
+/// print their activity — the gateway has no long-lived event channel.
+async fn fire_session_hooks(agent: &mut Agent, start: bool) {
+    let (tx, mut rx) = mpsc::channel::<AgentEvent>(256);
+    if start {
+        agent.fire_session_start(&tx).await;
+    } else {
+        agent.fire_session_end(Some(&tx)).await;
+    }
+    drop(tx);
+    while let Some(event) = rx.recv().await {
+        if let AgentEvent::HookFired {
+            event,
+            command,
+            outcome,
+        } = event
+        {
+            println!("hook {event}: {outcome} ({command})");
         }
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -113,16 +113,15 @@ pub async fn run(config: Config, _cli: Cli) -> Result<()> {
     }
 }
 
-/// Drive a gateway: build one sovereign / auto-approve agent, then loop —
-/// poll for inbound messages (retrying network errors with backoff), enforce
-/// the allow-list, run one agent turn per message, and send the reply (split
-/// into platform-sized chunks). Runs until Ctrl-C.
+/// Drive a gateway: build one sovereign agent, then loop — poll for inbound
+/// messages (retrying network errors with backoff), enforce the allow-list,
+/// run one agent turn per message, and send the reply (split into
+/// platform-sized chunks). Runs until Ctrl-C.
 async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Path) -> Result<()> {
-    // The gateway is fully autonomous: there is no terminal to approve tool
-    // calls, so run in sovereign / auto-approve posture.
+    // The gateway is fully autonomous: there is no terminal, so run in
+    // sovereign posture.
     let mut agent_config = config.clone();
     agent_config.mode = Mode::Sovereign;
-    agent_config.auto_approve = true;
     if agent_config.max_steps < Mode::Sovereign.default_max_steps() {
         agent_config.max_steps = Mode::Sovereign.default_max_steps();
     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,745 @@
+//! Lifecycle hooks: user-supplied shell commands that observe and steer the
+//! agent at fixed points of every mode (TUI genie, sovereign headless,
+//! perpetual continuous, gateway). See `docs/hooks.md`.
+//!
+//! Hooks are declared in `~/.wizard/hooks.toml` and
+//! `<project>/.wizard/hooks.toml` (project hooks run after global ones) and
+//! receive a JSON payload on stdin. Exit 0 continues — depending on the
+//! event, stdout may rewrite tool arguments or append extra context. Exit 2
+//! blocks, with stderr as the reason. Any other exit code, a timeout, or a
+//! spawn failure is a logged warning and the pipeline continues: a broken
+//! hook can never wedge the agent.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use globset::{Glob, GlobMatcher};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+
+use crate::agent::AgentEvent;
+use crate::config::{Config, Mode};
+
+/// Wall-clock budget for one hook when `timeout_secs` is not set.
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+/// Lifecycle points a hook can attach to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookEvent {
+    /// Before a tool call executes. May rewrite the arguments or block.
+    PreToolUse,
+    /// After a tool call executes. Stdout is appended to the tool result.
+    PostToolUse,
+    /// When a user message starts a turn. Stdout is appended to the message;
+    /// exit 2 ends the turn before the model sees it.
+    UserPromptSubmit,
+    /// Once when a session begins. Stdout becomes system context.
+    SessionStart,
+    /// Once when a session ends. Observational.
+    SessionEnd,
+    /// After every turn finishes. Observational.
+    TurnEnd,
+}
+
+impl HookEvent {
+    /// The snake_case name used in `hooks.toml` and the stdin payload.
+    pub fn name(self) -> &'static str {
+        match self {
+            HookEvent::PreToolUse => "pre_tool_use",
+            HookEvent::PostToolUse => "post_tool_use",
+            HookEvent::UserPromptSubmit => "user_prompt_submit",
+            HookEvent::SessionStart => "session_start",
+            HookEvent::SessionEnd => "session_end",
+            HookEvent::TurnEnd => "turn_end",
+        }
+    }
+}
+
+/// One `[[hooks]]` entry from a `hooks.toml` file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HookDef {
+    /// Which lifecycle event this hook fires on.
+    pub event: HookEvent,
+    /// Optional glob over the tool name (`"execute"`, `"git_*"`). Only
+    /// meaningful for the tool events; other events fire regardless.
+    #[serde(default)]
+    pub matcher: Option<String>,
+    /// Shell command, run via `sh -c` in the project root.
+    pub command: String,
+    /// Wall-clock budget; the hook is killed and ignored past it
+    /// (default 60).
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+/// On-disk shape of a `hooks.toml` file.
+#[derive(Debug, Default, Deserialize)]
+struct HooksFile {
+    #[serde(default)]
+    hooks: Vec<HookDef>,
+}
+
+/// Parse the contents of one `hooks.toml`.
+pub fn parse(raw: &str) -> Result<Vec<HookDef>, toml::de::Error> {
+    toml::from_str::<HooksFile>(raw).map(|file| file.hooks)
+}
+
+/// Load hook definitions for a project: global `~/.wizard/hooks.toml` first,
+/// then `<project>/.wizard/hooks.toml` appended after it.
+pub fn load(project_root: &Path) -> Vec<HookDef> {
+    let mut paths = Vec::new();
+    match Config::wizard_dir() {
+        Ok(dir) => paths.push(dir.join("hooks.toml")),
+        Err(err) => tracing::warn!("could not resolve ~/.wizard for hooks: {err}"),
+    }
+    paths.push(project_root.join(".wizard").join("hooks.toml"));
+    load_files(&paths)
+}
+
+/// Read and parse each path in order, concatenating the results. Missing
+/// files mean no hooks; unreadable or invalid files are skipped with a
+/// warning so a bad hook file can never prevent startup.
+fn load_files(paths: &[PathBuf]) -> Vec<HookDef> {
+    let mut defs = Vec::new();
+    for path in paths {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(raw) => raw,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                tracing::warn!("could not read {}: {err}", path.display());
+                continue;
+            }
+        };
+        match parse(&raw) {
+            Ok(mut hooks) => defs.append(&mut hooks),
+            Err(err) => tracing::warn!("skipping invalid {}: {err}", path.display()),
+        }
+    }
+    defs
+}
+
+/// What one hook execution did, surfaced via [`AgentEvent::HookFired`].
+/// Plain successes ([`HookOutcome::Ok`]) are not reported.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookOutcome {
+    /// Exit 0 with no pipeline effect.
+    Ok,
+    /// `pre_tool_use` rewrote the tool arguments.
+    UpdatedArgs,
+    /// Stdout was appended as extra context.
+    AppendedContext,
+    /// Exit 2: the action was blocked for this reason.
+    Blocked(String),
+    /// The hook misbehaved (other exit code, timeout, spawn failure) and was
+    /// ignored.
+    Warning(String),
+}
+
+impl fmt::Display for HookOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HookOutcome::Ok => write!(f, "ok"),
+            HookOutcome::UpdatedArgs => write!(f, "updated args"),
+            HookOutcome::AppendedContext => write!(f, "appended context"),
+            HookOutcome::Blocked(reason) => write!(f, "blocked — {reason}"),
+            HookOutcome::Warning(why) => write!(f, "warning — {why}"),
+        }
+    }
+}
+
+/// Verdict of the `pre_tool_use` chain for one tool call.
+#[derive(Debug)]
+pub enum PreToolUse {
+    /// Proceed; `Some` holds rewritten arguments.
+    Continue(Option<Value>),
+    /// Veto the call; the reason feeds back to the model as a tool error.
+    Block(String),
+}
+
+/// Verdict of the `user_prompt_submit` chain for one turn.
+#[derive(Debug)]
+pub enum PromptSubmit {
+    /// Proceed; `Some` holds extra context to append to the message.
+    Continue(Option<String>),
+    /// End the turn before the model sees the prompt.
+    Block(String),
+}
+
+/// Append `post_tool_use` hook context to a tool result body. Shared by the
+/// dispatcher and the subagent loop so the framing stays identical.
+pub fn append_context(content: &mut String, extra: &str) {
+    if !content.is_empty() {
+        content.push_str("\n\n");
+    }
+    content.push_str("[post_tool_use hook]\n");
+    content.push_str(extra);
+}
+
+/// A [`HookDef`] with its matcher glob compiled.
+struct CompiledHook {
+    def: HookDef,
+    matcher: Option<GlobMatcher>,
+}
+
+/// How one hook process finished.
+enum RunResult {
+    Exited {
+        code: i32,
+        stdout: String,
+        stderr: String,
+    },
+    /// Spawn failure, wait failure, or timeout.
+    Failed(String),
+}
+
+/// Internal verdict of [`HookEngine::fire`].
+enum FireResult {
+    Continue(Option<String>),
+    Block(String),
+}
+
+/// Runs the configured hooks for lifecycle events. Built once per agent and
+/// shared (via `Arc`) by the dispatcher, the agent loop, and the subagent
+/// spawner, so every tool call in every mode sees the same hooks. With no
+/// hooks configured every fire point reduces to an empty-Vec scan.
+pub struct HookEngine {
+    hooks: Vec<CompiledHook>,
+    /// Project root: hooks run here and it is the payload `cwd`.
+    cwd: PathBuf,
+    /// Current session id for payloads; swapped when `/clear` starts a new
+    /// session.
+    session_id: Mutex<String>,
+}
+
+impl HookEngine {
+    /// Compile `defs` into an engine. A hook with an invalid matcher glob is
+    /// dropped with a warning.
+    pub fn new(defs: Vec<HookDef>, cwd: PathBuf, session_id: String) -> Self {
+        let hooks = defs
+            .into_iter()
+            .filter_map(|def| {
+                let matcher = match &def.matcher {
+                    Some(pattern) => match Glob::new(pattern) {
+                        Ok(glob) => Some(glob.compile_matcher()),
+                        Err(err) => {
+                            tracing::warn!(
+                                "dropping hook '{}': invalid matcher '{pattern}': {err}",
+                                def.command
+                            );
+                            return None;
+                        }
+                    },
+                    None => None,
+                };
+                Some(CompiledHook { def, matcher })
+            })
+            .collect();
+        Self {
+            hooks,
+            cwd,
+            session_id: Mutex::new(session_id),
+        }
+    }
+
+    /// True when no hooks are configured (the default).
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
+    }
+
+    /// Swap the payload session id (after `/clear` starts a new session).
+    pub fn set_session_id(&self, id: String) {
+        *self.session_id.lock().unwrap() = id;
+    }
+
+    /// `pre_tool_use`: run the matching hooks before `tool` executes. Exit 2
+    /// vetoes the call; exit 0 with stdout `{"updated_args": {...}}` rewrites
+    /// the arguments (later hooks in the chain see the rewritten args).
+    pub async fn pre_tool_use(
+        &self,
+        tool: &str,
+        args: &Value,
+        mode: Mode,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> PreToolUse {
+        let mut updated: Option<Value> = None;
+        for hook in self.matching(HookEvent::PreToolUse, Some(tool)) {
+            let effective = updated.as_ref().unwrap_or(args);
+            let run = self
+                .run(hook, HookEvent::PreToolUse, Some((tool, effective)), mode)
+                .await;
+            match run {
+                RunResult::Exited {
+                    code: 0, stdout, ..
+                } => {
+                    if let Some(args) = parse_updated_args(&stdout) {
+                        updated = Some(args);
+                        self.report(
+                            events,
+                            HookEvent::PreToolUse,
+                            hook,
+                            HookOutcome::UpdatedArgs,
+                        )
+                        .await;
+                    }
+                }
+                RunResult::Exited {
+                    code: 2, stderr, ..
+                } => {
+                    let reason = block_reason(&stderr);
+                    self.report(
+                        events,
+                        HookEvent::PreToolUse,
+                        hook,
+                        HookOutcome::Blocked(reason.clone()),
+                    )
+                    .await;
+                    return PreToolUse::Block(reason);
+                }
+                RunResult::Exited { code, stderr, .. } => {
+                    self.report(
+                        events,
+                        HookEvent::PreToolUse,
+                        hook,
+                        HookOutcome::Warning(exit_warning(code, &stderr)),
+                    )
+                    .await;
+                }
+                RunResult::Failed(why) => {
+                    self.report(
+                        events,
+                        HookEvent::PreToolUse,
+                        hook,
+                        HookOutcome::Warning(why),
+                    )
+                    .await;
+                }
+            }
+        }
+        PreToolUse::Continue(updated)
+    }
+
+    /// `post_tool_use`: extra context to append to the tool result, if any
+    /// matching hook printed some.
+    pub async fn post_tool_use(
+        &self,
+        tool: &str,
+        args: &Value,
+        mode: Mode,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> Option<String> {
+        match self
+            .fire(
+                HookEvent::PostToolUse,
+                Some((tool, args)),
+                mode,
+                false,
+                true,
+                events,
+            )
+            .await
+        {
+            FireResult::Continue(extra) => extra,
+            // Unreachable: post_tool_use is not blockable.
+            FireResult::Block(_) => None,
+        }
+    }
+
+    /// `user_prompt_submit`: may veto the turn or add context to the message.
+    pub async fn user_prompt_submit(
+        &self,
+        mode: Mode,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> PromptSubmit {
+        match self
+            .fire(HookEvent::UserPromptSubmit, None, mode, true, true, events)
+            .await
+        {
+            FireResult::Continue(extra) => PromptSubmit::Continue(extra),
+            FireResult::Block(reason) => PromptSubmit::Block(reason),
+        }
+    }
+
+    /// `session_start`: extra system context for the session, if any matching
+    /// hook printed some.
+    pub async fn session_start(
+        &self,
+        mode: Mode,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> Option<String> {
+        match self
+            .fire(HookEvent::SessionStart, None, mode, false, true, events)
+            .await
+        {
+            FireResult::Continue(extra) => extra,
+            FireResult::Block(_) => None,
+        }
+    }
+
+    /// `session_end`: observational; output is ignored.
+    pub async fn session_end(&self, mode: Mode, events: Option<&mpsc::Sender<AgentEvent>>) {
+        self.fire(HookEvent::SessionEnd, None, mode, false, false, events)
+            .await;
+    }
+
+    /// `turn_end`: observational; output is ignored.
+    pub async fn turn_end(&self, mode: Mode, events: Option<&mpsc::Sender<AgentEvent>>) {
+        self.fire(HookEvent::TurnEnd, None, mode, false, false, events)
+            .await;
+    }
+
+    /// Run the matching hooks for `event` sequentially. `blockable` honors
+    /// exit 2; `capture` collects non-empty stdout as extra context.
+    async fn fire(
+        &self,
+        event: HookEvent,
+        tool: Option<(&str, &Value)>,
+        mode: Mode,
+        blockable: bool,
+        capture: bool,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> FireResult {
+        let mut extra: Vec<String> = Vec::new();
+        for hook in self.matching(event, tool.map(|(name, _)| name)) {
+            match self.run(hook, event, tool, mode).await {
+                RunResult::Exited {
+                    code: 0, stdout, ..
+                } => {
+                    let stdout = stdout.trim();
+                    if capture && !stdout.is_empty() {
+                        extra.push(stdout.to_string());
+                        self.report(events, event, hook, HookOutcome::AppendedContext)
+                            .await;
+                    }
+                }
+                RunResult::Exited {
+                    code: 2, stderr, ..
+                } if blockable => {
+                    let reason = block_reason(&stderr);
+                    self.report(events, event, hook, HookOutcome::Blocked(reason.clone()))
+                        .await;
+                    return FireResult::Block(reason);
+                }
+                RunResult::Exited { code, stderr, .. } => {
+                    self.report(
+                        events,
+                        event,
+                        hook,
+                        HookOutcome::Warning(exit_warning(code, &stderr)),
+                    )
+                    .await;
+                }
+                RunResult::Failed(why) => {
+                    self.report(events, event, hook, HookOutcome::Warning(why))
+                        .await;
+                }
+            }
+        }
+        FireResult::Continue((!extra.is_empty()).then(|| extra.join("\n")))
+    }
+
+    /// The configured hooks for `event`, filtered by matcher when the event
+    /// carries a tool name.
+    fn matching(
+        &self,
+        event: HookEvent,
+        tool: Option<&str>,
+    ) -> impl Iterator<Item = &CompiledHook> {
+        self.hooks.iter().filter(move |hook| {
+            hook.def.event == event
+                && match (&hook.matcher, tool) {
+                    (Some(matcher), Some(name)) => matcher.is_match(name),
+                    // Matchers are only meaningful for tool events.
+                    _ => true,
+                }
+        })
+    }
+
+    /// Run one hook to completion: payload on stdin, stdout/stderr captured,
+    /// timeout enforced (dropping the wait kills the child via
+    /// `kill_on_drop`).
+    async fn run(
+        &self,
+        hook: &CompiledHook,
+        event: HookEvent,
+        tool: Option<(&str, &Value)>,
+        mode: Mode,
+    ) -> RunResult {
+        let session_id = self.session_id.lock().unwrap().clone();
+        let payload = json!({
+            "event": event.name(),
+            "tool_name": tool.map(|(name, _)| name),
+            "args": tool.map(|(_, args)| args),
+            "cwd": self.cwd,
+            "session_id": session_id,
+            "mode": mode.to_string(),
+        });
+
+        let mut child = match tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&hook.def.command)
+            .current_dir(&self.cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => return RunResult::Failed(format!("spawn failed: {err}")),
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            // A hook that never reads stdin may close the pipe early; that is
+            // its prerogative, not an error.
+            let _ = stdin.write_all(payload.to_string().as_bytes()).await;
+        }
+
+        let timeout = Duration::from_secs(hook.def.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
+        match tokio::time::timeout(timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => RunResult::Exited {
+                code: output.status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            },
+            Ok(Err(err)) => RunResult::Failed(format!("wait failed: {err}")),
+            Err(_) => RunResult::Failed(format!("timed out after {}s", timeout.as_secs())),
+        }
+    }
+
+    /// Surface one hook's outcome. Warnings also land in the log; plain
+    /// successes stay silent so default behavior is unchanged.
+    async fn report(
+        &self,
+        events: Option<&mpsc::Sender<AgentEvent>>,
+        event: HookEvent,
+        hook: &CompiledHook,
+        outcome: HookOutcome,
+    ) {
+        if let HookOutcome::Warning(why) = &outcome {
+            tracing::warn!("hook {} ({}): {why}", event.name(), hook.def.command);
+        }
+        if outcome == HookOutcome::Ok {
+            return;
+        }
+        if let Some(events) = events {
+            let _ = events
+                .send(AgentEvent::HookFired {
+                    event: event.name(),
+                    command: hook.def.command.clone(),
+                    outcome,
+                })
+                .await;
+        }
+    }
+
+    /// Commands of the hooks that would fire for `event`/`tool` (tests).
+    #[cfg(test)]
+    fn matching_commands(&self, event: HookEvent, tool: Option<&str>) -> Vec<&str> {
+        self.matching(event, tool)
+            .map(|hook| hook.def.command.as_str())
+            .collect()
+    }
+}
+
+/// Parse a `pre_tool_use` hook's stdout as `{"updated_args": {...}}`.
+/// Anything else (empty, non-JSON, missing key, non-object value) means
+/// "leave the arguments alone".
+fn parse_updated_args(stdout: &str) -> Option<Value> {
+    let value: Value = serde_json::from_str(stdout.trim()).ok()?;
+    let updated = value.get("updated_args")?;
+    updated.is_object().then(|| updated.clone())
+}
+
+/// Reason for a block: trimmed stderr, with a fallback for silent hooks.
+fn block_reason(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        "hook gave no reason".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Warning text for an unexpected exit code.
+fn exit_warning(code: i32, stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        format!("exit {code}")
+    } else {
+        format!("exit {code}: {trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn def(event: HookEvent, matcher: Option<&str>, command: &str) -> HookDef {
+        HookDef {
+            event,
+            matcher: matcher.map(str::to_string),
+            command: command.to_string(),
+            timeout_secs: None,
+        }
+    }
+
+    fn engine(defs: Vec<HookDef>) -> HookEngine {
+        HookEngine::new(defs, std::env::temp_dir(), "test-session".to_string())
+    }
+
+    #[test]
+    fn parse_full_entry() {
+        let hooks = parse(
+            r#"
+            [[hooks]]
+            event = "pre_tool_use"
+            matcher = "execute"
+            command = "/path/to/script.sh"
+            timeout_secs = 30
+            "#,
+        )
+        .expect("valid hooks.toml");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].event, HookEvent::PreToolUse);
+        assert_eq!(hooks[0].matcher.as_deref(), Some("execute"));
+        assert_eq!(hooks[0].command, "/path/to/script.sh");
+        assert_eq!(hooks[0].timeout_secs, Some(30));
+    }
+
+    #[test]
+    fn parse_defaults_matcher_and_timeout() {
+        let hooks =
+            parse("[[hooks]]\nevent = \"turn_end\"\ncommand = \"date\"").expect("valid hooks.toml");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].event, HookEvent::TurnEnd);
+        assert!(hooks[0].matcher.is_none());
+        assert!(hooks[0].timeout_secs.is_none());
+    }
+
+    #[test]
+    fn parse_every_event_name() {
+        for (name, event) in [
+            ("pre_tool_use", HookEvent::PreToolUse),
+            ("post_tool_use", HookEvent::PostToolUse),
+            ("user_prompt_submit", HookEvent::UserPromptSubmit),
+            ("session_start", HookEvent::SessionStart),
+            ("session_end", HookEvent::SessionEnd),
+            ("turn_end", HookEvent::TurnEnd),
+        ] {
+            let raw = format!("[[hooks]]\nevent = \"{name}\"\ncommand = \"true\"");
+            let hooks = parse(&raw).expect("valid event name");
+            assert_eq!(hooks[0].event, event);
+            assert_eq!(event.name(), name, "name() round-trips the serde name");
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown_event() {
+        assert!(parse("[[hooks]]\nevent = \"on_boot\"\ncommand = \"true\"").is_err());
+    }
+
+    #[test]
+    fn parse_empty_and_missing_hooks_key() {
+        assert!(parse("").expect("empty file parses").is_empty());
+        assert!(parse("# just a comment\n").expect("parses").is_empty());
+    }
+
+    #[test]
+    fn load_files_appends_project_after_global_and_skips_bad_files() {
+        let dir = std::env::temp_dir().join(format!("wizard-hooks-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let global = dir.join("global.toml");
+        let project = dir.join("project.toml");
+        let broken = dir.join("broken.toml");
+        let missing = dir.join("missing.toml");
+        std::fs::write(
+            &global,
+            "[[hooks]]\nevent = \"turn_end\"\ncommand = \"global\"",
+        )
+        .unwrap();
+        std::fs::write(
+            &project,
+            "[[hooks]]\nevent = \"turn_end\"\ncommand = \"project\"",
+        )
+        .unwrap();
+        std::fs::write(&broken, "this is not toml [[[").unwrap();
+
+        let defs = load_files(&[global, broken, missing, project]);
+        let commands: Vec<&str> = defs.iter().map(|d| d.command.as_str()).collect();
+        assert_eq!(commands, vec!["global", "project"], "order preserved");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn matcher_glob_filters_tool_events() {
+        let engine = engine(vec![
+            def(HookEvent::PreToolUse, Some("execute"), "exact"),
+            def(HookEvent::PreToolUse, Some("git_*"), "glob"),
+            def(HookEvent::PreToolUse, None, "all"),
+            def(HookEvent::PostToolUse, Some("execute"), "post"),
+        ]);
+        assert_eq!(
+            engine.matching_commands(HookEvent::PreToolUse, Some("execute")),
+            vec!["exact", "all"]
+        );
+        assert_eq!(
+            engine.matching_commands(HookEvent::PreToolUse, Some("git_status")),
+            vec!["glob", "all"]
+        );
+        assert_eq!(
+            engine.matching_commands(HookEvent::PreToolUse, Some("read_file")),
+            vec!["all"]
+        );
+        assert_eq!(
+            engine.matching_commands(HookEvent::PostToolUse, Some("execute")),
+            vec!["post"]
+        );
+    }
+
+    #[test]
+    fn matcher_is_ignored_for_non_tool_events() {
+        // A matcher on a non-tool event is meaningless and matches anyway.
+        let engine = engine(vec![def(HookEvent::SessionStart, Some("execute"), "start")]);
+        assert_eq!(
+            engine.matching_commands(HookEvent::SessionStart, None),
+            vec!["start"]
+        );
+    }
+
+    #[test]
+    fn invalid_matcher_glob_drops_the_hook() {
+        let engine = engine(vec![
+            def(HookEvent::PreToolUse, Some("a{"), "bad"),
+            def(HookEvent::PreToolUse, None, "good"),
+        ]);
+        assert_eq!(
+            engine.matching_commands(HookEvent::PreToolUse, Some("execute")),
+            vec!["good"]
+        );
+    }
+
+    #[test]
+    fn updated_args_requires_a_json_object_under_the_key() {
+        assert_eq!(
+            parse_updated_args(r#"{"updated_args": {"path": "b.rs"}}"#),
+            Some(json!({"path": "b.rs"}))
+        );
+        assert!(parse_updated_args("").is_none());
+        assert!(parse_updated_args("all clear").is_none());
+        assert!(parse_updated_args(r#"{"other": 1}"#).is_none());
+        assert!(parse_updated_args(r#"{"updated_args": "nope"}"#).is_none());
+    }
+
+    #[test]
+    fn block_reason_falls_back_when_stderr_is_empty() {
+        assert_eq!(block_reason("  denied \n"), "denied");
+        assert_eq!(block_reason(""), "hook gave no reason");
+    }
+}

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,0 +1,313 @@
+//! Hierarchical project instructions.
+//!
+//! Wizard composes its "project instructions" prompt section from every
+//! directory between the filesystem root and the project root: in each
+//! directory the first of `WIZARD.md` > `AGENTS.md` > `CLAUDE.md` is taken,
+//! plus the global `~/.wizard/WIZARD.md`. Files are concatenated outermost
+//! first (global, then root-down), so the project root's file has the last
+//! word. Each file may pull in extra context with `@relative/path` lines
+//! (one level deep, capped per include); the assembled block is capped as a
+//! whole so a sprawling hierarchy cannot flood the context window.
+
+use std::path::{Path, PathBuf};
+
+use crate::tools::truncate_output;
+
+/// Instruction file names, in per-directory priority order (the first one
+/// that exists wins for that directory).
+const FILE_NAMES: [&str; 3] = ["WIZARD.md", "AGENTS.md", "CLAUDE.md"];
+
+/// Byte cap applied to each `@path` include.
+const INCLUDE_CAP: usize = 10_000;
+
+/// Byte cap applied to the fully assembled instruction block.
+const TOTAL_CAP: usize = 40_000;
+
+/// Load the full instruction hierarchy for `project_root`: the global
+/// `~/.wizard/WIZARD.md` plus one instruction file per ancestor directory,
+/// concatenated outermost-first. `None` when nothing exists.
+pub fn load(project_root: &Path) -> Option<String> {
+    let global = crate::config::Config::wizard_dir()
+        .ok()
+        .map(|dir| dir.join("WIZARD.md"));
+    load_with_global(project_root, global.as_deref())
+}
+
+/// Testable core of [`load`]: `global` is the path of the global
+/// instruction file (normally `~/.wizard/WIZARD.md`), checked first.
+fn load_with_global(project_root: &Path, global: Option<&Path>) -> Option<String> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    if let Some(global) = global
+        && global.is_file()
+    {
+        files.push(global.to_path_buf());
+    }
+
+    // ancestors() walks project root → filesystem root; reverse so the
+    // outermost file comes first and the project root's file last.
+    let mut chain: Vec<PathBuf> = project_root
+        .ancestors()
+        .filter_map(first_instruction_file)
+        .collect();
+    chain.reverse();
+    // The global file may also sit on the ancestor chain (project under
+    // ~/.wizard); never include it twice.
+    chain.retain(|path| files.first() != Some(path));
+    files.extend(chain);
+
+    let mut out = String::new();
+    for path in files {
+        let Some(content) = read_with_includes(&path) else {
+            continue;
+        };
+        if content.trim().is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str(&format!("<!-- instructions from {} -->\n", path.display()));
+        out.push_str(content.trim_end());
+        if out.len() >= TOTAL_CAP {
+            out = truncate_output(out, TOTAL_CAP);
+            break;
+        }
+    }
+
+    (!out.is_empty()).then_some(out)
+}
+
+/// The highest-priority instruction file present in `dir`, if any.
+fn first_instruction_file(dir: &Path) -> Option<PathBuf> {
+    FILE_NAMES
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|path| path.is_file())
+}
+
+/// Read one instruction file, expanding `@path` include lines one level
+/// deep: a line that is exactly `@` followed by a path inlines that file
+/// (resolved relative to the including file's directory, capped at
+/// [`INCLUDE_CAP`]). Includes inside included files are not expanded.
+/// An unreadable include keeps the `@` line verbatim; an unreadable
+/// instruction file yields `None`.
+fn read_with_includes(path: &Path) -> Option<String> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!("could not read {}: {err}", path.display());
+            }
+            return None;
+        }
+    };
+    let dir = path.parent().unwrap_or(Path::new("."));
+
+    let mut out = String::new();
+    for line in raw.lines() {
+        if let Some(target) = include_target(line) {
+            let include_path = if Path::new(target).is_absolute() {
+                PathBuf::from(target)
+            } else {
+                dir.join(target)
+            };
+            match std::fs::read_to_string(&include_path) {
+                Ok(content) => {
+                    out.push_str(&format!("<!-- include {} -->\n", include_path.display()));
+                    out.push_str(truncate_output(content, INCLUDE_CAP).trim_end());
+                    out.push('\n');
+                    continue;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "instruction include {} unreadable: {err}",
+                        include_path.display()
+                    );
+                }
+            }
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    Some(out)
+}
+
+/// The include path of an `@path` line, or `None` when the line is ordinary
+/// content. The whole (trimmed) line must be `@` followed by a single path —
+/// `@` mid-line or a line with multiple words is left alone.
+fn include_target(line: &str) -> Option<&str> {
+    let target = line.trim().strip_prefix('@')?;
+    if target.is_empty() || target.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Temp directory tree removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let dir = std::env::temp_dir().join(format!("wizard-instr-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().expect("has parent")).expect("mkdir");
+        std::fs::write(path, content).expect("write");
+    }
+
+    #[test]
+    fn hierarchy_orders_outermost_first_and_project_root_last() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("group").join("proj");
+        write(&tmp.0.join("CLAUDE.md"), "outermost rules");
+        write(&tmp.0.join("group").join("AGENTS.md"), "group rules");
+        write(&project.join("WIZARD.md"), "project rules");
+        let global = tmp.0.join("global").join("WIZARD.md");
+        write(&global, "global rules");
+
+        let out = load_with_global(&project, Some(&global)).expect("instructions found");
+        let pos = |needle: &str| {
+            out.find(needle)
+                .unwrap_or_else(|| panic!("missing {needle}"))
+        };
+        assert!(pos("global rules") < pos("outermost rules"));
+        assert!(pos("outermost rules") < pos("group rules"));
+        assert!(pos("group rules") < pos("project rules"));
+        // Each file is prefixed with a comment naming its path.
+        assert!(out.contains(&format!(
+            "<!-- instructions from {} -->",
+            project.join("WIZARD.md").display()
+        )));
+    }
+
+    #[test]
+    fn wizard_md_beats_agents_md_beats_claude_md_per_directory() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("proj");
+        write(&project.join("CLAUDE.md"), "claude content");
+        write(&project.join("AGENTS.md"), "agents content");
+        let out = load_with_global(&project, None).expect("found");
+        assert!(out.contains("agents content"));
+        assert!(
+            !out.contains("claude content"),
+            "AGENTS.md shadows CLAUDE.md"
+        );
+
+        write(&project.join("WIZARD.md"), "wizard content");
+        let out = load_with_global(&project, None).expect("found");
+        assert!(out.contains("wizard content"));
+        assert!(
+            !out.contains("agents content"),
+            "WIZARD.md shadows AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn missing_everything_yields_none() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("empty");
+        std::fs::create_dir_all(&project).unwrap();
+        // The walk may pick up stray files in /tmp's ancestors only if they
+        // exist; the temp tree itself has none.
+        let absent = tmp.0.join("nope").join("WIZARD.md");
+        let out = load_with_global(&project, Some(&absent));
+        // No file in the temp tree: anything found must come from outside it.
+        if let Some(out) = &out {
+            assert!(
+                !out.contains(&tmp.0.display().to_string()),
+                "nothing from the temp tree: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn at_lines_inline_the_referenced_file_one_level_deep() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("proj");
+        write(
+            &project.join("WIZARD.md"),
+            "before\n@docs/extra.md\nafter\n",
+        );
+        write(
+            &project.join("docs").join("extra.md"),
+            "extra context\n@docs/deeper.md\n",
+        );
+        write(&project.join("docs").join("deeper.md"), "too deep");
+
+        let out = load_with_global(&project, None).expect("found");
+        assert!(out.contains("before"));
+        assert!(out.contains("extra context"), "include inlined: {out}");
+        assert!(out.contains("after"));
+        assert!(
+            !out.contains("too deep"),
+            "includes are one level deep only: {out}"
+        );
+        // The nested @ line survives verbatim inside the inlined content.
+        assert!(out.contains("@docs/deeper.md"));
+    }
+
+    #[test]
+    fn unreadable_include_keeps_the_line_verbatim() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("proj");
+        write(&project.join("WIZARD.md"), "@missing/file.md\nrest\n");
+        let out = load_with_global(&project, None).expect("found");
+        assert!(out.contains("@missing/file.md"));
+        assert!(out.contains("rest"));
+    }
+
+    #[test]
+    fn at_mid_line_or_with_spaces_is_not_an_include() {
+        assert_eq!(include_target("@docs/extra.md"), Some("docs/extra.md"));
+        assert_eq!(include_target("  @docs/extra.md  "), Some("docs/extra.md"));
+        assert_eq!(include_target("email me @example"), None);
+        assert_eq!(include_target("@"), None);
+        assert_eq!(include_target("@two words"), None);
+        assert_eq!(include_target("plain"), None);
+    }
+
+    #[test]
+    fn includes_are_capped_per_file() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("proj");
+        write(&project.join("WIZARD.md"), "@big.md\n");
+        write(&project.join("big.md"), &"x".repeat(INCLUDE_CAP * 2));
+        let out = load_with_global(&project, None).expect("found");
+        assert!(
+            out.len() < INCLUDE_CAP + 1_000,
+            "capped: {} bytes",
+            out.len()
+        );
+        assert!(out.contains("[output truncated]"));
+    }
+
+    #[test]
+    fn total_is_capped() {
+        let tmp = TempDir::new();
+        let project = tmp.0.join("a").join("b");
+        write(&tmp.0.join("WIZARD.md"), &"r".repeat(TOTAL_CAP));
+        write(&tmp.0.join("a").join("WIZARD.md"), &"m".repeat(TOTAL_CAP));
+        write(&project.join("WIZARD.md"), "never reached");
+        let out = load_with_global(&project, None).expect("found");
+        assert!(
+            out.len() <= TOTAL_CAP + 100,
+            "total capped: {} bytes",
+            out.len()
+        );
+        assert!(out.contains("[output truncated]"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod agent;
 pub mod app;
 pub mod bench;
+pub mod checkpoint;
 pub mod cli;
 pub mod config;
 pub mod dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod app;
 pub mod bench;
 pub mod cli;
 pub mod config;
+pub mod dispatch;
 pub mod event;
 pub mod evolve;
 pub mod gateway;
@@ -65,6 +66,12 @@ pub async fn run(cli: cli::Cli) -> Result<()> {
     } else {
         config::Config::load()?
     };
+    if !config.auto_approve {
+        eprintln!(
+            "warning: `auto_approve = false` in config.toml is no longer honored — \
+             approval gating was removed; every tool call executes directly"
+        );
+    }
     config.apply_cli(&cli);
 
     if let Some(dir) = &cli.cwd {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod app;
 pub mod bench;
 pub mod checkpoint;
 pub mod cli;
+pub mod commands;
 pub mod config;
 pub mod dispatch;
 pub mod event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod memory;
 pub mod onboarding;
 pub mod output;
 pub mod progress;
+pub mod schedule;
 pub mod server;
 pub mod skills;
 pub mod tools;
@@ -63,6 +64,23 @@ pub async fn run(cli: cli::Cli) -> Result<i32> {
             std::env::set_current_dir(dir)?;
         }
         return doctor::run().await;
+    }
+
+    // Schedule CRUD and the scheduler daemon are config-independent too:
+    // they only touch ~/.wizard/schedule.toml, and the jobs they spawn are
+    // wizard child processes that load config themselves. `schedule run`
+    // propagates the child's exit code.
+    if let Some(cli::Command::Schedule { cmd }) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return schedule::run(cmd.clone()).await;
+    }
+    if let Some(cli::Command::Scheduler) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return schedule::run_daemon().await;
     }
 
     // `--login` is a one-shot credential flow: no config, no onboarding,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod dispatch;
+pub mod doctor;
 pub mod event;
 pub mod evolve;
 pub mod gateway;
@@ -52,6 +53,16 @@ pub async fn run(cli: cli::Cli) -> Result<i32> {
             std::env::set_current_dir(dir)?;
         }
         return bench::run(cmd.clone()).await.map(|()| 0);
+    }
+
+    // Doctor diagnoses the environment — starting with "does the config
+    // parse?" — so it too dispatches before the config load and can never
+    // trigger onboarding. Exits 0 when no check failed, 1 otherwise.
+    if let Some(cli::Command::Doctor) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return doctor::run().await;
     }
 
     // `--login` is a one-shot credential flow: no config, no onboarding,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod local_setup;
 pub mod mcp;
 pub mod memory;
 pub mod onboarding;
+pub mod output;
 pub mod progress;
 pub mod server;
 pub mod skills;
@@ -38,21 +39,28 @@ use crate::config::Mode;
 
 /// Top-level entry point: load config, apply CLI overrides, and dispatch to
 /// the selected run mode (genie TUI, sovereign headless loop, or `--evolve`).
-pub async fn run(cli: cli::Cli) -> Result<()> {
+///
+/// Returns the process exit code: headless runs map their outcome through
+/// [`output::exit_code`] (0 completed, 2 max-steps, 3 circuit breaker, 4 time
+/// limit); every other mode exits 0 on success. Hard errors surface as `Err`
+/// and exit 1 from `main`.
+pub async fn run(cli: cli::Cli) -> Result<i32> {
     // Bench is self-contained tooling: it must work with no config and no
     // LLM, so dispatch before onboarding and before the config load.
     if let Some(cli::Command::Bench { cmd }) = &cli.command {
         if let Some(dir) = &cli.cwd {
             std::env::set_current_dir(dir)?;
         }
-        return bench::run(cmd.clone()).await;
+        return bench::run(cmd.clone()).await.map(|()| 0);
     }
 
     // `--login` is a one-shot credential flow: no config, no onboarding,
     // no TUI. Tokens land in a dedicated file under ~/.wizard/.
     if let Some(provider) = &cli.login {
         return match provider.as_str() {
-            "xai" => llm::xai_oauth::login(|line: &str| println!("{line}")).await,
+            "xai" => llm::xai_oauth::login(|line: &str| println!("{line}"))
+                .await
+                .map(|()| 0),
             other => anyhow::bail!("unknown login provider '{other}' (supported: xai)"),
         };
     }
@@ -65,7 +73,7 @@ pub async fn run(cli: cli::Cli) -> Result<()> {
             Some(config) => config,
             None => {
                 println!("onboarding cancelled — run `wizard --onboard` any time.");
-                return Ok(());
+                return Ok(0);
             }
         }
     } else {
@@ -84,15 +92,15 @@ pub async fn run(cli: cli::Cli) -> Result<()> {
     }
 
     if cli.publish {
-        return evolve::run_publish_cli(config, cli).await;
+        return evolve::run_publish_cli(config, cli).await.map(|()| 0);
     }
 
     if cli.evolve {
-        return evolve::run_cli(config, cli).await;
+        return evolve::run_cli(config, cli).await.map(|()| 0);
     }
 
     if cli.gateway {
-        return gateway::run(config, cli).await;
+        return gateway::run(config, cli).await.map(|()| 0);
     }
 
     match config.mode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod evolve;
 pub mod gateway;
 pub mod hardware;
 pub mod hooks;
+pub mod instructions;
 pub mod llm;
 pub mod local_setup;
 pub mod mcp;
@@ -25,6 +26,7 @@ pub mod server;
 pub mod skills;
 pub mod tools;
 pub mod ui;
+pub mod usage;
 
 use std::io::IsTerminal;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod event;
 pub mod evolve;
 pub mod gateway;
 pub mod hardware;
+pub mod hooks;
 pub mod llm;
 pub mod local_setup;
 pub mod mcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod dispatch;
 pub mod doctor;
 pub mod event;
 pub mod evolve;
+pub mod fleet;
 pub mod gateway;
 pub mod hardware;
 pub mod hooks;
@@ -81,6 +82,17 @@ pub async fn run(cli: cli::Cli) -> Result<i32> {
             std::env::set_current_dir(dir)?;
         }
         return schedule::run_daemon().await;
+    }
+
+    // Fleet dispatches before the normal flow too, but `fleet run` loads
+    // config itself (its planning and synthesis turns drive a real
+    // in-process agent); `fleet status` / `fleet stop` only touch the
+    // project's `.wizard/fleet/` directory.
+    if let Some(cli::Command::Fleet { cmd }) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return fleet::run(cmd.clone()).await;
     }
 
     // `--login` is a one-shot credential flow: no config, no onboarding,

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -227,6 +227,10 @@ impl LlmProvider for AnthropicProvider {
         }
     }
 
+    async fn context_window(&self, model: &str) -> Option<u32> {
+        context_window(model)
+    }
+
     async fn chat_stream(&self, request: ChatRequest) -> Result<ChatStream> {
         let body = self.build_request_body(&request);
         let response = self
@@ -252,6 +256,21 @@ impl LlmProvider for AnthropicProvider {
 
     fn label(&self) -> String {
         format!("anthropic:{}", self.model)
+    }
+}
+
+/// Context-window table for Anthropic models: every `claude-*` model has a
+/// 200k window, with 1M-context variants flagged in the model name. Unknown
+/// (non-claude) tags report `None`.
+fn context_window(model: &str) -> Option<u32> {
+    let model = model.to_ascii_lowercase();
+    if !model.starts_with("claude") {
+        return None;
+    }
+    if model.contains("1m") {
+        Some(1_000_000)
+    } else {
+        Some(200_000)
     }
 }
 
@@ -648,5 +667,14 @@ mod tests {
         let last = chunks.next().await.expect("final").expect("ok");
         assert!(last.done);
         assert!(chunks.next().await.is_none());
+    }
+
+    #[test]
+    fn context_window_table_covers_claude_and_unknowns() {
+        assert_eq!(context_window("claude-fable-5"), Some(200_000));
+        assert_eq!(context_window("Claude-Opus-4"), Some(200_000));
+        assert_eq!(context_window("claude-sonnet-4-5[1m]"), Some(1_000_000));
+        assert_eq!(context_window("gpt-4o"), None);
+        assert_eq!(context_window(""), None);
     }
 }

--- a/src/llm/llamacpp.rs
+++ b/src/llm/llamacpp.rs
@@ -7,10 +7,12 @@
 //! (which distinguishes "still loading the model" from "down"), and
 //! connection failures tell the user how to start the server.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use tokio::sync::OnceCell;
 
 use super::openai::OpenAiProvider;
 use super::provider::LlmProvider;
@@ -32,6 +34,9 @@ pub struct LlamaCppProvider {
     /// OpenAI-compatible client bound to `{base_url}/v1`, handling chat
     /// streaming and `/v1/models`. Keyless — llama-server needs no auth.
     inner: OpenAiProvider,
+    /// Cached result of the `GET /props` context-window probe (`n_ctx`).
+    /// Probed once per provider instance; a failed probe caches `None`.
+    ctx_window: Arc<OnceCell<Option<u32>>>,
 }
 
 impl LlamaCppProvider {
@@ -52,7 +57,28 @@ impl LlamaCppProvider {
             base_url,
             model,
             inner,
+            ctx_window: Arc::new(OnceCell::new()),
         }
+    }
+
+    /// Probe llama-server's `GET /props` for the loaded model's context size
+    /// (`default_generation_settings.n_ctx`). Any failure — server down,
+    /// older server without the endpoint, unexpected shape — yields `None`.
+    async fn fetch_n_ctx(&self) -> Option<u32> {
+        let response = self
+            .http
+            .get(format!("{}/props", self.base_url))
+            .send()
+            .await
+            .ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let body: serde_json::Value = response.json().await.ok()?;
+        body.get("default_generation_settings")?
+            .get("n_ctx")?
+            .as_u64()
+            .and_then(|n| u32::try_from(n).ok())
     }
 
     /// Actionable error for a server that cannot be reached at all.
@@ -133,6 +159,12 @@ impl LlmProvider for LlamaCppProvider {
             .map_err(|err| self.reframe(err))
     }
 
+    /// llama-server serves whatever GGUF it was started with, so the live
+    /// `/props` probe beats any static table. Cached after the first call.
+    async fn context_window(&self, _model: &str) -> Option<u32> {
+        *self.ctx_window.get_or_init(|| self.fetch_n_ctx()).await
+    }
+
     fn label(&self) -> String {
         format!("llama.cpp:{}", self.model)
     }
@@ -156,6 +188,15 @@ mod tests {
         // The unreachable hint names the server root, not the /v1 endpoint.
         let hint = provider.reframe(anyhow!("plain error"));
         assert_eq!(hint.to_string(), "plain error", "non-connect passthrough");
+    }
+
+    #[tokio::test]
+    async fn context_window_probe_failure_degrades_to_none() {
+        // Port 1 on localhost: connection refused immediately, no server
+        // needed. The failed probe caches None instead of erroring.
+        let provider = LlamaCppProvider::new("http://127.0.0.1:1", "m");
+        assert_eq!(provider.context_window("m").await, None);
+        assert_eq!(provider.context_window("m").await, None, "cached");
     }
 
     #[tokio::test]

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -347,9 +347,42 @@ impl LlmProvider for OpenAiProvider {
         Ok(decode_sse(bytes))
     }
 
+    async fn context_window(&self, model: &str) -> Option<u32> {
+        context_window(model)
+    }
+
     fn label(&self) -> String {
         format!("{}:{}", self.vendor, self.model)
     }
+}
+
+/// Context-window table for OpenAI-compatible endpoints (OpenAI and xAI
+/// model families; llama.cpp overrides this with a live `/props` probe).
+/// Unknown tags report `None` so compaction falls back to the byte
+/// threshold.
+pub(crate) fn context_window(model: &str) -> Option<u32> {
+    let model = model.to_ascii_lowercase();
+    // xAI Grok (served through this provider with vendor "xai").
+    if model.starts_with("grok-4") {
+        return Some(256_000);
+    }
+    if model.starts_with("grok") {
+        return Some(131_072);
+    }
+    // OpenAI.
+    if model.starts_with("gpt-5") {
+        return Some(400_000);
+    }
+    if model.starts_with("gpt-4.1") {
+        return Some(1_047_576);
+    }
+    if model.starts_with("gpt-4o") || model.starts_with("gpt-4-turbo") {
+        return Some(128_000);
+    }
+    if model.starts_with("o1") || model.starts_with("o3") || model.starts_with("o4") {
+        return Some(200_000);
+    }
+    None
 }
 
 /// `GET /models` response (subset).
@@ -823,5 +856,18 @@ mod tests {
         let last = chunks.next().await.expect("final").expect("ok");
         assert!(last.done);
         assert!(chunks.next().await.is_none());
+    }
+
+    #[test]
+    fn context_window_table_covers_openai_xai_and_unknowns() {
+        assert_eq!(context_window("gpt-4o"), Some(128_000));
+        assert_eq!(context_window("gpt-4o-mini"), Some(128_000));
+        assert_eq!(context_window("gpt-4.1"), Some(1_047_576));
+        assert_eq!(context_window("gpt-5"), Some(400_000));
+        assert_eq!(context_window("o3-mini"), Some(200_000));
+        assert_eq!(context_window("grok-3"), Some(131_072));
+        assert_eq!(context_window("grok-4.3"), Some(256_000));
+        assert_eq!(context_window("qwen3-8b"), None, "local tags stay unknown");
+        assert_eq!(context_window(""), None);
     }
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -36,6 +36,15 @@ pub trait LlmProvider: Send + Sync {
         request: crate::llm::ChatRequest,
     ) -> anyhow::Result<crate::llm::ChatStream>;
 
+    /// Total context window of `model` in tokens, when known. Drives
+    /// token-aware history compaction; `None` means unknown, in which case
+    /// only the byte threshold applies. Implementations may consult static
+    /// tables (cloud APIs) or query the backend (llama.cpp `/props`) — a
+    /// probe failure must degrade to `None`, never error.
+    async fn context_window(&self, _model: &str) -> Option<u32> {
+        None
+    }
+
     /// Short human label for the status bar / errors (e.g. the host or
     /// `"openai:gpt-4o"`).
     fn label(&self) -> String;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,20 @@ async fn main() {
     }));
 
     let cli = Cli::parse();
-    if let Err(err) = wizard::run(cli).await {
-        // Make sure the error lands on a sane terminal even when the TUI
-        // errored out mid-frame.
-        wizard::app::restore_terminal_best_effort();
-        eprintln!("error: {err:#}");
-        std::process::exit(1);
-    }
+    let code = match wizard::run(cli).await {
+        Ok(code) => code,
+        Err(err) => {
+            // Make sure the error lands on a sane terminal even when the TUI
+            // errored out mid-frame.
+            wizard::app::restore_terminal_best_effort();
+            eprintln!("error: {err:#}");
+            1
+        }
+    };
+    // Headless runs encode their outcome in the exit code (see
+    // `wizard::output::exit_code`); flush before exiting so structured
+    // output is never cut off.
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
+    std::process::exit(code);
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -972,10 +972,6 @@ impl Tool for McpTool {
         }
     }
 
-    fn requires_approval(&self) -> bool {
-        true
-    }
-
     fn kind(&self) -> ToolKind {
         ToolKind::Mcp
     }
@@ -1162,7 +1158,7 @@ done"#
             .iter()
             .find(|tool| tool.name() == "alpha__weather")
             .expect("alpha__weather should be registered");
-        assert!(tool.requires_approval());
+        assert_eq!(tool.access(), crate::tools::ToolAccess::Execute);
         assert_eq!(tool.kind(), ToolKind::Mcp);
         let output = tool
             .execute(json!({}), &ctx)

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -105,6 +105,8 @@ impl Answers {
             model: self.model.clone(),
             api_key_env: self.api_key_env.clone(),
             gguf_path: self.gguf_path.clone(),
+            usd_per_mtok_in: None,
+            usd_per_mtok_out: None,
         };
 
         // Mirror an Ollama choice into the legacy fields so config files remain

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,628 @@
+//! Headless output sinks: how a sovereign (`-p`) run reports its events.
+//!
+//! The agent loop emits [`AgentEvent`]s; `run_headless` forwards them to one
+//! [`EventSink`] selected by `--output-format`:
+//!
+//! - `text` (default) — the human-readable stream: deltas as they arrive,
+//!   tool one-liners, a spinner on terminals.
+//! - `json` — silent until the run ends, then one JSON object summarizing
+//!   the result, steps, usage, and tool calls.
+//! - `stream-json` — one JSON object per line as events arrive, terminated
+//!   by a `{"type":"done", ...}` line.
+//!
+//! The run outcome also becomes the process exit code (see [`exit_code`]),
+//! so scripts can branch on *why* a run ended without parsing output.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::agent::{AgentEvent, DoneReason, PlanVerdict};
+use crate::progress::TurnSpinner;
+
+/// `--output-format` values for headless (`-p`) runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable streaming output (the default).
+    #[default]
+    Text,
+    /// One final JSON object summarizing the whole run.
+    Json,
+    /// One JSON object per line as events arrive (JSONL).
+    StreamJson,
+}
+
+/// Process exit code for a finished headless run. Hard errors exit 1 from
+/// `main`; a user-requested stop is a success.
+pub fn exit_code(reason: DoneReason) -> i32 {
+    match reason {
+        DoneReason::Completed | DoneReason::Stopped => 0,
+        DoneReason::MaxSteps => 2,
+        DoneReason::CircuitBreaker => 3,
+        DoneReason::TimeLimit => 4,
+    }
+}
+
+/// Stable snake_case name for a [`DoneReason`] in JSON output.
+pub fn reason_str(reason: DoneReason) -> &'static str {
+    match reason {
+        DoneReason::Completed => "completed",
+        DoneReason::MaxSteps => "max_steps",
+        DoneReason::TimeLimit => "time_limit",
+        DoneReason::Stopped => "stopped",
+        DoneReason::CircuitBreaker => "circuit_breaker",
+    }
+}
+
+/// Consumes the agent-event stream of one headless run.
+///
+/// `event` is called for every [`AgentEvent`] in order; `finish` exactly once
+/// after the run loop ends (and only for runs that did not hard-error), with
+/// the final outcome. Implementations own their output destination and must
+/// leave stdout flushed when `finish` returns.
+pub trait EventSink: Send {
+    fn event(&mut self, event: AgentEvent);
+    fn finish(&mut self, reason: DoneReason);
+}
+
+// ---------------------------------------------------------------------------
+// text
+// ---------------------------------------------------------------------------
+
+/// The default human-readable printer (previously inlined in
+/// `run_headless`): streams deltas, prints tool one-liners, auto-approves
+/// plans, and shares the run's busy spinner so lines never tear it.
+pub struct TextSink {
+    spinner: Arc<TurnSpinner>,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+}
+
+impl TextSink {
+    pub fn new(spinner: Arc<TurnSpinner>) -> Self {
+        Self {
+            spinner,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+        }
+    }
+}
+
+impl EventSink for TextSink {
+    fn event(&mut self, event: AgentEvent) {
+        match event {
+            AgentEvent::TextDelta(delta) => {
+                self.spinner.hide();
+                print!("{delta}");
+                let _ = std::io::stdout().flush();
+            }
+            AgentEvent::ThinkingDelta(delta) => {
+                // ANSI faint so reasoning reads as background noise.
+                self.spinner.hide();
+                print!("\x1b[2m{delta}\x1b[0m");
+                let _ = std::io::stdout().flush();
+            }
+            AgentEvent::ToolStarted { name, args } => {
+                self.spinner.println(&format!("\n→ {name} {args}"));
+                // The tool may run for a while: keep the verb spinning.
+                self.spinner.show();
+            }
+            AgentEvent::ToolFinished { name, output } => {
+                let status = if output.is_error { "error" } else { "ok" };
+                self.spinner.println(&format!("← {name} [{status}]"));
+                // Back to the model: it is thinking about the result.
+                self.spinner.show();
+            }
+            AgentEvent::StepCompleted { step } => {
+                tracing::debug!("step {step} completed");
+            }
+            AgentEvent::Error(message) => {
+                self.spinner.hide();
+                eprintln!("\nwizard error: {message}");
+            }
+            AgentEvent::HookFired {
+                event,
+                command,
+                outcome,
+            } => {
+                self.spinner
+                    .println(&format!("~ hook {event}: {outcome} ({command})"));
+            }
+            AgentEvent::PlanReady { plan, respond } => {
+                // Headless: print the plan and approve it, so the turn moves
+                // from planning to execution on its own.
+                self.spinner
+                    .println(&format!("\n=== plan ===\n{plan}\n=== plan approved ==="));
+                let _ = respond.send(PlanVerdict::approve());
+                self.spinner.show();
+            }
+            AgentEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            } => {
+                self.prompt_tokens += prompt_tokens;
+                self.completion_tokens += completion_tokens;
+            }
+            AgentEvent::TodoUpdated(items) => {
+                self.spinner
+                    .println(&crate::tools::todo::summary_line(&items));
+            }
+            AgentEvent::TaskFinished {
+                id,
+                command,
+                status,
+            } => {
+                self.spinner.println(&format!(
+                    "⏺ background task #{id} finished ({}): {command}",
+                    status.describe()
+                ));
+            }
+            AgentEvent::Done { reason } => {
+                self.spinner.hide();
+                println!("\n[turn done: {reason:?}]");
+            }
+        }
+    }
+
+    fn finish(&mut self, reason: DoneReason) {
+        if self.prompt_tokens > 0 || self.completion_tokens > 0 {
+            println!(
+                "[run finished: {reason:?} — {} prompt + {} completion tokens]",
+                self.prompt_tokens, self.completion_tokens
+            );
+        } else {
+            println!("[run finished: {reason:?}]");
+        }
+        let _ = std::io::stdout().flush();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// json
+// ---------------------------------------------------------------------------
+
+/// Per-tool aggregation for the final `json` summary.
+#[derive(Debug)]
+struct ToolCallsEntry {
+    name: String,
+    calls: u64,
+    errors: u64,
+}
+
+/// Buffers the whole run and emits one final JSON object:
+/// `{result, reason, turns, steps, usage, tool_calls, errors}`.
+pub struct JsonSink<W: Write + Send> {
+    out: W,
+    result: String,
+    turns: u64,
+    steps: u64,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    tool_calls: Vec<ToolCallsEntry>,
+    errors: Vec<String>,
+}
+
+impl JsonSink<std::io::Stdout> {
+    pub fn stdout() -> Self {
+        Self::new(std::io::stdout())
+    }
+}
+
+impl<W: Write + Send> JsonSink<W> {
+    pub fn new(out: W) -> Self {
+        Self {
+            out,
+            result: String::new(),
+            turns: 0,
+            steps: 0,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            tool_calls: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl<W: Write + Send> EventSink for JsonSink<W> {
+    fn event(&mut self, event: AgentEvent) {
+        match event {
+            AgentEvent::TextDelta(delta) => self.result.push_str(&delta),
+            AgentEvent::ToolStarted { name, .. } => {
+                match self.tool_calls.iter_mut().find(|entry| entry.name == name) {
+                    Some(entry) => entry.calls += 1,
+                    None => self.tool_calls.push(ToolCallsEntry {
+                        name,
+                        calls: 1,
+                        errors: 0,
+                    }),
+                }
+            }
+            AgentEvent::ToolFinished { name, output } => {
+                if output.is_error
+                    && let Some(entry) = self.tool_calls.iter_mut().find(|entry| entry.name == name)
+                {
+                    entry.errors += 1;
+                }
+            }
+            AgentEvent::StepCompleted { .. } => self.steps += 1,
+            AgentEvent::Error(message) => self.errors.push(message),
+            AgentEvent::PlanReady { respond, .. } => {
+                // No human in the loop: approve so the turn executes.
+                let _ = respond.send(PlanVerdict::approve());
+            }
+            AgentEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            } => {
+                self.prompt_tokens += prompt_tokens;
+                self.completion_tokens += completion_tokens;
+            }
+            AgentEvent::Done { .. } => self.turns += 1,
+            AgentEvent::ThinkingDelta(_)
+            | AgentEvent::HookFired { .. }
+            | AgentEvent::TodoUpdated(_)
+            | AgentEvent::TaskFinished { .. } => {}
+        }
+    }
+
+    fn finish(&mut self, reason: DoneReason) {
+        let summary = json!({
+            "result": self.result,
+            "reason": reason_str(reason),
+            "turns": self.turns,
+            "steps": self.steps,
+            "usage": {
+                "prompt_tokens": self.prompt_tokens,
+                "completion_tokens": self.completion_tokens,
+            },
+            "tool_calls": self.tool_calls.iter().map(|entry| json!({
+                "name": entry.name,
+                "calls": entry.calls,
+                "errors": entry.errors,
+            })).collect::<Vec<_>>(),
+            "errors": self.errors,
+        });
+        let _ = writeln!(self.out, "{summary}");
+        let _ = self.out.flush();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stream-json
+// ---------------------------------------------------------------------------
+
+/// Emits one JSON object per line as events arrive, ending with a
+/// `{"type":"done"}` line carrying the outcome and usage totals.
+pub struct StreamJsonSink<W: Write + Send> {
+    out: W,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+}
+
+impl StreamJsonSink<std::io::Stdout> {
+    pub fn stdout() -> Self {
+        Self::new(std::io::stdout())
+    }
+}
+
+impl<W: Write + Send> StreamJsonSink<W> {
+    pub fn new(out: W) -> Self {
+        Self {
+            out,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+        }
+    }
+
+    fn emit(&mut self, value: serde_json::Value) {
+        let _ = writeln!(self.out, "{value}");
+        let _ = self.out.flush();
+    }
+}
+
+impl<W: Write + Send> EventSink for StreamJsonSink<W> {
+    fn event(&mut self, event: AgentEvent) {
+        match event {
+            AgentEvent::TextDelta(text) => {
+                self.emit(json!({"type": "text_delta", "text": text}));
+            }
+            AgentEvent::ThinkingDelta(text) => {
+                self.emit(json!({"type": "thinking_delta", "text": text}));
+            }
+            AgentEvent::ToolStarted { name, args } => {
+                self.emit(json!({"type": "tool_call", "name": name, "args": args}));
+            }
+            AgentEvent::ToolFinished { name, output } => {
+                self.emit(json!({
+                    "type": "tool_result",
+                    "name": name,
+                    "is_error": output.is_error,
+                    "output": output.content,
+                }));
+            }
+            AgentEvent::StepCompleted { step } => {
+                self.emit(json!({"type": "step", "step": step}));
+            }
+            AgentEvent::Error(message) => {
+                self.emit(json!({"type": "error", "message": message}));
+            }
+            AgentEvent::HookFired {
+                event,
+                command,
+                outcome,
+            } => {
+                self.emit(json!({
+                    "type": "hook",
+                    "event": event,
+                    "command": command,
+                    "outcome": outcome.to_string(),
+                }));
+            }
+            AgentEvent::PlanReady { plan, respond } => {
+                // No human in the loop: report the plan and approve it.
+                self.emit(json!({"type": "plan", "plan": plan, "approved": true}));
+                let _ = respond.send(PlanVerdict::approve());
+            }
+            AgentEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+            } => {
+                self.prompt_tokens += prompt_tokens;
+                self.completion_tokens += completion_tokens;
+                self.emit(json!({
+                    "type": "usage",
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                }));
+            }
+            AgentEvent::TodoUpdated(items) => {
+                self.emit(json!({
+                    "type": "todo",
+                    "items": serde_json::to_value(&items).unwrap_or_default(),
+                }));
+            }
+            AgentEvent::TaskFinished {
+                id,
+                command,
+                status,
+            } => {
+                self.emit(json!({
+                    "type": "task_finished",
+                    "id": id,
+                    "command": command,
+                    "status": status.describe(),
+                }));
+            }
+            AgentEvent::Done { reason } => {
+                self.emit(json!({"type": "turn_done", "reason": reason_str(reason)}));
+            }
+        }
+    }
+
+    fn finish(&mut self, reason: DoneReason) {
+        self.emit(json!({
+            "type": "done",
+            "reason": reason_str(reason),
+            "usage": {
+                "prompt_tokens": self.prompt_tokens,
+                "completion_tokens": self.completion_tokens,
+            },
+        }));
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::tools::ToolOutput;
+    use crate::tools::todo::{TodoItem, TodoStatus};
+
+    /// A `Write` whose buffer outlives the sink, so tests can assert on what
+    /// a moved-in sink wrote. Shared with the agent-loop integration test.
+    #[derive(Clone, Default)]
+    pub(crate) struct SharedBuf(pub(crate) Arc<Mutex<Vec<u8>>>);
+
+    impl SharedBuf {
+        pub(crate) fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).expect("utf-8 output")
+        }
+    }
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn synthetic_events() -> Vec<AgentEvent> {
+        vec![
+            AgentEvent::ToolStarted {
+                name: "execute".to_string(),
+                args: json!({"command": "ls"}),
+            },
+            AgentEvent::ToolFinished {
+                name: "execute".to_string(),
+                output: ToolOutput::ok("file.txt"),
+            },
+            AgentEvent::StepCompleted { step: 1 },
+            AgentEvent::ToolStarted {
+                name: "execute".to_string(),
+                args: json!({"command": "false"}),
+            },
+            AgentEvent::ToolFinished {
+                name: "execute".to_string(),
+                output: ToolOutput::error("exit 1"),
+            },
+            AgentEvent::StepCompleted { step: 2 },
+            AgentEvent::TextDelta("all ".to_string()),
+            AgentEvent::TextDelta("done".to_string()),
+            AgentEvent::Usage {
+                prompt_tokens: 100,
+                completion_tokens: 20,
+            },
+            AgentEvent::TodoUpdated(vec![TodoItem {
+                content: "ship it".to_string(),
+                status: TodoStatus::InProgress,
+            }]),
+            AgentEvent::TaskFinished {
+                id: 1,
+                command: "sleep 1".to_string(),
+                status: crate::tools::tasks::TaskStatus::Done(0),
+            },
+            AgentEvent::Done {
+                reason: DoneReason::Completed,
+            },
+        ]
+    }
+
+    // --- exit codes ---
+
+    #[test]
+    fn exit_codes_map_run_outcomes() {
+        assert_eq!(exit_code(DoneReason::Completed), 0);
+        assert_eq!(exit_code(DoneReason::Stopped), 0);
+        assert_eq!(exit_code(DoneReason::MaxSteps), 2);
+        assert_eq!(exit_code(DoneReason::CircuitBreaker), 3);
+        assert_eq!(exit_code(DoneReason::TimeLimit), 4);
+    }
+
+    // --- json ---
+
+    #[test]
+    fn json_sink_emits_one_final_summary_object() {
+        let buf = SharedBuf::default();
+        let mut sink = JsonSink::new(buf.clone());
+        for event in synthetic_events() {
+            sink.event(event);
+        }
+        // Nothing until finish.
+        assert!(buf.contents().is_empty());
+        sink.finish(DoneReason::Completed);
+
+        let out = buf.contents();
+        assert_eq!(out.lines().count(), 1, "exactly one line: {out}");
+        let value: serde_json::Value = serde_json::from_str(out.trim()).expect("valid JSON");
+        assert_eq!(value["result"], "all done");
+        assert_eq!(value["reason"], "completed");
+        assert_eq!(value["turns"], 1);
+        assert_eq!(value["steps"], 2);
+        assert_eq!(value["usage"]["prompt_tokens"], 100);
+        assert_eq!(value["usage"]["completion_tokens"], 20);
+        assert_eq!(value["tool_calls"][0]["name"], "execute");
+        assert_eq!(value["tool_calls"][0]["calls"], 2);
+        assert_eq!(value["tool_calls"][0]["errors"], 1);
+        assert_eq!(value["errors"].as_array().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn json_sink_collects_errors() {
+        let buf = SharedBuf::default();
+        let mut sink = JsonSink::new(buf.clone());
+        sink.event(AgentEvent::Error("model unreachable".to_string()));
+        sink.finish(DoneReason::CircuitBreaker);
+        let value: serde_json::Value =
+            serde_json::from_str(buf.contents().trim()).expect("valid JSON");
+        assert_eq!(value["errors"][0], "model unreachable");
+        assert_eq!(value["reason"], "circuit_breaker");
+    }
+
+    // --- stream-json ---
+
+    #[test]
+    fn stream_json_sink_emits_one_parseable_object_per_event() {
+        let buf = SharedBuf::default();
+        let mut sink = StreamJsonSink::new(buf.clone());
+        for event in synthetic_events() {
+            sink.event(event);
+        }
+        sink.finish(DoneReason::Completed);
+
+        let out = buf.contents();
+        let values: Vec<serde_json::Value> = out
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("every line parses as JSON"))
+            .collect();
+        let types: Vec<&str> = values
+            .iter()
+            .map(|value| value["type"].as_str().expect("typed"))
+            .collect();
+        assert_eq!(
+            types,
+            [
+                "tool_call",
+                "tool_result",
+                "step",
+                "tool_call",
+                "tool_result",
+                "step",
+                "text_delta",
+                "text_delta",
+                "usage",
+                "todo",
+                "task_finished",
+                "turn_done",
+                "done",
+            ]
+        );
+        assert_eq!(values[0]["name"], "execute");
+        assert_eq!(values[1]["is_error"], false);
+        assert_eq!(values[4]["is_error"], true);
+        assert_eq!(values[6]["text"], "all ");
+        assert_eq!(values[9]["items"][0]["content"], "ship it");
+        let done = values.last().unwrap();
+        assert_eq!(done["reason"], "completed");
+        assert_eq!(done["usage"]["prompt_tokens"], 100);
+    }
+
+    #[test]
+    fn stream_json_plan_is_reported_and_auto_approved() {
+        let buf = SharedBuf::default();
+        let mut sink = StreamJsonSink::new(buf.clone());
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        sink.event(AgentEvent::PlanReady {
+            plan: "1. do it".to_string(),
+            respond: tx,
+        });
+        let verdict = rx.try_recv().expect("verdict sent synchronously");
+        assert!(verdict.approved);
+        let value: serde_json::Value =
+            serde_json::from_str(buf.contents().trim()).expect("valid JSON");
+        assert_eq!(value["type"], "plan");
+        assert_eq!(value["approved"], true);
+    }
+
+    // --- text ---
+
+    #[test]
+    fn text_sink_accumulates_usage_and_approves_plans() {
+        // The text sink prints to the real stdout (it shares the run's
+        // spinner), so this asserts its event handling, not captured bytes.
+        let mut sink = TextSink::new(Arc::new(TurnSpinner::new()));
+        sink.event(AgentEvent::Usage {
+            prompt_tokens: 7,
+            completion_tokens: 3,
+        });
+        sink.event(AgentEvent::Usage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+        });
+        assert_eq!(sink.prompt_tokens, 12);
+        assert_eq!(sink.completion_tokens, 4);
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        sink.event(AgentEvent::PlanReady {
+            plan: "plan".to_string(),
+            respond: tx,
+        });
+        assert!(rx.try_recv().expect("verdict sent").approved);
+        sink.finish(DoneReason::Completed);
+    }
+}

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,0 +1,851 @@
+//! Cron scheduler: `wizard schedule` (entry CRUD + foreground run) and the
+//! `wizard scheduler` daemon.
+//!
+//! Entries live in `~/.wizard/schedule.toml` as `[[entries]]` blocks. The
+//! daemon reloads the file every pass, so edits — by hand or via `wizard
+//! schedule add/remove` — are picked up without a restart. Missed runs are
+//! never backfilled: each entry's clock starts at daemon startup (or its
+//! last fire within this daemon's lifetime), so occurrences that passed
+//! while the daemon was down collapse into nothing, and several occurrences
+//! missed during one long sleep collapse into a single fire.
+//!
+//! Everything here is config-independent: no `config.toml` load, no LLM in
+//! this process. Jobs are spawned `wizard` child processes (via
+//! `current_exe()`) that load their own config, exactly like a user-invoked
+//! headless run.
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Local, TimeZone};
+use croner::Cron;
+use croner::parser::{CronParser, Seconds, Year};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::ScheduleCmd;
+use crate::config::Config;
+
+/// Daemon sleep cap so schedule reloads, job reaping, and timeout
+/// enforcement all happen at least this often.
+const MAX_SLEEP: Duration = Duration::from_secs(60);
+
+/// Grace beyond an entry's `max_hours` before the daemon hard-kills the
+/// child. The child also receives `--max-hours`, so the normal path is a
+/// graceful self-stop (exit code 4); the kill is the backstop.
+const KILL_GRACE: Duration = Duration::from_secs(120);
+
+/// Rotate `scheduler.log` past this size (rename to `.log.old`).
+const LOG_ROTATE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// One scheduled job (`[[entries]]` in schedule.toml).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleEntry {
+    /// Unique key (`[a-zA-Z0-9_-]+`).
+    pub name: String,
+    /// Standard 5-field cron expression, evaluated in local time.
+    pub cron: String,
+    /// Task prompt handed to the spawned headless run.
+    pub prompt: String,
+    /// Directory the run executes in.
+    pub cwd: PathBuf,
+    /// "sovereign" (default) or "continuous".
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    /// Wall-clock cap in hours for the spawned run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_hours: Option<f64>,
+    /// Disabled entries are kept in the file but never fired.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_mode() -> String {
+    "sovereign".to_string()
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Contents of `~/.wizard/schedule.toml`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScheduleFile {
+    #[serde(default)]
+    pub entries: Vec<ScheduleEntry>,
+}
+
+/// Dispatch a `wizard schedule` subcommand against the default schedule
+/// file. Returns the process exit code (`run` propagates the child's).
+pub async fn run(cmd: ScheduleCmd) -> Result<i32> {
+    let path = Config::schedule_path()?;
+    match cmd {
+        ScheduleCmd::Add {
+            name,
+            cron,
+            prompt,
+            cwd,
+            max_hours,
+            mode,
+        } => {
+            let cwd = cwd
+                .canonicalize()
+                .with_context(|| format!("--cwd {}: directory must exist", cwd.display()))?;
+            let entry = ScheduleEntry {
+                name,
+                cron,
+                prompt,
+                cwd,
+                mode,
+                max_hours,
+                enabled: true,
+            };
+            add_entry(&path, entry.clone())?;
+            let next = next_occurrence(&entry, &Local::now())?;
+            println!(
+                "added '{}' — next fire {} ({})",
+                entry.name,
+                next.format("%Y-%m-%d %H:%M:%S %Z"),
+                humanize_until(next - Local::now()),
+            );
+            Ok(0)
+        }
+        ScheduleCmd::List => {
+            list(&path)?;
+            Ok(0)
+        }
+        ScheduleCmd::Remove { name } => {
+            remove_entry(&path, &name)?;
+            println!("removed '{name}'");
+            Ok(0)
+        }
+        ScheduleCmd::Run { name } => run_foreground(&path, &name).await,
+    }
+}
+
+/// Strict 5-field cron parse (no seconds, no year field) — what crontab
+/// users expect; rejects everything else up front.
+pub fn parse_cron(expr: &str) -> Result<Cron> {
+    CronParser::builder()
+        .seconds(Seconds::Disallowed)
+        .year(Year::Disallowed)
+        .build()
+        .parse(expr)
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "invalid cron expression {expr:?}: {err} \
+                 (expected 5 fields: minute hour day month weekday)"
+            )
+        })
+}
+
+/// Entry names become toml keys and log labels; keep them path-safe.
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        bail!("invalid entry name {name:?}: only [a-zA-Z0-9_-] is allowed");
+    }
+    Ok(())
+}
+
+/// Reject anything but the two headless job modes.
+fn validate_mode(mode: &str) -> Result<()> {
+    match mode {
+        "sovereign" | "continuous" => Ok(()),
+        other => bail!("invalid mode {other:?} (expected sovereign or continuous)"),
+    }
+}
+
+/// Full per-entry validation: name, mode, cron, and an existing cwd.
+fn validate_entry(entry: &ScheduleEntry) -> Result<()> {
+    validate_name(&entry.name)?;
+    validate_mode(&entry.mode)?;
+    parse_cron(&entry.cron)?;
+    if !entry.cwd.is_dir() {
+        bail!(
+            "cwd {} does not exist or is not a directory",
+            entry.cwd.display()
+        );
+    }
+    if let Some(hours) = entry.max_hours
+        && (!hours.is_finite() || hours <= 0.0)
+    {
+        bail!("max_hours must be a positive number, got {hours}");
+    }
+    Ok(())
+}
+
+/// Load the schedule file; a missing file is an empty schedule.
+pub fn load_schedule(path: &Path) -> Result<ScheduleFile> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ScheduleFile::default());
+        }
+        Err(err) => return Err(err).context(format!("reading {}", path.display())),
+    };
+    toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+}
+
+/// Write the schedule file, creating parent directories as needed.
+pub fn save_schedule(path: &Path, file: &ScheduleFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let text = toml::to_string_pretty(file).context("serializing schedule")?;
+    std::fs::write(path, text).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Validate and append a new entry; the name must be unique.
+pub fn add_entry(path: &Path, entry: ScheduleEntry) -> Result<()> {
+    validate_entry(&entry)?;
+    let mut file = load_schedule(path)?;
+    if file.entries.iter().any(|e| e.name == entry.name) {
+        bail!(
+            "entry '{}' already exists — remove it first or pick another name",
+            entry.name
+        );
+    }
+    file.entries.push(entry);
+    save_schedule(path, &file)
+}
+
+/// Remove an entry by name; error when absent.
+pub fn remove_entry(path: &Path, name: &str) -> Result<()> {
+    let mut file = load_schedule(path)?;
+    let before = file.entries.len();
+    file.entries.retain(|e| e.name != name);
+    if file.entries.len() == before {
+        bail!("no entry named '{name}' — see `wizard schedule list`");
+    }
+    save_schedule(path, &file)
+}
+
+/// Next fire strictly after `now` for one entry.
+fn next_occurrence<Tz: TimeZone>(
+    entry: &ScheduleEntry,
+    now: &DateTime<Tz>,
+) -> Result<DateTime<Tz>> {
+    let cron = parse_cron(&entry.cron)?;
+    cron.find_next_occurrence(now, false)
+        .map_err(|err| anyhow::anyhow!("computing next fire for '{}': {err}", entry.name))
+}
+
+fn list(path: &Path) -> Result<()> {
+    let file = load_schedule(path)?;
+    if file.entries.is_empty() {
+        println!("no entries — add one with `wizard schedule add`");
+        return Ok(());
+    }
+    let now = Local::now();
+    let name_width = file
+        .entries
+        .iter()
+        .map(|e| e.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let cron_width = file
+        .entries
+        .iter()
+        .map(|e| e.cron.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    println!(
+        "{:<name_width$}  {:<cron_width$}  {:<3}  {:<32}  cwd",
+        "name", "cron", "on", "next"
+    );
+    for entry in &file.entries {
+        let on = if entry.enabled { "yes" } else { "no" };
+        let next = match next_occurrence(entry, &now) {
+            Ok(next) => format!(
+                "{} ({})",
+                next.format("%Y-%m-%d %H:%M"),
+                humanize_until(next - now)
+            ),
+            Err(_) => "invalid cron".to_string(),
+        };
+        println!(
+            "{:<name_width$}  {:<cron_width$}  {on:<3}  {next:<32}  {}",
+            entry.name,
+            entry.cron,
+            entry.cwd.display()
+        );
+    }
+    Ok(())
+}
+
+/// Argv (after the binary itself) of the wizard child that executes `entry`
+/// — the single source of truth for both the daemon and `schedule run`.
+/// `--max-hours` is passed through so the child winds down gracefully on
+/// its own; the daemon's kill at `max_hours + grace` is only a backstop.
+pub fn child_args(entry: &ScheduleEntry) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    if entry.mode == "continuous" {
+        // --continuous implies sovereign.
+        args.push("--continuous".to_string());
+    } else {
+        args.push("--mode".to_string());
+        args.push("sovereign".to_string());
+    }
+    args.push("-p".to_string());
+    args.push(entry.prompt.clone());
+    args.push("--cwd".to_string());
+    args.push(entry.cwd.display().to_string());
+    if let Some(hours) = entry.max_hours {
+        args.push("--max-hours".to_string());
+        args.push(hours.to_string());
+    }
+    args
+}
+
+/// Build the child command: this binary, the entry's argv, cwd set (both
+/// via `--cwd` and the process working directory, so relative paths inside
+/// the run resolve correctly either way).
+fn child_command(entry: &ScheduleEntry) -> Result<tokio::process::Command> {
+    let exe = std::env::current_exe().context("locating the wizard binary for the job")?;
+    let mut cmd = tokio::process::Command::new(exe);
+    cmd.args(child_args(entry)).current_dir(&entry.cwd);
+    Ok(cmd)
+}
+
+/// `wizard schedule run <name>`: spawn the entry's job in the foreground
+/// with inherited stdio and return its exit code. `max_hours` is enforced
+/// here too: on the hard timeout the child is killed and the run exits 4
+/// (the time-limit exit code).
+async fn run_foreground(path: &Path, name: &str) -> Result<i32> {
+    let file = load_schedule(path)?;
+    let entry = file
+        .entries
+        .iter()
+        .find(|e| e.name == name)
+        .with_context(|| format!("no entry named '{name}' — see `wizard schedule list`"))?;
+    validate_entry(entry)?;
+
+    let mut child = child_command(entry)?
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawning the job")?;
+    let deadline = entry
+        .max_hours
+        .map(|hours| Duration::from_secs_f64(hours * 3600.0) + KILL_GRACE);
+    let status = match deadline {
+        Some(cap) => match tokio::time::timeout(cap, child.wait()).await {
+            Ok(status) => status.context("waiting for the job")?,
+            Err(_elapsed) => {
+                child.kill().await.ok();
+                eprintln!("job '{name}' exceeded max_hours — killed");
+                return Ok(4);
+            }
+        },
+        None => child.wait().await.context("waiting for the job")?,
+    };
+    Ok(status.code().unwrap_or(1))
+}
+
+// ---------------------------------------------------------------------------
+// Daemon
+// ---------------------------------------------------------------------------
+
+/// A job the daemon has spawned and not yet reaped.
+struct RunningJob {
+    name: String,
+    child: tokio::process::Child,
+    started: Instant,
+    /// `max_hours + KILL_GRACE` from spawn; `None` = unbounded.
+    deadline: Option<Instant>,
+}
+
+/// Pure due-detection: which enabled entries have an occurrence at or
+/// before `now`, measured strictly after their basis — the entry's last
+/// fire within this daemon's lifetime, or `started` for entries that have
+/// not fired yet. Entries with invalid cron expressions are never due.
+pub fn due_entries<'a, Tz: TimeZone>(
+    entries: &'a [ScheduleEntry],
+    last_fired: &HashMap<String, DateTime<Tz>>,
+    started: &DateTime<Tz>,
+    now: &DateTime<Tz>,
+) -> Vec<&'a ScheduleEntry> {
+    entries
+        .iter()
+        .filter(|entry| {
+            if !entry.enabled {
+                return false;
+            }
+            let Ok(cron) = parse_cron(&entry.cron) else {
+                return false;
+            };
+            let basis = last_fired.get(&entry.name).unwrap_or(started);
+            match cron.find_next_occurrence(basis, false) {
+                Ok(next) => next <= *now,
+                Err(_) => false,
+            }
+        })
+        .collect()
+}
+
+/// Earliest next fire across enabled, valid entries, strictly after `now`.
+pub fn next_fire_across<Tz: TimeZone>(
+    entries: &[ScheduleEntry],
+    now: &DateTime<Tz>,
+) -> Option<DateTime<Tz>> {
+    entries
+        .iter()
+        .filter(|entry| entry.enabled)
+        .filter_map(|entry| {
+            parse_cron(&entry.cron)
+                .ok()?
+                .find_next_occurrence(now, false)
+                .ok()
+        })
+        .min()
+}
+
+/// Append a timestamped line to the scheduler log (rotating past
+/// [`LOG_ROTATE_BYTES`]) and echo it to stdout for foreground / journald
+/// visibility. Logging must never take the daemon down, so errors are
+/// swallowed.
+fn log_line(path: &Path, msg: &str) {
+    let line = format!("{} {msg}", Local::now().format("%Y-%m-%d %H:%M:%S%z"));
+    println!("{line}");
+    if let Ok(meta) = std::fs::metadata(path)
+        && meta.len() > LOG_ROTATE_BYTES
+    {
+        let _ = std::fs::rename(path, path.with_extension("log.old"));
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(file, "{line}");
+    }
+}
+
+/// Spawn one entry's job for the daemon: stdio detached to null (the run's
+/// own transcript lives in the child's `~/.wizard` state, not here).
+fn spawn_job(entry: &ScheduleEntry) -> Result<RunningJob> {
+    let child = child_command(entry)?
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawning job")?;
+    let now = Instant::now();
+    Ok(RunningJob {
+        name: entry.name.clone(),
+        child,
+        started: now,
+        deadline: entry
+            .max_hours
+            .map(|hours| now + Duration::from_secs_f64(hours * 3600.0) + KILL_GRACE),
+    })
+}
+
+/// Reap finished children and kill the ones past their deadline.
+async fn reap_jobs(jobs: &mut Vec<RunningJob>, log_path: &Path) {
+    let mut kept = Vec::with_capacity(jobs.len());
+    for mut job in jobs.drain(..) {
+        match job.child.try_wait() {
+            Ok(Some(status)) => {
+                log_line(
+                    log_path,
+                    &format!(
+                        "finished '{}' — exit {} after {:.0}s",
+                        job.name,
+                        status
+                            .code()
+                            .map_or_else(|| "signal".to_string(), |code| code.to_string()),
+                        job.started.elapsed().as_secs_f64()
+                    ),
+                );
+            }
+            Ok(None) => {
+                if job
+                    .deadline
+                    .is_some_and(|deadline| Instant::now() >= deadline)
+                {
+                    job.child.kill().await.ok();
+                    log_line(
+                        log_path,
+                        &format!(
+                            "timeout '{}' — killed after {:.0}s (max_hours exceeded)",
+                            job.name,
+                            job.started.elapsed().as_secs_f64()
+                        ),
+                    );
+                } else {
+                    kept.push(job);
+                }
+            }
+            Err(err) => {
+                log_line(
+                    log_path,
+                    &format!("error waiting on '{}': {err} — dropping it", job.name),
+                );
+            }
+        }
+    }
+    *jobs = kept;
+}
+
+/// `wizard scheduler`: the foreground daemon loop. Each pass it reaps
+/// children, reloads the schedule, fires every due entry (concurrently —
+/// one spawn each, never serialized), then sleeps until the next fire,
+/// capped at [`MAX_SLEEP`] so reloads stay timely. Ctrl-C kills running
+/// jobs and exits 0.
+pub async fn run_daemon() -> Result<i32> {
+    let schedule_path = Config::schedule_path()?;
+    let logs_dir = Config::logs_dir()?;
+    std::fs::create_dir_all(&logs_dir)
+        .with_context(|| format!("creating {}", logs_dir.display()))?;
+    let log_path = logs_dir.join("scheduler.log");
+
+    let started = Local::now();
+    let mut last_fired: HashMap<String, DateTime<Local>> = HashMap::new();
+    let mut jobs: Vec<RunningJob> = Vec::new();
+    log_line(
+        &log_path,
+        &format!(
+            "scheduler started — schedule {} (missed runs are not backfilled)",
+            schedule_path.display()
+        ),
+    );
+
+    loop {
+        reap_jobs(&mut jobs, &log_path).await;
+
+        let entries = match load_schedule(&schedule_path) {
+            Ok(file) => file.entries,
+            Err(err) => {
+                log_line(&log_path, &format!("schedule load failed: {err:#}"));
+                Vec::new()
+            }
+        };
+
+        let now = Local::now();
+        let due: Vec<ScheduleEntry> = due_entries(&entries, &last_fired, &started, &now)
+            .into_iter()
+            .cloned()
+            .collect();
+        for entry in due {
+            last_fired.insert(entry.name.clone(), now);
+            match spawn_job(&entry) {
+                Ok(job) => {
+                    log_line(
+                        &log_path,
+                        &format!(
+                            "fired '{}' (pid {}) — {} in {}",
+                            job.name,
+                            job.child.id().unwrap_or(0),
+                            entry.mode,
+                            entry.cwd.display()
+                        ),
+                    );
+                    jobs.push(job);
+                }
+                Err(err) => {
+                    log_line(
+                        &log_path,
+                        &format!("spawn failed for '{}': {err:#}", entry.name),
+                    );
+                }
+            }
+        }
+
+        let sleep_for = match next_fire_across(&entries, &Local::now()) {
+            Some(next) => (next - Local::now())
+                .to_std()
+                .unwrap_or(Duration::ZERO)
+                .clamp(Duration::from_secs(1), MAX_SLEEP),
+            None => MAX_SLEEP,
+        };
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                result.context("listening for ctrl-c")?;
+                log_line(
+                    &log_path,
+                    &format!("interrupt — stopping; killing {} running job(s)", jobs.len()),
+                );
+                for mut job in jobs {
+                    job.child.kill().await.ok();
+                    log_line(&log_path, &format!("killed '{}' on shutdown", job.name));
+                }
+                log_line(&log_path, "scheduler stopped");
+                return Ok(0);
+            }
+            () = tokio::time::sleep(sleep_for) => {}
+        }
+    }
+}
+
+/// "in 45s" / "in 10h 32m" / "in 3d 4h" for a future delta ("now" when it
+/// is not in the future).
+fn humanize_until(delta: chrono::TimeDelta) -> String {
+    let secs = delta.num_seconds();
+    if secs <= 0 {
+        return "now".to_string();
+    }
+    let (days, hours, mins) = (secs / 86_400, (secs % 86_400) / 3_600, (secs % 3_600) / 60);
+    if days > 0 {
+        format!("in {days}d {hours}h")
+    } else if hours > 0 {
+        format!("in {hours}h {mins}m")
+    } else if mins > 0 {
+        format!("in {mins}m")
+    } else {
+        format!("in {secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn entry(name: &str, cron: &str) -> ScheduleEntry {
+        ScheduleEntry {
+            name: name.to_string(),
+            cron: cron.to_string(),
+            prompt: "do the thing".to_string(),
+            cwd: std::env::temp_dir(),
+            mode: "sovereign".to_string(),
+            max_hours: None,
+            enabled: true,
+        }
+    }
+
+    fn utc(s: &str) -> DateTime<Utc> {
+        s.parse().expect("test timestamp parses")
+    }
+
+    #[test]
+    fn cron_validation_accepts_standard_five_fields() {
+        for ok in ["0 3 * * *", "*/5 * * * *", "0 0 1 1 0", "30 6 * * MON-FRI"] {
+            assert!(parse_cron(ok).is_ok(), "{ok:?} must parse");
+        }
+    }
+
+    #[test]
+    fn cron_validation_rejects_garbage_and_wrong_field_counts() {
+        for bad in ["", "not a cron", "0 3 * *", "0 0 3 * * *", "61 * * * *"] {
+            assert!(parse_cron(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn next_occurrence_from_a_known_instant() {
+        let cron = parse_cron("0 3 * * *").expect("parses");
+        let now = utc("2026-01-01T00:00:00Z");
+        let next = cron.find_next_occurrence(&now, false).expect("next");
+        assert_eq!(next, utc("2026-01-01T03:00:00Z"));
+
+        // Strictly after: exactly at the fire instant the next one is tomorrow.
+        let at_fire = utc("2026-01-01T03:00:00Z");
+        let next = cron.find_next_occurrence(&at_fire, false).expect("next");
+        assert_eq!(next, utc("2026-01-02T03:00:00Z"));
+    }
+
+    #[test]
+    fn schedule_file_round_trip_add_remove() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("schedule.toml");
+
+        add_entry(&path, entry("nightly", "0 3 * * *")).expect("first add");
+        add_entry(&path, entry("hourly", "0 * * * *")).expect("second add");
+
+        let file = load_schedule(&path).expect("loads");
+        assert_eq!(file.entries.len(), 2);
+        assert_eq!(file.entries[0].name, "nightly");
+        assert_eq!(file.entries[0].cron, "0 3 * * *");
+        assert_eq!(file.entries[0].mode, "sovereign");
+        assert!(file.entries[0].enabled, "enabled defaults to true");
+
+        // Duplicate names are rejected.
+        let err = add_entry(&path, entry("nightly", "0 4 * * *")).unwrap_err();
+        assert!(err.to_string().contains("already exists"), "{err}");
+
+        remove_entry(&path, "nightly").expect("removes");
+        let file = load_schedule(&path).expect("loads");
+        assert_eq!(file.entries.len(), 1);
+        assert_eq!(file.entries[0].name, "hourly");
+
+        let err = remove_entry(&path, "nightly").unwrap_err();
+        assert!(err.to_string().contains("no entry"), "{err}");
+    }
+
+    #[test]
+    fn missing_schedule_file_is_an_empty_schedule() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = load_schedule(&dir.path().join("absent.toml")).expect("loads");
+        assert!(file.entries.is_empty());
+    }
+
+    #[test]
+    fn add_rejects_invalid_cron_name_mode_and_cwd() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("schedule.toml");
+
+        let mut bad_cron = entry("a", "whenever");
+        bad_cron.cron = "whenever".to_string();
+        assert!(add_entry(&path, bad_cron).is_err());
+
+        let bad_name = entry("no spaces", "0 3 * * *");
+        assert!(add_entry(&path, bad_name).is_err());
+
+        let mut bad_mode = entry("b", "0 3 * * *");
+        bad_mode.mode = "genie".to_string();
+        assert!(add_entry(&path, bad_mode).is_err());
+
+        let mut bad_cwd = entry("c", "0 3 * * *");
+        bad_cwd.cwd = dir.path().join("does-not-exist");
+        assert!(add_entry(&path, bad_cwd).is_err());
+
+        let mut bad_hours = entry("d", "0 3 * * *");
+        bad_hours.max_hours = Some(0.0);
+        assert!(add_entry(&path, bad_hours).is_err());
+
+        assert!(
+            load_schedule(&path).expect("loads").entries.is_empty(),
+            "nothing invalid may be persisted"
+        );
+    }
+
+    #[test]
+    fn legacy_minimal_entry_parses_with_defaults() {
+        let text = "[[entries]]\n\
+                    name = \"n\"\n\
+                    cron = \"0 3 * * *\"\n\
+                    prompt = \"p\"\n\
+                    cwd = \"/tmp\"\n";
+        let file: ScheduleFile = toml::from_str(text).expect("parses");
+        assert_eq!(file.entries[0].mode, "sovereign");
+        assert_eq!(file.entries[0].max_hours, None);
+        assert!(file.entries[0].enabled);
+    }
+
+    #[test]
+    fn due_detection_fires_after_an_occurrence_passes() {
+        let entries = vec![entry("minutely", "* * * * *")];
+        let started = utc("2026-01-01T00:00:30Z");
+        let mut last_fired: HashMap<String, DateTime<Utc>> = HashMap::new();
+
+        // 10 seconds in: the first occurrence after start (00:01:00) has not
+        // passed yet.
+        let now = utc("2026-01-01T00:00:40Z");
+        assert!(due_entries(&entries, &last_fired, &started, &now).is_empty());
+
+        // Past 00:01:00: due exactly once.
+        let now = utc("2026-01-01T00:01:05Z");
+        let due = due_entries(&entries, &last_fired, &started, &now);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].name, "minutely");
+
+        // After recording the fire, the same instant is no longer due...
+        last_fired.insert("minutely".to_string(), now);
+        assert!(due_entries(&entries, &last_fired, &started, &now).is_empty());
+
+        // ...and several missed occurrences collapse into one fire.
+        let later = utc("2026-01-01T00:05:30Z");
+        let due = due_entries(&entries, &last_fired, &started, &later);
+        assert_eq!(due.len(), 1);
+    }
+
+    #[test]
+    fn due_detection_skips_disabled_and_invalid_entries() {
+        let mut disabled = entry("off", "* * * * *");
+        disabled.enabled = false;
+        let mut invalid = entry("broken", "* * * * *");
+        invalid.cron = "not a cron".to_string();
+        let entries = vec![disabled, invalid, entry("on", "* * * * *")];
+
+        let started = utc("2026-01-01T00:00:00Z");
+        let now = utc("2026-01-01T00:02:00Z");
+        let due = due_entries(&entries, &HashMap::new(), &started, &now);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].name, "on");
+    }
+
+    #[test]
+    fn due_detection_does_not_backfill_before_startup() {
+        // Daily 03:00 job; daemon starts at 10:00 — yesterday's and today's
+        // 03:00 are gone, the entry is not due until tomorrow 03:00.
+        let entries = vec![entry("daily", "0 3 * * *")];
+        let started = utc("2026-01-01T10:00:00Z");
+        let now = utc("2026-01-01T23:59:00Z");
+        assert!(due_entries(&entries, &HashMap::new(), &started, &now).is_empty());
+
+        let tomorrow = utc("2026-01-02T03:00:00Z");
+        let due = due_entries(&entries, &HashMap::new(), &started, &tomorrow);
+        assert_eq!(due.len(), 1);
+    }
+
+    #[test]
+    fn next_fire_across_picks_the_earliest_enabled_entry() {
+        let mut late = entry("late", "0 12 * * *");
+        late.enabled = true;
+        let early = entry("early", "0 6 * * *");
+        let mut disabled = entry("disabled", "0 1 * * *");
+        disabled.enabled = false;
+        let entries = vec![late, early, disabled];
+
+        let now = utc("2026-01-01T00:00:00Z");
+        let next = next_fire_across(&entries, &now).expect("a next fire exists");
+        assert_eq!(next, utc("2026-01-01T06:00:00Z"));
+
+        assert!(next_fire_across(&[], &now).is_none());
+    }
+
+    #[test]
+    fn child_args_sovereign_with_cap() {
+        let mut e = entry("n", "0 3 * * *");
+        e.prompt = "tidy the repo".to_string();
+        e.cwd = PathBuf::from("/home/user/proj");
+        e.max_hours = Some(2.0);
+        assert_eq!(
+            child_args(&e),
+            vec![
+                "--mode",
+                "sovereign",
+                "-p",
+                "tidy the repo",
+                "--cwd",
+                "/home/user/proj",
+                "--max-hours",
+                "2",
+            ]
+        );
+    }
+
+    #[test]
+    fn child_args_continuous_without_cap() {
+        let mut e = entry("n", "0 3 * * *");
+        e.mode = "continuous".to_string();
+        e.prompt = "keep improving".to_string();
+        e.cwd = PathBuf::from("/srv/app");
+        assert_eq!(
+            child_args(&e),
+            vec!["--continuous", "-p", "keep improving", "--cwd", "/srv/app"]
+        );
+    }
+
+    #[test]
+    fn humanize_until_buckets() {
+        use chrono::TimeDelta;
+        assert_eq!(humanize_until(TimeDelta::seconds(-5)), "now");
+        assert_eq!(humanize_until(TimeDelta::seconds(45)), "in 45s");
+        assert_eq!(humanize_until(TimeDelta::seconds(150)), "in 2m");
+        assert_eq!(humanize_until(TimeDelta::seconds(37_920)), "in 10h 32m");
+        assert_eq!(humanize_until(TimeDelta::seconds(273_600)), "in 3d 4h");
+    }
+}

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -176,8 +176,9 @@ pub fn render_for_prompt(skills: &[Skill]) -> String {
 
 /// Split optional `---`-fenced frontmatter from the markdown body. When the
 /// file does not start with a `---` line (or the closing fence is missing),
-/// the whole content is the body.
-fn split_frontmatter(raw: &str) -> (SkillMeta, String) {
+/// the whole content is the body. Shared with the custom-command loader
+/// (`crate::commands`), which uses the same convention.
+pub(crate) fn split_frontmatter(raw: &str) -> (SkillMeta, String) {
     let lines: Vec<&str> = raw.lines().collect();
     if lines.first().map(|l| l.trim_end()) == Some("---")
         && let Some(end) = lines[1..].iter().position(|l| l.trim_end() == "---")

--- a/src/tools/evolve.rs
+++ b/src/tools/evolve.rs
@@ -1,9 +1,7 @@
 //! `evolve` tool: lets the agent extend or rebuild ITSELF at runtime.
-//! Wraps the tiered self-extension pipeline (`crate::evolve`). Auto-approved
-//! by default in both modes (genie bypasses permissions, sovereign is
-//! autonomous); subject to the y/n gate only when auto-approve is disabled
-//! (`requires_approval` = true). A successful deep rebuild drops a re-exec
-//! marker so the continuous loop relaunches into the new binary.
+//! Wraps the tiered self-extension pipeline (`crate::evolve`). A successful
+//! deep rebuild drops a re-exec marker so the continuous loop relaunches
+//! into the new binary.
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -72,10 +70,6 @@ impl Tool for EvolveTool {
         })
     }
 
-    fn requires_approval(&self) -> bool {
-        true
-    }
-
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
         let args: EvolveArgs = parse_args(self.name(), args)?;
 
@@ -86,9 +80,6 @@ impl Tool for EvolveTool {
             } else {
                 EvolveTier::Runtime
             },
-            // The tool-layer approval gate already governs whether this
-            // `execute` is reached, so the pipeline itself need not re-prompt.
-            auto_approve: true,
         };
 
         let outcome = match Evolver::new(self.config.clone()).run(request).await {

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -12,8 +12,8 @@ use tokio::process::Command;
 
 use super::shell::run_command;
 use super::{
-    MAX_OUTPUT_BYTES, Tool, ToolContext, ToolError, ToolOutput, parse_args, resolve_path,
-    truncate_output,
+    MAX_OUTPUT_BYTES, Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args,
+    resolve_path, truncate_output,
 };
 
 /// Maximum number of lines a single `read_file` call returns.
@@ -65,6 +65,10 @@ impl Tool for ReadFileTool {
             },
             "required": ["path"]
         })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
@@ -141,8 +145,7 @@ pub struct WriteFileArgs {
     pub content: String,
 }
 
-/// `write_file` — create or overwrite a file. Opts into the approval gate
-/// (only active when `auto_approve = false`).
+/// `write_file` — create or overwrite a file.
 pub struct WriteFileTool;
 
 #[async_trait]
@@ -166,8 +169,8 @@ impl Tool for WriteFileTool {
         })
     }
 
-    fn requires_approval(&self) -> bool {
-        true
+    fn access(&self) -> ToolAccess {
+        ToolAccess::Edit
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
@@ -214,8 +217,7 @@ pub struct EditFileArgs {
     pub replace_all: bool,
 }
 
-/// `edit_file` — exact search-and-replace edit. Opts into the approval gate
-/// (only active when `auto_approve = false`).
+/// `edit_file` — exact search-and-replace edit.
 pub struct EditFileTool;
 
 #[async_trait]
@@ -241,8 +243,8 @@ impl Tool for EditFileTool {
         })
     }
 
-    fn requires_approval(&self) -> bool {
-        true
+    fn access(&self) -> ToolAccess {
+        ToolAccess::Edit
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
@@ -351,6 +353,10 @@ impl Tool for ListFilesTool {
                 "glob": { "type": "string", "description": "Glob filter, e.g. **/*.rs" }
             }
         })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
@@ -544,6 +550,10 @@ impl Tool for SearchFilesTool {
             },
             "required": ["pattern"]
         })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {

--- a/src/tools/git.rs
+++ b/src/tools/git.rs
@@ -10,7 +10,8 @@ use tokio::process::Command;
 
 use super::shell::{CommandResult, run_command};
 use super::{
-    MAX_OUTPUT_BYTES, Tool, ToolContext, ToolError, ToolOutput, parse_args, truncate_output,
+    MAX_OUTPUT_BYTES, Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args,
+    truncate_output,
 };
 
 /// Timeout for git subprocesses. Status and diff are local operations, so
@@ -50,6 +51,10 @@ impl Tool for GitStatusTool {
 
     fn parameters(&self) -> Value {
         json!({ "type": "object", "properties": {} })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
@@ -104,6 +109,10 @@ impl Tool for GitDiffTool {
                 "path": { "type": "string", "description": "Limit the diff to this path" }
             }
         })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {

--- a/src/tools/memory.rs
+++ b/src/tools/memory.rs
@@ -3,8 +3,7 @@
 //! Backed by `crate::memory::MemoryStore` (one markdown file per memory
 //! under `~/.wizard/memory/<project-slug>/`). The index of saved memories is
 //! injected into the system prompt at session start, so a save made now is
-//! recalled automatically next session. Confined to `~/.wizard/memory`, so
-//! it never opts into the approval gate.
+//! recalled automatically next session. Confined to `~/.wizard/memory`.
 
 use async_trait::async_trait;
 use serde::Deserialize;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,7 @@ pub mod evolve;
 pub mod file;
 pub mod git;
 pub mod memory;
+pub mod plan;
 pub mod publish;
 pub mod registry;
 pub mod scripted;
@@ -53,6 +54,11 @@ pub struct ToolContext {
     pub tasks: Arc<tasks::TaskRegistry>,
     /// The agent's working todo list, shared by every call in the session.
     pub todos: Arc<Mutex<todo::TodoList>>,
+    /// Event channel of the turn currently dispatching, injected by the
+    /// dispatcher so tools that converse with the surface (`exit_plan`'s
+    /// approval round-trip) can reach it. `None` outside the dispatch
+    /// pipeline (subagents, direct registry execution).
+    pub events: Option<tokio::sync::mpsc::Sender<crate::agent::AgentEvent>>,
 }
 
 impl ToolContext {
@@ -61,6 +67,15 @@ impl ToolContext {
             cwd: cwd.into(),
             tasks: Arc::new(tasks::TaskRegistry::new()),
             todos: Arc::new(Mutex::new(todo::TodoList::new())),
+            events: None,
+        }
+    }
+
+    /// A copy of this context carrying the turn's event channel.
+    pub fn with_events(&self, events: tokio::sync::mpsc::Sender<crate::agent::AgentEvent>) -> Self {
+        Self {
+            events: Some(events),
+            ..self.clone()
         }
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,14 +11,17 @@ pub mod publish;
 pub mod registry;
 pub mod scripted;
 pub mod shell;
+pub mod tasks;
+pub mod todo;
 
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
 use crate::llm::ToolSpec;
 
-/// Where a tool comes from. Affects display and default approval policy.
+/// Where a tool comes from. Affects display.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolKind {
     /// Compiled into the binary.
@@ -29,16 +32,36 @@ pub enum ToolKind {
     Mcp,
 }
 
+/// How a tool touches the world. Drives the plan-mode read-only gate and
+/// checkpoint snapshots of `Edit`-class targets — never prompting.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ToolAccess {
+    /// Observes only (reads files, queries state).
+    ReadOnly,
+    /// Modifies a file at a resolvable path.
+    Edit,
+    /// Runs commands or has other side effects.
+    Execute,
+}
+
 /// Per-call execution context.
 #[derive(Debug, Clone)]
 pub struct ToolContext {
     /// Project root all relative paths resolve against.
     pub cwd: PathBuf,
+    /// Session-wide registry of background shell tasks.
+    pub tasks: Arc<tasks::TaskRegistry>,
+    /// The agent's working todo list, shared by every call in the session.
+    pub todos: Arc<Mutex<todo::TodoList>>,
 }
 
 impl ToolContext {
     pub fn new(cwd: impl Into<PathBuf>) -> Self {
-        Self { cwd: cwd.into() }
+        Self {
+            cwd: cwd.into(),
+            tasks: Arc::new(tasks::TaskRegistry::new()),
+            todos: Arc::new(Mutex::new(todo::TodoList::new())),
+        }
     }
 }
 
@@ -77,8 +100,6 @@ pub enum ToolError {
     UnknownTool(String),
     #[error("invalid arguments for '{tool}': {message}")]
     InvalidArgs { tool: String, message: String },
-    #[error("user denied execution of '{0}'")]
-    Denied(String),
     #[error("tool '{tool}' timed out after {seconds}s")]
     Timeout { tool: String, seconds: u64 },
     #[error("tool '{tool}' failed")]
@@ -146,9 +167,8 @@ pub(crate) fn truncate_output(mut text: String, max_bytes: usize) -> String {
 /// - `parameters` returns a JSON Schema object; `execute` receives arguments
 ///   already validated against nothing — implementations must deserialize
 ///   defensively and return [`ToolError::InvalidArgs`] on shape mismatch.
-/// - `requires_approval` marks tools that CAN trigger the y/n gate; the gate
-///   only fires when per-action confirmation is enabled (`auto_approve = false`
-///   in config). Both modes auto-approve by default.
+/// - `access` classifies side effects conservatively: anything not provably
+///   read-only or a path-addressed edit stays [`ToolAccess::Execute`].
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// Unique tool name as advertised to the model (snake_case).
@@ -160,9 +180,10 @@ pub trait Tool: Send + Sync {
     /// JSON Schema describing the arguments object.
     fn parameters(&self) -> serde_json::Value;
 
-    /// Whether this tool opts into the y/n gate when `auto_approve` is false.
-    fn requires_approval(&self) -> bool {
-        false
+    /// How this tool touches the world. Drives the plan-mode read-only gate
+    /// and checkpoint snapshots — never prompting.
+    fn access(&self) -> ToolAccess {
+        ToolAccess::Execute
     }
 
     /// Origin of this tool.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,6 +14,7 @@ pub mod scripted;
 pub mod shell;
 pub mod tasks;
 pub mod todo;
+pub mod web;
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -59,6 +60,9 @@ pub struct ToolContext {
     /// approval round-trip) can reach it. `None` outside the dispatch
     /// pipeline (subagents, direct registry execution).
     pub events: Option<tokio::sync::mpsc::Sender<crate::agent::AgentEvent>>,
+    /// Settings for the native web tools (`[web]` in `config.toml`), set by
+    /// the agent at construction; defaults elsewhere.
+    pub web: Arc<crate::config::WebConfig>,
 }
 
 impl ToolContext {
@@ -68,7 +72,14 @@ impl ToolContext {
             tasks: Arc::new(tasks::TaskRegistry::new()),
             todos: Arc::new(Mutex::new(todo::TodoList::new())),
             events: None,
+            web: Arc::new(crate::config::WebConfig::default()),
         }
+    }
+
+    /// This context with `web` tool settings applied (agent construction).
+    pub fn with_web(mut self, web: crate::config::WebConfig) -> Self {
+        self.web = Arc::new(web);
+        self
     }
 
     /// A copy of this context carrying the turn's event channel.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -63,6 +63,11 @@ pub struct ToolContext {
     /// Settings for the native web tools (`[web]` in `config.toml`), set by
     /// the agent at construction; defaults elsewhere.
     pub web: Arc<crate::config::WebConfig>,
+    /// Per-file checkpoint store, set by the agent at construction. The
+    /// dispatcher and the subagent loop snapshot `Edit`-class targets into
+    /// it before execution. `None` outside an agent (direct registry
+    /// execution in tests).
+    pub checkpoints: Option<Arc<crate::checkpoint::CheckpointStore>>,
 }
 
 impl ToolContext {
@@ -73,12 +78,19 @@ impl ToolContext {
             todos: Arc::new(Mutex::new(todo::TodoList::new())),
             events: None,
             web: Arc::new(crate::config::WebConfig::default()),
+            checkpoints: None,
         }
     }
 
     /// This context with `web` tool settings applied (agent construction).
     pub fn with_web(mut self, web: crate::config::WebConfig) -> Self {
         self.web = Arc::new(web);
+        self
+    }
+
+    /// This context with the checkpoint store attached (agent construction).
+    pub fn with_checkpoints(mut self, store: Arc<crate::checkpoint::CheckpointStore>) -> Self {
+        self.checkpoints = Some(store);
         self
     }
 

--- a/src/tools/plan.rs
+++ b/src/tools/plan.rs
@@ -1,0 +1,273 @@
+//! Plan mode's exit hatch: the `exit_plan` tool.
+//!
+//! While plan mode is active the dispatcher blocks every non-read-only tool
+//! (see `crate::dispatch`); `exit_plan` is the one sanctioned way out. The
+//! model calls it with the finished plan, the plan is persisted to
+//! `<project>/.wizard/plan.md`, and an [`AgentEvent::PlanReady`] asks the
+//! surface for a verdict: the TUI renders a review, headless runners and the
+//! gateway auto-approve. Approval flips plan mode off and tells the model to
+//! execute; rejection feeds the reviewer's feedback back as an ordinary tool
+//! error and plan mode stays on.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::sync::oneshot;
+
+use crate::agent::AgentEvent;
+
+use super::{Tool, ToolContext, ToolError, ToolOutput, parse_args};
+
+/// Advertised name of the tool; the dispatcher's plan gate exempts it.
+pub const EXIT_PLAN_TOOL_NAME: &str = "exit_plan";
+
+/// Where the plan markdown is persisted, relative to the project root.
+pub const PLAN_FILE: &str = ".wizard/plan.md";
+
+/// `exit_plan` — present the finished plan for review and leave plan mode on
+/// approval. Registered always (so the model can see it documented), but it
+/// only does anything while plan mode is active.
+pub struct ExitPlanTool {
+    /// Plan-mode flag shared with the agent and its dispatcher; approval
+    /// clears it.
+    plan_mode: Arc<AtomicBool>,
+}
+
+impl ExitPlanTool {
+    pub fn new(plan_mode: Arc<AtomicBool>) -> Self {
+        Self { plan_mode }
+    }
+}
+
+#[async_trait]
+impl Tool for ExitPlanTool {
+    fn name(&self) -> &str {
+        EXIT_PLAN_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Finish plan mode by presenting your implementation plan for review. \
+         Call this only while in plan mode, after investigating with read-only \
+         tools. The plan is saved to .wizard/plan.md and reviewed; if approved \
+         you may execute it, if rejected you receive feedback and stay in plan \
+         mode."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "description": "The full implementation plan, as markdown"
+                }
+            },
+            "required": ["plan"]
+        })
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        #[derive(Deserialize)]
+        struct Args {
+            plan: String,
+        }
+        let Args { plan } = parse_args(EXIT_PLAN_TOOL_NAME, args)?;
+
+        if !self.plan_mode.load(Ordering::SeqCst) {
+            return Ok(ToolOutput::error(
+                "not in plan mode — exit_plan only applies while plan mode is active",
+            ));
+        }
+        let Some(events) = ctx.events.clone() else {
+            // Outside the dispatch pipeline there is no surface to review the
+            // plan (e.g. a subagent context); refuse rather than silently
+            // approve.
+            return Ok(ToolOutput::error(
+                "plan review is unavailable in this context; continue in plan mode",
+            ));
+        };
+
+        // Persist the plan before asking for a verdict, so it survives a
+        // rejected or interrupted review.
+        let path = ctx.cwd.join(PLAN_FILE);
+        let write = path
+            .parent()
+            .map_or(Ok(()), std::fs::create_dir_all)
+            .and_then(|()| std::fs::write(&path, &plan));
+        if let Err(err) = write {
+            return Err(ToolError::Execution {
+                tool: EXIT_PLAN_TOOL_NAME.to_string(),
+                source: anyhow::anyhow!("writing {}: {err}", path.display()),
+            });
+        }
+
+        let (respond, verdict) = oneshot::channel();
+        if events
+            .send(AgentEvent::PlanReady {
+                plan: plan.clone(),
+                respond,
+            })
+            .await
+            .is_err()
+        {
+            // The surface is gone; the turn is ending anyway.
+            return Ok(ToolOutput::error(
+                "plan review was cancelled (no surface to approve it); still in plan mode",
+            ));
+        }
+
+        Ok(match verdict.await {
+            Ok(verdict) if verdict.approved => {
+                self.plan_mode.store(false, Ordering::SeqCst);
+                ToolOutput::ok("Plan approved — proceed to execute it.")
+            }
+            Ok(verdict) => {
+                let feedback = if verdict.feedback.trim().is_empty() {
+                    "the plan was not accepted".to_string()
+                } else {
+                    verdict.feedback
+                };
+                ToolOutput::error(format!(
+                    "plan rejected: {feedback}. Revise the plan (you are still in plan mode) \
+                     and call exit_plan again."
+                ))
+            }
+            Err(_) => ToolOutput::error("plan review ended without a verdict; still in plan mode"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::agent::PlanVerdict;
+
+    /// Temp project dir removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let dir = std::env::temp_dir().join(format!("wizard-test-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn flag(on: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(on))
+    }
+
+    #[tokio::test]
+    async fn errors_outside_plan_mode() {
+        let tmp = TempDir::new();
+        let tool = ExitPlanTool::new(flag(false));
+        let out = tool
+            .execute(json!({ "plan": "# p" }), &ToolContext::new(&tmp.0))
+            .await
+            .expect("executes");
+        assert!(out.is_error);
+        assert!(out.content.contains("not in plan mode"), "{}", out.content);
+        assert!(!tmp.0.join(PLAN_FILE).exists(), "no plan file written");
+    }
+
+    #[tokio::test]
+    async fn errors_without_an_event_channel() {
+        let tmp = TempDir::new();
+        let tool = ExitPlanTool::new(flag(true));
+        let out = tool
+            .execute(json!({ "plan": "# p" }), &ToolContext::new(&tmp.0))
+            .await
+            .expect("executes");
+        assert!(out.is_error);
+        assert!(out.content.contains("unavailable"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn approval_writes_plan_and_clears_the_flag() {
+        let tmp = TempDir::new();
+        let plan_mode = flag(true);
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new(&tmp.0).with_events(tx);
+
+        let reviewer = async {
+            let Some(AgentEvent::PlanReady { plan, respond }) = rx.recv().await else {
+                panic!("expected PlanReady");
+            };
+            assert_eq!(plan, "# the plan");
+            respond.send(PlanVerdict::approve()).expect("verdict sent");
+        };
+        let (out, ()) = tokio::join!(
+            tool.execute(json!({ "plan": "# the plan" }), &ctx),
+            reviewer
+        );
+        let out = out.expect("executes");
+
+        assert!(!out.is_error, "{}", out.content);
+        assert!(out.content.contains("Plan approved"), "{}", out.content);
+        assert!(!plan_mode.load(Ordering::SeqCst), "plan mode cleared");
+        let saved = std::fs::read_to_string(tmp.0.join(PLAN_FILE)).expect("plan persisted");
+        assert_eq!(saved, "# the plan");
+    }
+
+    #[tokio::test]
+    async fn rejection_keeps_plan_mode_and_returns_feedback() {
+        let tmp = TempDir::new();
+        let plan_mode = flag(true);
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new(&tmp.0).with_events(tx);
+
+        let reviewer = async {
+            let Some(AgentEvent::PlanReady { respond, .. }) = rx.recv().await else {
+                panic!("expected PlanReady");
+            };
+            respond
+                .send(PlanVerdict::reject("cover the error path too"))
+                .expect("verdict sent");
+        };
+        let (out, ()) = tokio::join!(tool.execute(json!({ "plan": "# p" }), &ctx), reviewer);
+        let out = out.expect("executes");
+
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("cover the error path too"),
+            "{}",
+            out.content
+        );
+        assert!(plan_mode.load(Ordering::SeqCst), "plan mode stays on");
+    }
+
+    #[tokio::test]
+    async fn dropped_verdict_keeps_plan_mode() {
+        let tmp = TempDir::new();
+        let plan_mode = flag(true);
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new(&tmp.0).with_events(tx);
+
+        let reviewer = async {
+            let Some(AgentEvent::PlanReady { respond, .. }) = rx.recv().await else {
+                panic!("expected PlanReady");
+            };
+            drop(respond); // surface went away without answering
+        };
+        let (out, ()) = tokio::join!(tool.execute(json!({ "plan": "# p" }), &ctx), reviewer);
+        let out = out.expect("executes");
+        assert!(out.is_error);
+        assert!(plan_mode.load(Ordering::SeqCst), "plan mode stays on");
+    }
+}

--- a/src/tools/publish.rs
+++ b/src/tools/publish.rs
@@ -2,8 +2,7 @@
 //! installer for their variant.
 //!
 //! Mirrors [`crate::tools::evolve::EvolveTool`] in structure. Requires `gh`
-//! authenticated; opts into `requires_approval` so a y/n prompt fires when
-//! `auto_approve = false`; both modes auto-approve by default.
+//! authenticated (`gh auth login`).
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -62,18 +61,11 @@ impl Tool for PublishTool {
         })
     }
 
-    fn requires_approval(&self) -> bool {
-        true
-    }
-
     async fn execute(&self, args: Value, _ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
         let args: PublishArgs = parse_args(self.name(), args)?;
 
         let req = PublishRequest {
             branch: args.branch,
-            // The tool-layer approval gate already governs whether
-            // execute() is reached, so the pipeline itself need not re-prompt.
-            auto_approve: true,
         };
 
         match publish(&self.config, req, false).await {

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -104,8 +104,7 @@ impl ToolRegistry {
         Ok(count)
     }
 
-    /// Dispatch a tool call by name. Approval gating happens in the agent
-    /// loop before this is reached.
+    /// Dispatch a tool call by name.
     pub async fn execute(
         &self,
         name: &str,
@@ -137,6 +136,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::tools::ToolAccess;
 
     /// Temp project dir removed on drop.
     struct TempDir(PathBuf);
@@ -217,22 +217,29 @@ mod tests {
     }
 
     #[test]
-    fn risky_tools_require_approval_and_read_only_tools_do_not() {
+    fn native_tools_report_their_access_class() {
         let registry = ToolRegistry::with_native_tools();
-        let approval = |name: &str| registry.get(name).expect(name).requires_approval();
+        let access = |name: &str| registry.get(name).expect(name).access();
 
-        for risky in ["write_file", "edit_file", "execute"] {
-            assert!(approval(risky), "{risky} must be gated behind approval");
-        }
-        for safe in [
+        for read_only in [
             "read_file",
             "list_files",
             "search_files",
             "git_status",
             "git_diff",
-            "memory",
         ] {
-            assert!(!approval(safe), "{safe} must not require approval");
+            assert_eq!(access(read_only), ToolAccess::ReadOnly, "{read_only}");
+        }
+        for edit in ["write_file", "edit_file"] {
+            assert_eq!(access(edit), ToolAccess::Edit, "{edit}");
+        }
+        // `execute` runs arbitrary commands; `memory` mutates its store.
+        for side_effecting in ["execute", "memory"] {
+            assert_eq!(
+                access(side_effecting),
+                ToolAccess::Execute,
+                "{side_effecting}"
+            );
         }
     }
 
@@ -327,9 +334,10 @@ mod tests {
         assert_eq!(added, 1);
         let tool = registry.get("greet").expect("scripted tool registered");
         assert_eq!(tool.kind(), crate::tools::ToolKind::Scripted);
-        assert!(
-            tool.requires_approval(),
-            "scripted tools are risky by default"
+        assert_eq!(
+            tool.access(),
+            ToolAccess::Execute,
+            "scripted tools keep the Execute default"
         );
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -16,6 +16,7 @@ use super::file::{EditFileTool, ListFilesTool, ReadFileTool, SearchFilesTool, Wr
 use super::git::{GitDiffTool, GitStatusTool};
 use super::memory::MemoryTool;
 use super::shell::ExecuteTool;
+use super::todo::TodoTool;
 
 /// Registry of every callable tool, keyed by advertised name.
 /// Registration order is preserved for stable spec ordering in prompts.
@@ -33,7 +34,8 @@ impl ToolRegistry {
 
     /// Registry pre-populated with all native tools
     /// (`read_file`, `write_file`, `edit_file`, `list_files`,
-    /// `search_files`, `execute`, `git_status`, `git_diff`, `memory`).
+    /// `search_files`, `execute`, `git_status`, `git_diff`, `memory`,
+    /// `todo`).
     pub fn with_native_tools() -> Self {
         let mut registry = Self::new();
         registry.register(Arc::new(ReadFileTool));
@@ -45,6 +47,7 @@ impl ToolRegistry {
         registry.register(Arc::new(GitStatusTool));
         registry.register(Arc::new(GitDiffTool));
         registry.register(Arc::new(MemoryTool));
+        registry.register(Arc::new(TodoTool));
         registry
     }
 
@@ -204,9 +207,10 @@ mod tests {
                 "git_status",
                 "git_diff",
                 "memory",
+                "todo",
             ]
         );
-        assert_eq!(registry.len(), 9);
+        assert_eq!(registry.len(), 10);
         assert!(!registry.is_empty());
 
         for spec in registry.specs() {
@@ -227,6 +231,9 @@ mod tests {
             "search_files",
             "git_status",
             "git_diff",
+            // `todo` mutates only agent-local state, so it stays usable in
+            // plan mode.
+            "todo",
         ] {
             assert_eq!(access(read_only), ToolAccess::ReadOnly, "{read_only}");
         }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -16,6 +16,7 @@ use super::file::{EditFileTool, ListFilesTool, ReadFileTool, SearchFilesTool, Wr
 use super::git::{GitDiffTool, GitStatusTool};
 use super::memory::MemoryTool;
 use super::shell::ExecuteTool;
+use super::tasks::{TaskKillTool, TaskOutputTool};
 use super::todo::TodoTool;
 use super::web::{WebFetchTool, WebSearchTool};
 
@@ -36,7 +37,7 @@ impl ToolRegistry {
     /// Registry pre-populated with all native tools
     /// (`read_file`, `write_file`, `edit_file`, `list_files`,
     /// `search_files`, `execute`, `git_status`, `git_diff`, `memory`,
-    /// `todo`, `web_fetch`, `web_search`).
+    /// `todo`, `web_fetch`, `web_search`, `task_output`, `task_kill`).
     pub fn with_native_tools() -> Self {
         let mut registry = Self::new();
         registry.register(Arc::new(ReadFileTool));
@@ -51,6 +52,8 @@ impl ToolRegistry {
         registry.register(Arc::new(TodoTool));
         registry.register(Arc::new(WebFetchTool));
         registry.register(Arc::new(WebSearchTool));
+        registry.register(Arc::new(TaskOutputTool));
+        registry.register(Arc::new(TaskKillTool));
         registry
     }
 
@@ -213,9 +216,11 @@ mod tests {
                 "todo",
                 "web_fetch",
                 "web_search",
+                "task_output",
+                "task_kill",
             ]
         );
-        assert_eq!(registry.len(), 12);
+        assert_eq!(registry.len(), 14);
         assert!(!registry.is_empty());
 
         for spec in registry.specs() {
@@ -242,14 +247,17 @@ mod tests {
             // The web tools only observe the outside world.
             "web_fetch",
             "web_search",
+            // `task_output` only reads buffered task state.
+            "task_output",
         ] {
             assert_eq!(access(read_only), ToolAccess::ReadOnly, "{read_only}");
         }
         for edit in ["write_file", "edit_file"] {
             assert_eq!(access(edit), ToolAccess::Edit, "{edit}");
         }
-        // `execute` runs arbitrary commands; `memory` mutates its store.
-        for side_effecting in ["execute", "memory"] {
+        // `execute` runs arbitrary commands; `memory` mutates its store;
+        // `task_kill` terminates processes.
+        for side_effecting in ["execute", "memory", "task_kill"] {
             assert_eq!(
                 access(side_effecting),
                 ToolAccess::Execute,

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -17,6 +17,7 @@ use super::git::{GitDiffTool, GitStatusTool};
 use super::memory::MemoryTool;
 use super::shell::ExecuteTool;
 use super::todo::TodoTool;
+use super::web::{WebFetchTool, WebSearchTool};
 
 /// Registry of every callable tool, keyed by advertised name.
 /// Registration order is preserved for stable spec ordering in prompts.
@@ -35,7 +36,7 @@ impl ToolRegistry {
     /// Registry pre-populated with all native tools
     /// (`read_file`, `write_file`, `edit_file`, `list_files`,
     /// `search_files`, `execute`, `git_status`, `git_diff`, `memory`,
-    /// `todo`).
+    /// `todo`, `web_fetch`, `web_search`).
     pub fn with_native_tools() -> Self {
         let mut registry = Self::new();
         registry.register(Arc::new(ReadFileTool));
@@ -48,6 +49,8 @@ impl ToolRegistry {
         registry.register(Arc::new(GitDiffTool));
         registry.register(Arc::new(MemoryTool));
         registry.register(Arc::new(TodoTool));
+        registry.register(Arc::new(WebFetchTool));
+        registry.register(Arc::new(WebSearchTool));
         registry
     }
 
@@ -208,9 +211,11 @@ mod tests {
                 "git_diff",
                 "memory",
                 "todo",
+                "web_fetch",
+                "web_search",
             ]
         );
-        assert_eq!(registry.len(), 10);
+        assert_eq!(registry.len(), 12);
         assert!(!registry.is_empty());
 
         for spec in registry.specs() {
@@ -234,6 +239,9 @@ mod tests {
             // `todo` mutates only agent-local state, so it stays usable in
             // plan mode.
             "todo",
+            // The web tools only observe the outside world.
+            "web_fetch",
+            "web_search",
         ] {
             assert_eq!(access(read_only), ToolAccess::ReadOnly, "{read_only}");
         }

--- a/src/tools/scripted.rs
+++ b/src/tools/scripted.rs
@@ -54,7 +54,6 @@ impl ScriptManifest {
 }
 
 /// A loaded scripted tool: manifest plus resolved script path.
-/// Runs through the same approval gate as `execute`.
 #[derive(Debug, Clone)]
 pub struct ScriptedTool {
     pub manifest: ScriptManifest,
@@ -153,10 +152,6 @@ impl Tool for ScriptedTool {
 
     fn parameters(&self) -> Value {
         self.manifest.parameters.clone()
-    }
-
-    fn requires_approval(&self) -> bool {
-        true
     }
 
     fn kind(&self) -> ToolKind {

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -1,9 +1,7 @@
 //! Native `execute` tool: run shell commands with a timeout.
 //!
 //! Security note (see `docs/architecture.md`): this is real shell access and
-//! cannot be confined to the working directory. Opts into the approval gate,
-//! which only fires when `auto_approve = false`; both modes auto-approve by
-//! default.
+//! cannot be confined to the working directory.
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -149,10 +147,6 @@ impl Tool for ExecuteTool {
             },
             "required": ["command"]
         })
-    }
-
-    fn requires_approval(&self) -> bool {
-        true
     }
 
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -120,9 +120,14 @@ pub(crate) fn render_command_result(result: &CommandResult) -> ToolOutput {
 pub struct ExecuteArgs {
     /// Shell command line, run via `sh -c` in the project root.
     pub command: String,
-    /// Timeout in seconds (default 120, clamped to 600).
+    /// Timeout in seconds (default 120, clamped to 600). Ignored for
+    /// background tasks, which use the fixed background timeout.
     #[serde(default)]
     pub timeout_secs: Option<u64>,
+    /// Run detached as a background task: returns immediately with a task
+    /// id; the agent is notified when the command finishes.
+    #[serde(default)]
+    pub run_in_background: bool,
 }
 
 /// `execute` — run a shell command, capturing stdout, stderr, and exit code.
@@ -135,7 +140,10 @@ impl Tool for ExecuteTool {
     }
 
     fn description(&self) -> &str {
-        "Run a shell command in the project root and return its stdout, stderr, and exit code. Killed on timeout."
+        "Run a shell command in the project root and return its stdout, stderr, and exit code. \
+         Killed on timeout. With run_in_background, the command is detached as a background \
+         task: the call returns a task id immediately, you are notified when it finishes, and \
+         task_output / task_kill manage it meanwhile."
     }
 
     fn parameters(&self) -> Value {
@@ -143,7 +151,8 @@ impl Tool for ExecuteTool {
             "type": "object",
             "properties": {
                 "command": { "type": "string", "description": "Shell command line (run via sh -c)" },
-                "timeout_secs": { "type": "integer", "description": "Timeout in seconds (default 120, max 600)" }
+                "timeout_secs": { "type": "integer", "description": "Timeout in seconds (default 120, max 600); ignored for background tasks" },
+                "run_in_background": { "type": "boolean", "description": "Detach as a background task and return immediately (default false)" }
             },
             "required": ["command"]
         })
@@ -171,6 +180,24 @@ impl Tool for ExecuteTool {
 
         let mut command = Command::new("sh");
         command.arg("-c").arg(&args.command).current_dir(&ctx.cwd);
+
+        if args.run_in_background {
+            command
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true);
+            let child = command.spawn().map_err(|err| ToolError::Execution {
+                tool: self.name().to_string(),
+                source: anyhow::Error::new(err).context("failed to spawn background process"),
+            })?;
+            let id = ctx.tasks.spawn(&args.command, child);
+            return Ok(ToolOutput::ok(format!(
+                "Background task #{id} started: {}\nYou will be notified when it finishes; \
+                 use task_output to inspect it or task_kill to stop it.",
+                args.command
+            )));
+        }
 
         let result = run_command(self.name(), command, timeout).await?;
         Ok(render_command_result(&result))
@@ -297,6 +324,42 @@ mod tests {
             .await
             .expect_err("missing command must be rejected");
         assert!(matches!(err, ToolError::InvalidArgs { tool, .. } if tool == "execute"));
+    }
+
+    #[tokio::test]
+    async fn execute_run_in_background_registers_a_task_and_returns_immediately() {
+        let tmp = TempDir::new();
+        let ctx = tmp.ctx();
+        let out = ExecuteTool
+            .execute(
+                json!({ "command": "echo bg-marker", "run_in_background": true }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(
+            out.content
+                .contains("Background task #1 started: echo bg-marker"),
+            "{}",
+            out.content
+        );
+
+        // The task runs to completion in the registry and its output is
+        // captured for the finished-task notification.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let status = ctx.tasks.status(1).expect("task registered");
+            if status.is_finished() {
+                assert_eq!(status, crate::tools::tasks::TaskStatus::Done(0));
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "task finished");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let drained = ctx.tasks.drain_completed();
+        assert_eq!(drained.len(), 1);
+        assert!(drained[0].tail.contains("bg-marker"), "{}", drained[0].tail);
     }
 
     #[test]

--- a/src/tools/tasks.rs
+++ b/src/tools/tasks.rs
@@ -1,25 +1,73 @@
 //! Background task registry, shared across tool calls via
-//! [`ToolContext`](super::ToolContext).
+//! [`ToolContext`](super::ToolContext), plus the `task_output` and
+//! `task_kill` tools.
 //!
-//! Bookkeeping for shell commands running in the background: ids, the
-//! command line, and lifecycle state. Process handles and output buffers
-//! attach to [`Task`] when the background-execution tools land.
+//! The `execute` tool with `run_in_background: true` spawns a detached child
+//! and registers it here. A monitor task captures stdout/stderr into a
+//! tail-capped buffer, enforces the [`BACKGROUND_TIMEOUT`], and records the
+//! exit. The agent loop calls [`TaskRegistry::drain_completed`] at the top of
+//! every step to notify the model of finished tasks exactly once.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
+use tokio::sync::oneshot;
+
+use super::{Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args};
+
+/// Cap on the output buffered per task; the tail is kept when exceeded.
+pub const OUTPUT_CAP_BYTES: usize = 200 * 1024;
+
+/// Output tail included in finished-task notifications to the model.
+pub const NOTIFY_TAIL_BYTES: usize = 2 * 1024;
+
+/// Default output tail returned by `task_output` when `tail_bytes` is unset.
+const DEFAULT_TAIL_BYTES: usize = 20_000;
+
+/// Largest tail `task_output` returns (stays inside the global tool-output
+/// cap together with the status header).
+const MAX_TAIL_BYTES: usize = 28_000;
+
+/// Wall-clock limit on a background task; the child is killed when it
+/// elapses and the status reflects the timeout.
+pub const BACKGROUND_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Lifecycle state of one background task.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskStatus {
     Running,
-    /// Exited with the given code.
+    /// Exited with the given code (`-1` when terminated by a signal).
     Done(i32),
-    /// Terminated on request.
+    /// Terminated on request (`task_kill`, `kill_all`).
     Killed,
+    /// Killed at the [`BACKGROUND_TIMEOUT`].
+    TimedOut,
 }
 
-/// One background command and its state.
+impl TaskStatus {
+    /// Whether the task is no longer running.
+    pub fn is_finished(self) -> bool {
+        !matches!(self, TaskStatus::Running)
+    }
+
+    /// Short human description: `running`, `exit 0`, `killed`, `timed out`.
+    pub fn describe(self) -> String {
+        match self {
+            TaskStatus::Running => "running".to_string(),
+            TaskStatus::Done(code) => format!("exit {code}"),
+            TaskStatus::Killed => "killed".to_string(),
+            TaskStatus::TimedOut => "timed out".to_string(),
+        }
+    }
+}
+
+/// Snapshot of one background command and its state.
 #[derive(Debug, Clone)]
 pub struct Task {
     pub id: u32,
@@ -27,10 +75,76 @@ pub struct Task {
     pub status: TaskStatus,
 }
 
+/// A finished task as returned by [`TaskRegistry::drain_completed`] —
+/// reported to the model exactly once.
+#[derive(Debug, Clone)]
+pub struct FinishedTask {
+    pub id: u32,
+    pub command: String,
+    pub status: TaskStatus,
+    /// Last [`NOTIFY_TAIL_BYTES`] of combined stdout/stderr.
+    pub tail: String,
+}
+
+/// Byte buffer that keeps only the most recent `cap` bytes.
+#[derive(Debug)]
+struct TailBuffer {
+    buf: Vec<u8>,
+    cap: usize,
+    truncated: bool,
+}
+
+impl TailBuffer {
+    fn with_cap(cap: usize) -> Self {
+        Self {
+            buf: Vec::new(),
+            cap,
+            truncated: false,
+        }
+    }
+
+    fn append(&mut self, data: &[u8]) {
+        self.buf.extend_from_slice(data);
+        if self.buf.len() > self.cap {
+            let excess = self.buf.len() - self.cap;
+            self.buf.drain(..excess);
+            self.truncated = true;
+        }
+    }
+
+    /// Last `bytes` of the buffer, lossily decoded.
+    fn tail(&self, bytes: usize) -> String {
+        let start = self.buf.len().saturating_sub(bytes);
+        String::from_utf8_lossy(&self.buf[start..]).into_owned()
+    }
+}
+
+/// Internal per-task state (snapshot exposed as [`Task`]).
+#[derive(Debug)]
+struct TaskEntry {
+    command: String,
+    status: TaskStatus,
+    output: TailBuffer,
+    /// Already returned by [`TaskRegistry::drain_completed`].
+    reported: bool,
+    /// Signals the monitor to kill the child. Consumed on first kill.
+    kill: Option<oneshot::Sender<()>>,
+}
+
+impl TaskEntry {
+    fn snapshot(&self, id: u32) -> Task {
+        Task {
+            id,
+            command: self.command.clone(),
+            status: self.status,
+        }
+    }
+}
+
 /// Session-wide registry of background tasks.
 #[derive(Debug, Default)]
 pub struct TaskRegistry {
-    tasks: Mutex<HashMap<u32, Task>>,
+    tasks: Mutex<HashMap<u32, TaskEntry>>,
     next_id: AtomicU32,
 }
 
@@ -39,38 +153,347 @@ impl TaskRegistry {
         Self::default()
     }
 
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<u32, TaskEntry>> {
+        self.tasks.lock().expect("task registry lock poisoned")
+    }
+
     /// Register a new running task and return its id (1-based).
     pub fn add(&self, command: impl Into<String>) -> u32 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
-        let task = Task {
+        self.lock().insert(
             id,
-            command: command.into(),
-            status: TaskStatus::Running,
-        };
-        self.tasks
-            .lock()
-            .expect("task registry lock poisoned")
-            .insert(id, task);
+            TaskEntry {
+                command: command.into(),
+                status: TaskStatus::Running,
+                output: TailBuffer::with_cap(OUTPUT_CAP_BYTES),
+                reported: false,
+                kill: None,
+            },
+        );
         id
+    }
+
+    /// Take ownership of an already-spawned child: register it, capture its
+    /// stdout/stderr into the tail buffer, enforce the
+    /// [`BACKGROUND_TIMEOUT`], and record the exit. Returns the task id.
+    pub fn spawn(self: &Arc<Self>, command_line: &str, child: tokio::process::Child) -> u32 {
+        self.spawn_with_timeout(command_line, child, BACKGROUND_TIMEOUT)
+    }
+
+    /// [`spawn`](Self::spawn) with an explicit timeout (tests).
+    pub fn spawn_with_timeout(
+        self: &Arc<Self>,
+        command_line: &str,
+        mut child: tokio::process::Child,
+        timeout: Duration,
+    ) -> u32 {
+        let id = self.add(command_line);
+        let (kill_tx, mut kill_rx) = oneshot::channel::<()>();
+        if let Some(entry) = self.lock().get_mut(&id) {
+            entry.kill = Some(kill_tx);
+        }
+
+        let out_task = tokio::spawn(read_into(Arc::clone(self), id, child.stdout.take()));
+        let err_task = tokio::spawn(read_into(Arc::clone(self), id, child.stderr.take()));
+
+        let registry = Arc::clone(self);
+        tokio::spawn(async move {
+            // Wait for exit, kill request, or timeout. The wait future is
+            // pinned in an inner scope so `child` is free again for `kill`.
+            let waited = {
+                let wait = tokio::time::timeout(timeout, child.wait());
+                tokio::pin!(wait);
+                tokio::select! {
+                    _ = &mut kill_rx => None,
+                    res = &mut wait => Some(res),
+                }
+            };
+            let status = match waited {
+                // Kill requested (task_kill / kill_all).
+                None => {
+                    let _ = child.kill().await;
+                    TaskStatus::Killed
+                }
+                Some(Ok(Ok(exit))) => TaskStatus::Done(exit.code().unwrap_or(-1)),
+                Some(Ok(Err(err))) => {
+                    tracing::warn!("waiting on background task #{id} failed: {err}");
+                    TaskStatus::Done(-1)
+                }
+                // Timeout elapsed.
+                Some(Err(_)) => {
+                    let _ = child.kill().await;
+                    TaskStatus::TimedOut
+                }
+            };
+            // Let the readers capture whatever output is still buffered
+            // before the task becomes drainable.
+            let _ = out_task.await;
+            let _ = err_task.await;
+            registry.finish(id, status);
+        });
+        id
+    }
+
+    /// Record the final status of a task and drop its kill handle.
+    fn finish(&self, id: u32, status: TaskStatus) {
+        if let Some(entry) = self.lock().get_mut(&id) {
+            if entry.status == TaskStatus::Running {
+                entry.status = status;
+            }
+            entry.kill = None;
+        }
+    }
+
+    /// Append captured output to a task's tail buffer.
+    fn append_output(&self, id: u32, data: &[u8]) {
+        if let Some(entry) = self.lock().get_mut(&id) {
+            entry.output.append(data);
+        }
     }
 
     /// Snapshot of all tasks, ordered by id.
     pub fn list(&self) -> Vec<Task> {
         let mut tasks: Vec<Task> = self
-            .tasks
             .lock()
-            .expect("task registry lock poisoned")
-            .values()
-            .cloned()
+            .iter()
+            .map(|(id, entry)| entry.snapshot(*id))
             .collect();
         tasks.sort_unstable_by_key(|task| task.id);
         tasks
+    }
+
+    /// Status of one task, if it exists.
+    pub fn status(&self, id: u32) -> Option<TaskStatus> {
+        self.lock().get(&id).map(|entry| entry.status)
+    }
+
+    /// Snapshot plus the last `tail_bytes` of buffered output of one task.
+    pub fn output(&self, id: u32, tail_bytes: usize) -> Option<(Task, String)> {
+        self.lock()
+            .get(&id)
+            .map(|entry| (entry.snapshot(id), entry.output.tail(tail_bytes)))
+    }
+
+    /// Request termination of a running task. Returns false when the task is
+    /// unknown or already finished (or a kill is already in flight).
+    pub fn kill(&self, id: u32) -> bool {
+        let sender = self.lock().get_mut(&id).and_then(|entry| entry.kill.take());
+        match sender {
+            Some(sender) => sender.send(()).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Kill every running task (agent shutdown). The children also carry
+    /// `kill_on_drop`, this makes the teardown explicit and immediate.
+    pub fn kill_all(&self) {
+        let senders: Vec<oneshot::Sender<()>> = self
+            .lock()
+            .values_mut()
+            .filter_map(|entry| entry.kill.take())
+            .collect();
+        for sender in senders {
+            let _ = sender.send(());
+        }
+    }
+
+    /// Finished tasks not yet reported, each returned exactly once, ordered
+    /// by id. The tail carries the last [`NOTIFY_TAIL_BYTES`] of output.
+    pub fn drain_completed(&self) -> Vec<FinishedTask> {
+        let mut finished: Vec<FinishedTask> = self
+            .lock()
+            .iter_mut()
+            .filter(|(_, entry)| entry.status.is_finished() && !entry.reported)
+            .map(|(id, entry)| {
+                entry.reported = true;
+                FinishedTask {
+                    id: *id,
+                    command: entry.command.clone(),
+                    status: entry.status,
+                    tail: entry.output.tail(NOTIFY_TAIL_BYTES),
+                }
+            })
+            .collect();
+        finished.sort_unstable_by_key(|task| task.id);
+        finished
+    }
+}
+
+/// Stream a child's stdout or stderr into the task's tail buffer.
+async fn read_into(
+    registry: Arc<TaskRegistry>,
+    id: u32,
+    stream: Option<impl tokio::io::AsyncRead + Unpin + Send + 'static>,
+) {
+    let Some(mut stream) = stream else { return };
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => registry.append_output(id, &buf[..n]),
+        }
+    }
+}
+
+/// Arguments for [`TaskOutputTool`].
+#[derive(Debug, Deserialize)]
+struct TaskOutputArgs {
+    id: u32,
+    /// How many bytes of the output tail to return (default 20000).
+    #[serde(default)]
+    tail_bytes: Option<usize>,
+}
+
+/// `task_output` — buffered output and status of a background task.
+pub struct TaskOutputTool;
+
+#[async_trait]
+impl Tool for TaskOutputTool {
+    fn name(&self) -> &str {
+        "task_output"
+    }
+
+    fn description(&self) -> &str {
+        "Return the status and buffered output (stdout+stderr tail) of a background task \
+         started with execute run_in_background."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "integer", "description": "Background task id" },
+                "tail_bytes": { "type": "integer", "description": "How many bytes of the output tail to return (default 20000)" }
+            },
+            "required": ["id"]
+        })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let args: TaskOutputArgs = parse_args(self.name(), args)?;
+        let tail_bytes = args
+            .tail_bytes
+            .unwrap_or(DEFAULT_TAIL_BYTES)
+            .min(MAX_TAIL_BYTES);
+        let Some((task, output)) = ctx.tasks.output(args.id, tail_bytes) else {
+            return Ok(ToolOutput::error(format!(
+                "no background task #{}",
+                args.id
+            )));
+        };
+        let mut content = format!(
+            "Background task #{} [{}]: {}",
+            task.id,
+            task.status.describe(),
+            task.command
+        );
+        if output.trim().is_empty() {
+            content.push_str("\n(no output)");
+        } else {
+            content.push('\n');
+            content.push_str(output.trim_end());
+        }
+        Ok(ToolOutput::ok(content))
+    }
+}
+
+/// Arguments for [`TaskKillTool`].
+#[derive(Debug, Deserialize)]
+struct TaskKillArgs {
+    id: u32,
+}
+
+/// `task_kill` — terminate a running background task.
+pub struct TaskKillTool;
+
+#[async_trait]
+impl Tool for TaskKillTool {
+    fn name(&self) -> &str {
+        "task_kill"
+    }
+
+    fn description(&self) -> &str {
+        "Kill a running background task started with execute run_in_background."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "integer", "description": "Background task id" }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let args: TaskKillArgs = parse_args(self.name(), args)?;
+        if ctx.tasks.kill(args.id) {
+            return Ok(ToolOutput::ok(format!(
+                "kill signal sent to background task #{}",
+                args.id
+            )));
+        }
+        Ok(match ctx.tasks.status(args.id) {
+            None => ToolOutput::error(format!("no background task #{}", args.id)),
+            Some(status) if status.is_finished() => ToolOutput::error(format!(
+                "background task #{} already finished ({})",
+                args.id,
+                status.describe()
+            )),
+            Some(_) => ToolOutput::error(format!(
+                "background task #{} is already being killed",
+                args.id
+            )),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::process::Stdio;
+
     use super::*;
+
+    /// Spawn `sh -c <script>` with piped stdio, ready for the registry.
+    fn spawn_sh(script: &str) -> tokio::process::Child {
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        command.spawn().expect("spawn test child")
+    }
+
+    /// Poll until task `id` is finished (10s deadline).
+    async fn wait_finished(registry: &TaskRegistry, id: u32) -> TaskStatus {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let status = registry.status(id).expect("task exists");
+            if status.is_finished() {
+                return status;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "task #{id} did not finish in time"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn ctx_with(registry: &Arc<TaskRegistry>) -> ToolContext {
+        ToolContext {
+            tasks: Arc::clone(registry),
+            ..ToolContext::new(std::env::temp_dir())
+        }
+    }
 
     #[test]
     fn add_assigns_sequential_ids_and_list_is_ordered() {
@@ -88,5 +511,160 @@ mod tests {
         assert_eq!(tasks[0].command, "cargo build");
         assert_eq!(tasks[0].status, TaskStatus::Running);
         assert_eq!(tasks[1].id, 2);
+    }
+
+    #[test]
+    fn tail_buffer_keeps_the_tail_when_over_cap() {
+        let mut buffer = TailBuffer::with_cap(10);
+        buffer.append(b"0123456789");
+        assert!(!buffer.truncated);
+        assert_eq!(buffer.tail(100), "0123456789");
+
+        buffer.append(b"abcdef");
+        assert!(buffer.truncated);
+        assert_eq!(buffer.buf.len(), 10);
+        assert_eq!(buffer.tail(100), "6789abcdef");
+        assert_eq!(buffer.tail(4), "cdef", "tail respects the byte count");
+
+        // One oversized append keeps only the newest cap bytes.
+        let mut buffer = TailBuffer::with_cap(4);
+        buffer.append(b"abcdefgh");
+        assert_eq!(buffer.tail(100), "efgh");
+        assert!(buffer.truncated);
+    }
+
+    #[tokio::test]
+    async fn spawn_records_exit_and_output_and_drains_exactly_once() {
+        let registry = Arc::new(TaskRegistry::new());
+        let id = registry.spawn("echo demo", spawn_sh("echo out; echo err >&2; exit 3"));
+        assert_eq!(id, 1);
+
+        let status = wait_finished(&registry, id).await;
+        assert_eq!(status, TaskStatus::Done(3));
+        assert_eq!(status.describe(), "exit 3");
+
+        let drained = registry.drain_completed();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].id, 1);
+        assert_eq!(drained[0].command, "echo demo");
+        assert_eq!(drained[0].status, TaskStatus::Done(3));
+        assert!(drained[0].tail.contains("out"), "{}", drained[0].tail);
+        assert!(drained[0].tail.contains("err"), "{}", drained[0].tail);
+
+        assert!(
+            registry.drain_completed().is_empty(),
+            "finished tasks are reported exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_skips_running_tasks() {
+        let registry = Arc::new(TaskRegistry::new());
+        let quick = registry.spawn("quick", spawn_sh("echo hi"));
+        let slow = registry.spawn("slow", spawn_sh("sleep 30"));
+        wait_finished(&registry, quick).await;
+
+        let drained = registry.drain_completed();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].id, quick);
+        assert_eq!(registry.status(slow), Some(TaskStatus::Running));
+
+        registry.kill_all();
+        wait_finished(&registry, slow).await;
+    }
+
+    #[tokio::test]
+    async fn kill_terminates_a_running_task() {
+        let registry = Arc::new(TaskRegistry::new());
+        let id = registry.spawn("sleep", spawn_sh("sleep 30"));
+        assert!(registry.kill(id));
+        let status = wait_finished(&registry, id).await;
+        assert_eq!(status, TaskStatus::Killed);
+        assert!(!registry.kill(id), "kill of a finished task reports false");
+        assert!(!registry.kill(999), "kill of an unknown id reports false");
+    }
+
+    #[tokio::test]
+    async fn kill_all_terminates_every_running_task() {
+        let registry = Arc::new(TaskRegistry::new());
+        let a = registry.spawn("a", spawn_sh("sleep 30"));
+        let b = registry.spawn("b", spawn_sh("sleep 30"));
+        registry.kill_all();
+        assert_eq!(wait_finished(&registry, a).await, TaskStatus::Killed);
+        assert_eq!(wait_finished(&registry, b).await, TaskStatus::Killed);
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_the_task_and_marks_it_timed_out() {
+        let registry = Arc::new(TaskRegistry::new());
+        let id =
+            registry.spawn_with_timeout("sleep", spawn_sh("sleep 30"), Duration::from_millis(50));
+        let status = wait_finished(&registry, id).await;
+        assert_eq!(status, TaskStatus::TimedOut);
+        assert_eq!(status.describe(), "timed out");
+        let drained = registry.drain_completed();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].status, TaskStatus::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn task_output_tool_returns_status_and_tail() {
+        let registry = Arc::new(TaskRegistry::new());
+        let id = registry.spawn("echo", spawn_sh("printf 'abcdefgh'"));
+        wait_finished(&registry, id).await;
+        let ctx = ctx_with(&registry);
+
+        let out = TaskOutputTool
+            .execute(json!({ "id": id }), &ctx)
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(out.content.contains("[exit 0]"), "{}", out.content);
+        assert!(out.content.contains("abcdefgh"), "{}", out.content);
+
+        // tail_bytes limits the returned output.
+        let out = TaskOutputTool
+            .execute(json!({ "id": id, "tail_bytes": 4 }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.content.contains("efgh"), "{}", out.content);
+        assert!(!out.content.contains("abcd"), "{}", out.content);
+
+        // Unknown ids are tool-level errors.
+        let out = TaskOutputTool
+            .execute(json!({ "id": 999 }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(out.content.contains("no background task #999"));
+    }
+
+    #[tokio::test]
+    async fn task_kill_tool_kills_and_reports_state() {
+        let registry = Arc::new(TaskRegistry::new());
+        let id = registry.spawn("sleep", spawn_sh("sleep 30"));
+        let ctx = ctx_with(&registry);
+
+        let out = TaskKillTool
+            .execute(json!({ "id": id }), &ctx)
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(out.content.contains("kill signal sent"), "{}", out.content);
+        wait_finished(&registry, id).await;
+
+        let out = TaskKillTool
+            .execute(json!({ "id": id }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(out.content.contains("already finished"), "{}", out.content);
+
+        let out = TaskKillTool
+            .execute(json!({ "id": 7 }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(out.content.contains("no background task #7"));
     }
 }

--- a/src/tools/tasks.rs
+++ b/src/tools/tasks.rs
@@ -1,0 +1,92 @@
+//! Background task registry, shared across tool calls via
+//! [`ToolContext`](super::ToolContext).
+//!
+//! Bookkeeping for shell commands running in the background: ids, the
+//! command line, and lifecycle state. Process handles and output buffers
+//! attach to [`Task`] when the background-execution tools land.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Lifecycle state of one background task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    Running,
+    /// Exited with the given code.
+    Done(i32),
+    /// Terminated on request.
+    Killed,
+}
+
+/// One background command and its state.
+#[derive(Debug, Clone)]
+pub struct Task {
+    pub id: u32,
+    pub command: String,
+    pub status: TaskStatus,
+}
+
+/// Session-wide registry of background tasks.
+#[derive(Debug, Default)]
+pub struct TaskRegistry {
+    tasks: Mutex<HashMap<u32, Task>>,
+    next_id: AtomicU32,
+}
+
+impl TaskRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new running task and return its id (1-based).
+    pub fn add(&self, command: impl Into<String>) -> u32 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let task = Task {
+            id,
+            command: command.into(),
+            status: TaskStatus::Running,
+        };
+        self.tasks
+            .lock()
+            .expect("task registry lock poisoned")
+            .insert(id, task);
+        id
+    }
+
+    /// Snapshot of all tasks, ordered by id.
+    pub fn list(&self) -> Vec<Task> {
+        let mut tasks: Vec<Task> = self
+            .tasks
+            .lock()
+            .expect("task registry lock poisoned")
+            .values()
+            .cloned()
+            .collect();
+        tasks.sort_unstable_by_key(|task| task.id);
+        tasks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_assigns_sequential_ids_and_list_is_ordered() {
+        let registry = TaskRegistry::new();
+        assert!(registry.list().is_empty());
+
+        let first = registry.add("cargo build");
+        let second = registry.add("cargo test");
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+
+        let tasks = registry.list();
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].id, 1);
+        assert_eq!(tasks[0].command, "cargo build");
+        assert_eq!(tasks[0].status, TaskStatus::Running);
+        assert_eq!(tasks[1].id, 2);
+    }
+}

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -1,0 +1,20 @@
+//! Shared todo-list state, exposed to tools via
+//! [`ToolContext`](super::ToolContext).
+
+/// Progress state of one todo item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+/// One entry in the agent's working todo list.
+#[derive(Debug, Clone)]
+pub struct TodoItem {
+    pub content: String,
+    pub status: TodoStatus,
+}
+
+/// The agent's working todo list.
+pub type TodoList = Vec<TodoItem>;

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -1,16 +1,47 @@
-//! Shared todo-list state, exposed to tools via
-//! [`ToolContext`](super::ToolContext).
+//! The `todo` tool and its shared list state.
+//!
+//! The agent maintains a working todo list for multi-step tasks: action
+//! `write` replaces the entire list, `read` returns it. State lives in
+//! [`ToolContext::todos`](super::ToolContext) (agent-local, never on disk),
+//! and every write emits [`AgentEvent::TodoUpdated`] so the TUI side panel
+//! and the headless printer can mirror progress. The tool is classified
+//! [`ToolAccess::ReadOnly`]: it touches nothing outside the agent, so todo
+//! upkeep stays available in plan mode — planning is exactly when the list
+//! gets drafted.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::agent::AgentEvent;
+
+use super::{Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args};
+
+/// Advertised name of the tool.
+pub const TODO_TOOL_NAME: &str = "todo";
 
 /// Progress state of one todo item.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TodoStatus {
     Pending,
     InProgress,
     Completed,
 }
 
+impl TodoStatus {
+    /// Status glyph used by every surface (TUI panel, tool output).
+    pub fn glyph(self) -> &'static str {
+        match self {
+            TodoStatus::Pending => "☐",
+            TodoStatus::InProgress => "▸",
+            TodoStatus::Completed => "✓",
+        }
+    }
+}
+
 /// One entry in the agent's working todo list.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TodoItem {
     pub content: String,
     pub status: TodoStatus,
@@ -18,3 +49,266 @@ pub struct TodoItem {
 
 /// The agent's working todo list.
 pub type TodoList = Vec<TodoItem>;
+
+/// `(completed, total)` counts for a list.
+pub fn progress(items: &[TodoItem]) -> (usize, usize) {
+    let done = items
+        .iter()
+        .filter(|item| item.status == TodoStatus::Completed)
+        .count();
+    (done, items.len())
+}
+
+/// The first in-progress item, if any (what the agent is working on now).
+pub fn current(items: &[TodoItem]) -> Option<&TodoItem> {
+    items
+        .iter()
+        .find(|item| item.status == TodoStatus::InProgress)
+}
+
+/// Render a list as glyph-prefixed lines (the tool's `read` output).
+pub fn render(items: &[TodoItem]) -> String {
+    if items.is_empty() {
+        return "(todo list is empty)".to_string();
+    }
+    items
+        .iter()
+        .map(|item| format!("{} {}", item.status.glyph(), item.content))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// One-line progress summary for headless surfaces:
+/// `≡ todo: 2/5 done — current: <in_progress item>`.
+pub fn summary_line(items: &[TodoItem]) -> String {
+    let (done, total) = progress(items);
+    match current(items) {
+        Some(item) => format!("≡ todo: {done}/{total} done — current: {}", item.content),
+        None => format!("≡ todo: {done}/{total} done"),
+    }
+}
+
+/// What a `todo` call does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Action {
+    Write,
+    Read,
+}
+
+/// `todo` — maintain the session's working todo list.
+pub struct TodoTool;
+
+#[async_trait]
+impl Tool for TodoTool {
+    fn name(&self) -> &str {
+        TODO_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Maintain your working todo list for the current task. Action \"write\" replaces the \
+         entire list (pass every item, including completed ones, each as {content, status}); \
+         action \"read\" returns the current list. Statuses: pending, in_progress, completed — \
+         keep exactly one item in_progress at a time and mark items completed as soon as they \
+         are done."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["write", "read"],
+                    "description": "write replaces the whole list; read returns it"
+                },
+                "items": {
+                    "type": "array",
+                    "description": "The full todo list (write only)",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "content": { "type": "string" },
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed"]
+                            }
+                        },
+                        "required": ["content", "status"]
+                    }
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    /// Mutates only agent-local state (never the filesystem), so it stays
+    /// usable in plan mode — drafting the todo list is part of planning.
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        #[derive(Deserialize)]
+        struct Args {
+            action: Action,
+            #[serde(default)]
+            items: Option<Vec<TodoItem>>,
+        }
+        let args: Args = parse_args(TODO_TOOL_NAME, args)?;
+
+        match args.action {
+            Action::Read => {
+                let items = ctx.todos.lock().expect("todo list lock poisoned").clone();
+                Ok(ToolOutput::ok(render(&items)))
+            }
+            Action::Write => {
+                let Some(items) = args.items else {
+                    return Err(ToolError::InvalidArgs {
+                        tool: TODO_TOOL_NAME.to_string(),
+                        message: "action \"write\" requires `items` (the full list)".to_string(),
+                    });
+                };
+                *ctx.todos.lock().expect("todo list lock poisoned") = items.clone();
+                if let Some(events) = &ctx.events {
+                    let _ = events.send(AgentEvent::TodoUpdated(items.clone())).await;
+                }
+                let (done, total) = progress(&items);
+                Ok(ToolOutput::ok(format!(
+                    "todo list updated — {done}/{total} done\n{}",
+                    render(&items)
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext::new(std::env::temp_dir())
+    }
+
+    fn item(content: &str, status: TodoStatus) -> TodoItem {
+        TodoItem {
+            content: content.to_string(),
+            status,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_replaces_the_list_and_read_returns_it() {
+        let tool = TodoTool;
+        let ctx = ctx();
+
+        let out = tool
+            .execute(json!({ "action": "read" }), &ctx)
+            .await
+            .expect("read ok");
+        assert_eq!(out.content, "(todo list is empty)");
+
+        let out = tool
+            .execute(
+                json!({
+                    "action": "write",
+                    "items": [
+                        { "content": "first", "status": "completed" },
+                        { "content": "second", "status": "in_progress" },
+                        { "content": "third", "status": "pending" }
+                    ]
+                }),
+                &ctx,
+            )
+            .await
+            .expect("write ok");
+        assert!(!out.is_error);
+        assert!(out.content.contains("1/3 done"), "{}", out.content);
+
+        let out = tool
+            .execute(json!({ "action": "read" }), &ctx)
+            .await
+            .expect("read ok");
+        assert_eq!(out.content, "✓ first\n▸ second\n☐ third");
+
+        // A second write replaces, never appends.
+        tool.execute(
+            json!({ "action": "write", "items": [{ "content": "only", "status": "pending" }] }),
+            &ctx,
+        )
+        .await
+        .expect("write ok");
+        assert_eq!(ctx.todos.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn write_emits_todo_updated_on_the_event_channel() {
+        let tool = TodoTool;
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ctx().with_events(tx);
+
+        tool.execute(
+            json!({ "action": "write", "items": [{ "content": "a", "status": "pending" }] }),
+            &ctx,
+        )
+        .await
+        .expect("write ok");
+
+        match rx.try_recv() {
+            Ok(AgentEvent::TodoUpdated(items)) => {
+                assert_eq!(items, vec![item("a", TodoStatus::Pending)]);
+            }
+            other => panic!("expected TodoUpdated, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_without_items_is_invalid_args() {
+        let err = TodoTool
+            .execute(json!({ "action": "write" }), &ctx())
+            .await
+            .expect_err("missing items");
+        assert!(matches!(err, ToolError::InvalidArgs { .. }));
+    }
+
+    #[tokio::test]
+    async fn unknown_action_or_status_is_invalid_args() {
+        let err = TodoTool
+            .execute(json!({ "action": "append" }), &ctx())
+            .await
+            .expect_err("bad action");
+        assert!(matches!(err, ToolError::InvalidArgs { .. }));
+
+        let err = TodoTool
+            .execute(
+                json!({ "action": "write", "items": [{ "content": "x", "status": "doing" }] }),
+                &ctx(),
+            )
+            .await
+            .expect_err("bad status");
+        assert!(matches!(err, ToolError::InvalidArgs { .. }));
+    }
+
+    #[test]
+    fn summary_line_names_the_current_item() {
+        let items = vec![
+            item("done thing", TodoStatus::Completed),
+            item("active thing", TodoStatus::InProgress),
+            item("later thing", TodoStatus::Pending),
+        ];
+        assert_eq!(
+            summary_line(&items),
+            "≡ todo: 1/3 done — current: active thing"
+        );
+        let all_done = vec![item("a", TodoStatus::Completed)];
+        assert_eq!(summary_line(&all_done), "≡ todo: 1/1 done");
+    }
+
+    #[test]
+    fn tool_is_read_only_for_the_plan_gate() {
+        assert_eq!(TodoTool.access(), ToolAccess::ReadOnly);
+    }
+}

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -1,0 +1,1127 @@
+//! Native web tools: `web_fetch` (URL → markdown/text) and `web_search`
+//! (pluggable search backends).
+//!
+//! Both are [`ToolAccess::ReadOnly`], so they stay available in plan mode.
+//! Settings live in `[web]` in `config.toml` (see
+//! [`WebConfig`](crate::config::WebConfig)), carried into the tools via
+//! [`ToolContext::web`](super::ToolContext). Fetches are SSRF-guarded:
+//! requests to localhost and private/link-local ranges are rejected unless
+//! `allow_local = true`. Search API keys are read from the environment at
+//! call time and never stored.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    MAX_OUTPUT_BYTES, Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args,
+    truncate_output,
+};
+
+/// Whole-request timeout for fetches and searches.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Desktop browser user agent (some sites block obvious bots outright).
+const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) \
+                          Chrome/124.0.0.0 Safari/537.36";
+
+/// Default number of search results.
+const DEFAULT_SEARCH_COUNT: usize = 5;
+
+/// Hard cap on requested search results.
+const MAX_SEARCH_COUNT: usize = 10;
+
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+
+/// Whether an address is local/private: loopback (127.0.0.0/8, ::1), RFC1918
+/// (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local (169.254.0.0/16,
+/// fe80::/10), unique-local (fc00::/7), or unspecified.
+fn ip_is_local(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
+        }
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return ip_is_local(IpAddr::V4(mapped));
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // unique local fc00::/7
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link local fe80::/10
+        }
+    }
+}
+
+/// Whether a hostname is a local name: `localhost` or `*.local` (mDNS).
+fn host_is_local_name(host: &str) -> bool {
+    let host = host.trim_end_matches('.');
+    host.eq_ignore_ascii_case("localhost")
+        || (host.len() >= 6 && host[host.len() - 6..].eq_ignore_ascii_case(".local"))
+}
+
+/// Synchronous URL checks: scheme, literal IPs, and local hostnames. Used
+/// before the request and inside the redirect policy (which cannot resolve
+/// DNS asynchronously).
+fn check_url_sync(url: &reqwest::Url, allow_local: bool) -> Result<(), String> {
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "unsupported URL scheme '{other}' (only http and https are allowed)"
+            ));
+        }
+    }
+    let Some(host) = url.host_str() else {
+        return Err("URL has no host".to_string());
+    };
+    if allow_local {
+        return Ok(());
+    }
+    let blocked = format!(
+        "fetching local/private address '{host}' is blocked \
+         (set [web] allow_local = true in config.toml to permit)"
+    );
+    // Literal IPs (IPv6 literals come bracketed in URLs).
+    let bare = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = bare.parse::<IpAddr>() {
+        if ip_is_local(ip) {
+            return Err(blocked);
+        }
+        return Ok(());
+    }
+    if host_is_local_name(host) {
+        return Err(blocked);
+    }
+    Ok(())
+}
+
+/// Full SSRF check: the synchronous checks plus DNS resolution of domain
+/// hosts, rejecting any URL whose host resolves to a local/private address.
+async fn check_url(url: &reqwest::Url, allow_local: bool) -> Result<(), String> {
+    check_url_sync(url, allow_local)?;
+    if allow_local {
+        return Ok(());
+    }
+    let Some(host) = url.host_str() else {
+        return Err("URL has no host".to_string());
+    };
+    // Literal IPs were already checked synchronously.
+    let bare = host.trim_start_matches('[').trim_end_matches(']');
+    if bare.parse::<IpAddr>().is_ok() {
+        return Ok(());
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|err| format!("could not resolve host '{host}': {err}"))?;
+    for addr in addrs {
+        if ip_is_local(addr.ip()) {
+            return Err(format!(
+                "host '{host}' resolves to local/private address {} — blocked \
+                 (set [web] allow_local = true in config.toml to permit)",
+                addr.ip()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// HTTP client for the web tools: desktop UA, 30s timeout, and a redirect
+/// policy that re-applies the synchronous SSRF checks on every hop.
+fn web_client(allow_local: bool) -> Result<reqwest::Client, reqwest::Error> {
+    let policy = reqwest::redirect::Policy::custom(move |attempt| {
+        if attempt.previous().len() > 10 {
+            return attempt.error("too many redirects");
+        }
+        match check_url_sync(attempt.url(), allow_local) {
+            Ok(()) => attempt.follow(),
+            Err(reason) => attempt.error(reason),
+        }
+    });
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .redirect(policy)
+        .timeout(FETCH_TIMEOUT)
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+}
+
+// ---------------------------------------------------------------------------
+// web_fetch
+// ---------------------------------------------------------------------------
+
+/// Arguments for [`WebFetchTool`].
+#[derive(Debug, Deserialize)]
+struct FetchArgs {
+    url: String,
+    /// Response byte cap; clamped to `[web] fetch_max_bytes`.
+    #[serde(default)]
+    max_bytes: Option<usize>,
+}
+
+/// `web_fetch` — fetch a URL and return its content, HTML as markdown.
+pub struct WebFetchTool;
+
+#[async_trait]
+impl Tool for WebFetchTool {
+    fn name(&self) -> &str {
+        "web_fetch"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch a URL over HTTP(S) and return its content. HTML pages are converted to \
+         markdown; other text content is returned as-is. Responses are size-capped."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": { "type": "string", "description": "The http(s) URL to fetch" },
+                "max_bytes": { "type": "integer", "description": "Cap on response bytes read (default and ceiling from config)" }
+            },
+            "required": ["url"]
+        })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let args: FetchArgs = parse_args(self.name(), args)?;
+        let url = reqwest::Url::parse(args.url.trim()).map_err(|err| ToolError::InvalidArgs {
+            tool: self.name().to_string(),
+            message: format!("invalid url '{}': {err}", args.url),
+        })?;
+
+        let allow_local = ctx.web.allow_local;
+        if let Err(reason) = check_url(&url, allow_local).await {
+            return Ok(ToolOutput::error(reason));
+        }
+
+        let client = web_client(allow_local).map_err(|err| ToolError::Execution {
+            tool: self.name().to_string(),
+            source: anyhow::Error::new(err).context("building HTTP client"),
+        })?;
+
+        let response = match client.get(url.clone()).send().await {
+            Ok(response) => response,
+            Err(err) => return Ok(ToolOutput::error(format!("fetch failed: {err}"))),
+        };
+
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
+
+        let cap = args
+            .max_bytes
+            .unwrap_or(ctx.web.fetch_max_bytes)
+            .min(ctx.web.fetch_max_bytes)
+            .max(1);
+        let (body, capped) = match read_capped(response, cap).await {
+            Ok(read) => read,
+            Err(err) => return Ok(ToolOutput::error(format!("reading response failed: {err}"))),
+        };
+
+        if !status.is_success() {
+            let snippet = truncate_output(String::from_utf8_lossy(&body).into_owned(), 1_000);
+            return Ok(ToolOutput::error(format!(
+                "fetch of {url} returned HTTP {status}\n{snippet}"
+            )));
+        }
+
+        let text = String::from_utf8_lossy(&body).into_owned();
+        let mut content = if content_type.contains("html") {
+            // HTML → markdown; fall back to the raw HTML if conversion fails.
+            htmd::convert(&text).unwrap_or(text)
+        } else if is_texty(&content_type) {
+            text
+        } else {
+            return Ok(ToolOutput::ok(format!(
+                "(binary content type '{content_type}', {} bytes — not shown)",
+                body.len()
+            )));
+        };
+
+        if capped {
+            content.push_str(&format!("\n... [response capped at {cap} bytes]"));
+        }
+        Ok(ToolOutput::ok(truncate_output(content, MAX_OUTPUT_BYTES)))
+    }
+}
+
+/// Whether a content type is textual enough to return verbatim. An absent
+/// content type is treated as text.
+fn is_texty(content_type: &str) -> bool {
+    content_type.is_empty()
+        || content_type.starts_with("text/")
+        || content_type.contains("json")
+        || content_type.contains("xml")
+        || content_type.contains("javascript")
+        || content_type.contains("yaml")
+        || content_type.contains("toml")
+        || content_type.contains("x-www-form-urlencoded")
+}
+
+/// Stream a response body, stopping after `cap` bytes. Returns the (possibly
+/// capped) body and whether the cap cut anything off.
+async fn read_capped(
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<(Vec<u8>, bool), reqwest::Error> {
+    let mut body: Vec<u8> = Vec::new();
+    let mut capped = false;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if body.len() + chunk.len() > cap {
+            let room = cap - body.len();
+            body.extend_from_slice(&chunk[..room]);
+            capped = true;
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok((body, capped))
+}
+
+// ---------------------------------------------------------------------------
+// web_search
+// ---------------------------------------------------------------------------
+
+/// One search hit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+}
+
+/// A pluggable `web_search` backend.
+#[async_trait]
+pub trait SearchBackend: Send + Sync {
+    async fn search(&self, query: &str, count: usize) -> anyhow::Result<Vec<SearchResult>>;
+}
+
+/// Default backend: scrape the DuckDuckGo HTML endpoint. No API key.
+pub struct DuckDuckGoHtml {
+    base_url: String,
+}
+
+impl DuckDuckGoHtml {
+    pub fn new() -> Self {
+        Self::with_base_url("https://html.duckduckgo.com/html/")
+    }
+
+    /// Point the backend at a different endpoint (tests use a local server).
+    pub fn with_base_url(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+}
+
+impl Default for DuckDuckGoHtml {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SearchBackend for DuckDuckGoHtml {
+    async fn search(&self, query: &str, count: usize) -> anyhow::Result<Vec<SearchResult>> {
+        let client = web_client(true)?;
+        let response = client
+            .get(&self.base_url)
+            .query(&[("q", query)])
+            .send()
+            .await?
+            .error_for_status()?;
+        let html = response.text().await?;
+        Ok(parse_duckduckgo_html(&html, count))
+    }
+}
+
+/// Parse DuckDuckGo HTML-endpoint results. Kept synchronous and self-
+/// contained (scraper's DOM is not `Send`, so it must not live across an
+/// await point) and separate for fixture-based unit tests.
+fn parse_duckduckgo_html(html: &str, count: usize) -> Vec<SearchResult> {
+    let document = scraper::Html::parse_document(html);
+    let result_sel = scraper::Selector::parse("div.result").expect("valid selector");
+    let title_sel = scraper::Selector::parse("a.result__a").expect("valid selector");
+    let snippet_sel = scraper::Selector::parse(".result__snippet").expect("valid selector");
+
+    let mut results = Vec::new();
+    for result in document.select(&result_sel) {
+        if results.len() >= count {
+            break;
+        }
+        let Some(link) = result.select(&title_sel).next() else {
+            continue;
+        };
+        let title = link.text().collect::<String>().trim().to_string();
+        let url = decode_ddg_href(link.value().attr("href").unwrap_or(""));
+        if title.is_empty() || url.is_empty() {
+            continue;
+        }
+        let snippet = result
+            .select(&snippet_sel)
+            .next()
+            .map(|node| node.text().collect::<String>().trim().to_string())
+            .unwrap_or_default();
+        results.push(SearchResult {
+            title,
+            url,
+            snippet,
+        });
+    }
+    results
+}
+
+/// Unwrap a DuckDuckGo redirect href
+/// (`//duckduckgo.com/l/?uddg=<encoded target>&rut=...`) to the real target.
+/// Non-redirect hrefs are returned as-is.
+fn decode_ddg_href(href: &str) -> String {
+    let absolute = if href.starts_with("//") {
+        format!("https:{href}")
+    } else {
+        href.to_string()
+    };
+    if let Ok(url) = reqwest::Url::parse(&absolute) {
+        if let Some((_, target)) = url.query_pairs().find(|(key, _)| key == "uddg") {
+            return target.into_owned();
+        }
+        return absolute;
+    }
+    href.to_string()
+}
+
+/// Brave Search API backend (`X-Subscription-Token` key).
+pub struct BraveSearch {
+    base_url: String,
+    api_key: String,
+}
+
+impl BraveSearch {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url("https://api.search.brave.com", api_key)
+    }
+
+    pub fn with_base_url(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl SearchBackend for BraveSearch {
+    async fn search(&self, query: &str, count: usize) -> anyhow::Result<Vec<SearchResult>> {
+        let client = web_client(true)?;
+        let response = client
+            .get(format!("{}/res/v1/web/search", self.base_url))
+            .header("X-Subscription-Token", &self.api_key)
+            .header("Accept", "application/json")
+            .query(&[("q", query), ("count", &count.to_string())])
+            .send()
+            .await?
+            .error_for_status()?;
+        let body: Value = response.json().await?;
+        let results = body["web"]["results"]
+            .as_array()
+            .map(|results| {
+                results
+                    .iter()
+                    .take(count)
+                    .filter_map(|hit| {
+                        let title = hit["title"].as_str()?.to_string();
+                        let url = hit["url"].as_str()?.to_string();
+                        let snippet = hit["description"].as_str().unwrap_or("").to_string();
+                        Some(SearchResult {
+                            title,
+                            url,
+                            snippet,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(results)
+    }
+}
+
+/// Tavily Search API backend (key in the JSON request body).
+pub struct TavilySearch {
+    base_url: String,
+    api_key: String,
+}
+
+impl TavilySearch {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url("https://api.tavily.com", api_key)
+    }
+
+    pub fn with_base_url(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl SearchBackend for TavilySearch {
+    async fn search(&self, query: &str, count: usize) -> anyhow::Result<Vec<SearchResult>> {
+        let client = web_client(true)?;
+        let response = client
+            .post(format!("{}/search", self.base_url))
+            .json(&json!({
+                "api_key": self.api_key,
+                "query": query,
+                "max_results": count,
+            }))
+            .send()
+            .await?
+            .error_for_status()?;
+        let body: Value = response.json().await?;
+        let results = body["results"]
+            .as_array()
+            .map(|results| {
+                results
+                    .iter()
+                    .take(count)
+                    .filter_map(|hit| {
+                        let title = hit["title"].as_str()?.to_string();
+                        let url = hit["url"].as_str()?.to_string();
+                        let snippet = hit["content"].as_str().unwrap_or("").to_string();
+                        Some(SearchResult {
+                            title,
+                            url,
+                            snippet,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(results)
+    }
+}
+
+/// Render results as the numbered markdown list fed back to the model.
+fn render_results(results: &[SearchResult]) -> String {
+    results
+        .iter()
+        .enumerate()
+        .map(|(index, result)| {
+            let mut line = format!("{}. [{}]({})", index + 1, result.title, result.url);
+            if !result.snippet.is_empty() {
+                line.push_str("\n   ");
+                line.push_str(&result.snippet);
+            }
+            line
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Arguments for [`WebSearchTool`].
+#[derive(Debug, Deserialize)]
+struct SearchArgs {
+    query: String,
+    /// Number of results (default 5, max 10).
+    #[serde(default)]
+    count: Option<usize>,
+}
+
+/// `web_search` — query the configured search backend.
+pub struct WebSearchTool;
+
+impl WebSearchTool {
+    /// Build the configured backend, reading any API key from the
+    /// environment at call time (keys are never stored).
+    fn backend(ctx: &ToolContext) -> Result<Box<dyn SearchBackend>, String> {
+        let name = ctx.web.search_backend.trim().to_ascii_lowercase();
+        match name.as_str() {
+            "" | "duckduckgo" => Ok(Box::new(DuckDuckGoHtml::new())),
+            "brave" => Ok(Box::new(BraveSearch::new(Self::api_key(ctx, "brave")?))),
+            "tavily" => Ok(Box::new(TavilySearch::new(Self::api_key(ctx, "tavily")?))),
+            other => Err(format!(
+                "unknown [web] search_backend '{other}' (expected duckduckgo, brave, or tavily)"
+            )),
+        }
+    }
+
+    fn api_key(ctx: &ToolContext, backend: &str) -> Result<String, String> {
+        let Some(env_name) = ctx.web.search_api_key_env.as_deref() else {
+            return Err(format!(
+                "search backend '{backend}' needs an API key: set [web] search_api_key_env \
+                 in config.toml to the name of the env var holding it"
+            ));
+        };
+        match std::env::var(env_name) {
+            Ok(key) if !key.trim().is_empty() => Ok(key),
+            _ => Err(format!(
+                "search backend '{backend}' needs an API key, but ${env_name} is unset or empty"
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn name(&self) -> &str {
+        "web_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the web and return a numbered list of results (title, url, snippet)."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Search query" },
+                "count": { "type": "integer", "description": "Number of results (default 5, max 10)" }
+            },
+            "required": ["query"]
+        })
+    }
+
+    fn access(&self) -> ToolAccess {
+        ToolAccess::ReadOnly
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let args: SearchArgs = parse_args(self.name(), args)?;
+        if args.query.trim().is_empty() {
+            return Err(ToolError::InvalidArgs {
+                tool: self.name().to_string(),
+                message: "query must not be empty".to_string(),
+            });
+        }
+        let count = args
+            .count
+            .unwrap_or(DEFAULT_SEARCH_COUNT)
+            .clamp(1, MAX_SEARCH_COUNT);
+
+        let backend = match Self::backend(ctx) {
+            Ok(backend) => backend,
+            Err(reason) => return Ok(ToolOutput::error(reason)),
+        };
+        let results = match backend.search(args.query.trim(), count).await {
+            Ok(results) => results,
+            Err(err) => return Ok(ToolOutput::error(format!("search failed: {err:#}"))),
+        };
+        if results.is_empty() {
+            return Ok(ToolOutput::ok("(no results)"));
+        }
+        Ok(ToolOutput::ok(truncate_output(
+            render_results(&results),
+            MAX_OUTPUT_BYTES,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::config::WebConfig;
+
+    // -- SSRF guard -----------------------------------------------------------
+
+    #[test]
+    fn local_ips_are_detected() {
+        for ip in [
+            "127.0.0.1",
+            "127.8.8.8",
+            "10.0.0.1",
+            "10.255.255.255",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.0.1",
+            "192.168.255.255",
+            "169.254.0.1",
+            "0.0.0.0",
+            "::1",
+            "fe80::1",
+            "fc00::1",
+            "fd12:3456::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+        ] {
+            assert!(ip_is_local(ip.parse().unwrap()), "{ip} is local");
+        }
+        for ip in [
+            "8.8.8.8",
+            "1.1.1.1",
+            "172.32.0.1",
+            "172.15.0.1",
+            "2606:4700::1111",
+        ] {
+            assert!(!ip_is_local(ip.parse().unwrap()), "{ip} is public");
+        }
+    }
+
+    #[test]
+    fn local_hostnames_are_detected() {
+        assert!(host_is_local_name("localhost"));
+        assert!(host_is_local_name("LOCALHOST"));
+        assert!(host_is_local_name("localhost."));
+        assert!(host_is_local_name("printer.local"));
+        assert!(host_is_local_name("nas.Local"));
+        assert!(!host_is_local_name("example.com"));
+        assert!(!host_is_local_name("local"));
+        assert!(!host_is_local_name("notlocal.com"));
+    }
+
+    #[tokio::test]
+    async fn check_url_rejects_private_ranges_and_local_names() {
+        for url in [
+            "http://127.0.0.1/",
+            "http://127.0.0.1:8080/path",
+            "http://10.1.2.3/",
+            "http://172.16.0.1/",
+            "http://192.168.1.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]/",
+            "http://localhost/",
+            "http://localhost:3000/",
+            "http://printer.local/",
+        ] {
+            let parsed = reqwest::Url::parse(url).unwrap();
+            let err = check_url(&parsed, false).await.expect_err(url);
+            assert!(err.contains("blocked"), "{url}: {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn check_url_allows_local_when_configured() {
+        for url in [
+            "http://127.0.0.1:8080/",
+            "http://localhost/",
+            "http://10.0.0.1/",
+        ] {
+            let parsed = reqwest::Url::parse(url).unwrap();
+            check_url(&parsed, true).await.expect(url);
+        }
+    }
+
+    #[tokio::test]
+    async fn check_url_rejects_non_http_schemes_even_when_local_is_allowed() {
+        for url in ["ftp://example.com/", "file:///etc/passwd", "gopher://x/"] {
+            let parsed = reqwest::Url::parse(url).unwrap();
+            for allow_local in [false, true] {
+                let err = check_url(&parsed, allow_local)
+                    .await
+                    .expect_err("non-http scheme rejected");
+                assert!(err.contains("unsupported URL scheme"), "{url}: {err}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn check_url_allows_public_ip_literals_without_dns() {
+        // A public IP literal needs no DNS resolution to pass.
+        let parsed = reqwest::Url::parse("http://8.8.8.8/").unwrap();
+        check_url(&parsed, false).await.expect("public IP allowed");
+    }
+
+    // -- local fixture server -------------------------------------------------
+
+    /// Serve a fixed raw HTTP response on a loopback listener; returns the
+    /// bound address. Every connection gets the same response.
+    async fn serve(response: String) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fixture server");
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let response = response.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    let _ = socket.read(&mut buf).await;
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        addr
+    }
+
+    fn http_response(content_type: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// Context whose `[web]` settings allow loopback fetches.
+    fn local_ctx() -> ToolContext {
+        ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            allow_local: true,
+            ..WebConfig::default()
+        })
+    }
+
+    // -- web_fetch ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_converts_html_to_markdown() {
+        let addr = serve(http_response(
+            "text/html; charset=utf-8",
+            "<html><body><h1>Spellbook</h1><p>Read the <a href=\"https://example.com/docs\">docs</a>.</p></body></html>",
+        ))
+        .await;
+        let out = WebFetchTool
+            .execute(json!({ "url": format!("http://{addr}/") }), &local_ctx())
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{}", out.content);
+        assert!(out.content.contains("# Spellbook"), "{}", out.content);
+        assert!(
+            out.content.contains("[docs](https://example.com/docs)"),
+            "{}",
+            out.content
+        );
+        assert!(
+            !out.content.contains("<h1>"),
+            "no raw html: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_plain_text_as_is() {
+        let addr = serve(http_response("text/plain", "plain payload, not markdown")).await;
+        let out = WebFetchTool
+            .execute(json!({ "url": format!("http://{addr}/") }), &local_ctx())
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert_eq!(out.content, "plain payload, not markdown");
+    }
+
+    #[tokio::test]
+    async fn fetch_notes_binary_content_instead_of_dumping_it() {
+        let addr = serve(http_response("application/octet-stream", "\u{1}\u{2}\u{3}")).await;
+        let out = WebFetchTool
+            .execute(json!({ "url": format!("http://{addr}/") }), &local_ctx())
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(
+            out.content
+                .contains("binary content type 'application/octet-stream'"),
+            "{}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_caps_the_response_at_the_configured_bytes() {
+        let body = "a".repeat(5_000);
+        let addr = serve(http_response("text/plain", &body)).await;
+        let ctx = ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            allow_local: true,
+            fetch_max_bytes: 100,
+            ..WebConfig::default()
+        });
+        let out = WebFetchTool
+            .execute(json!({ "url": format!("http://{addr}/") }), &ctx)
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(
+            out.content.contains("[response capped at 100 bytes]"),
+            "{}",
+            out.content
+        );
+        assert!(out.content.len() < 200, "content stayed small");
+    }
+
+    #[tokio::test]
+    async fn fetch_max_bytes_arg_is_clamped_to_the_config_cap() {
+        let body = "b".repeat(5_000);
+        let addr = serve(http_response("text/plain", &body)).await;
+        let ctx = ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            allow_local: true,
+            fetch_max_bytes: 100,
+            ..WebConfig::default()
+        });
+        // Asking for more than the config cap still stops at the cap.
+        let out = WebFetchTool
+            .execute(
+                json!({ "url": format!("http://{addr}/"), "max_bytes": 50_000 }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            out.content.contains("capped at 100 bytes"),
+            "{}",
+            out.content
+        );
+
+        // Asking for less reads less.
+        let out = WebFetchTool
+            .execute(
+                json!({ "url": format!("http://{addr}/"), "max_bytes": 10 }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            out.content.contains("capped at 10 bytes"),
+            "{}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_loopback_by_default() {
+        // No request is made: the guard rejects before connecting, so an
+        // unbound port is fine.
+        let ctx = ToolContext::new(std::env::temp_dir());
+        assert!(!ctx.web.allow_local, "guard on by default");
+        let out = WebFetchTool
+            .execute(json!({ "url": "http://127.0.0.1:1/" }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(out.content.contains("blocked"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn fetch_reports_http_errors_as_tool_errors() {
+        let addr = serve(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\nConnection: close\r\n\r\nnot found".to_string(),
+        )
+        .await;
+        let out = WebFetchTool
+            .execute(
+                json!({ "url": format!("http://{addr}/missing") }),
+                &local_ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(out.content.contains("HTTP 404"), "{}", out.content);
+        assert!(out.content.contains("not found"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_urls_as_invalid_args() {
+        let err = WebFetchTool
+            .execute(json!({ "url": "not a url" }), &local_ctx())
+            .await
+            .expect_err("invalid url");
+        assert!(matches!(err, ToolError::InvalidArgs { tool, .. } if tool == "web_fetch"));
+    }
+
+    // -- web_search -----------------------------------------------------------
+
+    /// DuckDuckGo-shaped HTML fixture: two results, one with a wrapped
+    /// redirect href and one with a plain absolute href.
+    const DDG_FIXTURE: &str = r#"<!DOCTYPE html><html><body>
+      <div class="serp__results">
+        <div class="result results_links results_links_deep web-result">
+          <div class="links_main links_deep result__body">
+            <h2 class="result__title">
+              <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.rust%2Dlang.org%2F&amp;rut=abc123">Rust Programming Language</a>
+            </h2>
+            <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.rust%2Dlang.org%2F&amp;rut=abc123">A language empowering everyone to build reliable software.</a>
+          </div>
+        </div>
+        <div class="result results_links results_links_deep web-result">
+          <div class="links_main links_deep result__body">
+            <h2 class="result__title">
+              <a rel="nofollow" class="result__a" href="https://doc.rust-lang.org/book/">The Rust Book</a>
+            </h2>
+            <a class="result__snippet" href="https://doc.rust-lang.org/book/">An introductory book about Rust.</a>
+          </div>
+        </div>
+      </div>
+    </body></html>"#;
+
+    #[test]
+    fn duckduckgo_parser_extracts_results_from_fixture() {
+        let results = parse_duckduckgo_html(DDG_FIXTURE, 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Rust Programming Language");
+        assert_eq!(
+            results[0].url, "https://www.rust-lang.org/",
+            "uddg redirect href is unwrapped"
+        );
+        assert!(results[0].snippet.contains("reliable software"));
+        assert_eq!(results[1].title, "The Rust Book");
+        assert_eq!(results[1].url, "https://doc.rust-lang.org/book/");
+    }
+
+    #[test]
+    fn duckduckgo_parser_honors_count_and_empty_input() {
+        assert_eq!(parse_duckduckgo_html(DDG_FIXTURE, 1).len(), 1);
+        assert!(parse_duckduckgo_html("<html><body>no results</body></html>", 5).is_empty());
+    }
+
+    #[test]
+    fn ddg_href_decoding_handles_plain_and_wrapped_links() {
+        assert_eq!(
+            decode_ddg_href("//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa%20b&rut=x"),
+            "https://example.com/a b"
+        );
+        assert_eq!(
+            decode_ddg_href("https://example.com/direct"),
+            "https://example.com/direct"
+        );
+        assert_eq!(decode_ddg_href(""), "");
+    }
+
+    #[tokio::test]
+    async fn duckduckgo_backend_searches_a_local_fixture_server() {
+        let addr = serve(http_response("text/html", DDG_FIXTURE)).await;
+        let backend = DuckDuckGoHtml::with_base_url(format!("http://{addr}/html/"));
+        let results = backend.search("rust", 5).await.expect("search ok");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].url, "https://www.rust-lang.org/");
+    }
+
+    #[tokio::test]
+    async fn brave_backend_parses_the_api_shape() {
+        let body = json!({
+            "web": { "results": [
+                { "title": "Result One", "url": "https://one.example/", "description": "first" },
+                { "title": "Result Two", "url": "https://two.example/", "description": "second" }
+            ]}
+        })
+        .to_string();
+        let addr = serve(http_response("application/json", &body)).await;
+        let backend = BraveSearch::with_base_url(format!("http://{addr}"), "test-key");
+        let results = backend.search("anything", 5).await.expect("search ok");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Result One");
+        assert_eq!(results[1].snippet, "second");
+    }
+
+    #[tokio::test]
+    async fn tavily_backend_parses_the_api_shape() {
+        let body = json!({
+            "results": [
+                { "title": "Tavily Hit", "url": "https://hit.example/", "content": "summary text" }
+            ]
+        })
+        .to_string();
+        let addr = serve(http_response("application/json", &body)).await;
+        let backend = TavilySearch::with_base_url(format!("http://{addr}"), "test-key");
+        let results = backend.search("anything", 5).await.expect("search ok");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].snippet, "summary text");
+    }
+
+    #[test]
+    fn results_render_as_a_numbered_markdown_list() {
+        let rendered = render_results(&[
+            SearchResult {
+                title: "One".to_string(),
+                url: "https://one.example/".to_string(),
+                snippet: "first snippet".to_string(),
+            },
+            SearchResult {
+                title: "Two".to_string(),
+                url: "https://two.example/".to_string(),
+                snippet: String::new(),
+            },
+        ]);
+        assert_eq!(
+            rendered,
+            "1. [One](https://one.example/)\n   first snippet\n2. [Two](https://two.example/)"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_rejects_empty_queries() {
+        let err = WebSearchTool
+            .execute(json!({ "query": "  " }), &local_ctx())
+            .await
+            .expect_err("empty query");
+        assert!(matches!(err, ToolError::InvalidArgs { tool, .. } if tool == "web_search"));
+    }
+
+    #[tokio::test]
+    async fn search_unknown_backend_is_a_tool_error_without_network() {
+        let ctx = ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            search_backend: "askjeeves".to_string(),
+            ..WebConfig::default()
+        });
+        let out = WebSearchTool
+            .execute(json!({ "query": "rust" }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(
+            out.content
+                .contains("unknown [web] search_backend 'askjeeves'"),
+            "{}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn search_keyed_backends_require_a_key_env() {
+        // No env var configured at all.
+        let ctx = ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            search_backend: "brave".to_string(),
+            search_api_key_env: None,
+            ..WebConfig::default()
+        });
+        let out = WebSearchTool
+            .execute(json!({ "query": "rust" }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("search_api_key_env"),
+            "{}",
+            out.content
+        );
+
+        // Env var configured but unset in the environment.
+        let ctx = ToolContext::new(std::env::temp_dir()).with_web(WebConfig {
+            search_backend: "tavily".to_string(),
+            search_api_key_env: Some("WIZARD_TEST_KEY_THAT_DOES_NOT_EXIST".to_string()),
+            ..WebConfig::default()
+        });
+        let out = WebSearchTool
+            .execute(json!({ "query": "rust" }), &ctx)
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("WIZARD_TEST_KEY_THAT_DOES_NOT_EXIST"),
+            "{}",
+            out.content
+        );
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -79,11 +79,14 @@ pub fn draw(frame: &mut Frame, app: &App) {
     draw_status_bar(frame, app, status_area);
 
     // Floating layers, back to front.
-    if app.picker.is_none() {
+    if app.picker.is_none() && app.plan_review.is_none() {
         draw_suggestions(frame, app, input_area);
     }
     if app.picker.is_some() {
         draw_picker(frame, app);
+    }
+    if app.plan_review.is_some() {
+        draw_plan_review(frame, app);
     }
 }
 
@@ -438,6 +441,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(" · ", dim()),
         mode_span(app.status.mode),
     ];
+    if app.plan_mode {
+        spans.push(Span::styled(" · ", dim()));
+        spans.push(Span::styled("PLAN", accent().bold()));
+    }
     if let Some(label) = &app.rebuilding {
         spans.push(Span::styled(" · ", dim()));
         spans.push(Span::styled(format!("{spinner} "), accent()));
@@ -463,7 +470,13 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
     // Contextual key hints, right-aligned in a sub-rect so the left side is
     // never overdrawn.
-    let hints = if app.picker.is_some() {
+    let hints = if let Some(review) = &app.plan_review {
+        if review.feedback.is_some() {
+            "type feedback · Enter reject · Esc back"
+        } else {
+            "y/Enter approve · n reject · ↑↓ scroll"
+        }
+    } else if app.picker.is_some() {
         "↑↓ move · Enter select · Esc cancel"
     } else if !app.suggestions.is_empty() {
         "↑↓ select · Tab complete · Enter run"
@@ -556,7 +569,7 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
         area,
     );
 
-    if app.picker.is_none() {
+    if app.picker.is_none() && app.plan_review.is_none() {
         frame.set_cursor_position(Position::new(cursor_x, area.y + 1));
     }
 }
@@ -706,6 +719,95 @@ fn draw_picker(frame: &mut Frame, app: &App) {
             Line::from(Span::styled(" ↑↓ move · Enter select · Esc cancel ", dim())).centered(),
         );
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
+}
+
+/// Plan-review modal (plan mode): the plan markdown with a verdict footer.
+/// The turn is paused inside `exit_plan` until the user answers, so this
+/// floats above everything else. While rejecting, a feedback line replaces
+/// the bottom edge of the body.
+fn draw_plan_review(frame: &mut Frame, app: &App) {
+    let Some(review) = &app.plan_review else {
+        return;
+    };
+
+    let frame_area = frame.area();
+    let width = frame_area.width.saturating_sub(6).clamp(24, 100);
+    let height = frame_area.height.saturating_sub(2).max(5);
+    let area = Rect {
+        x: frame_area.x + (frame_area.width.saturating_sub(width)) / 2,
+        y: frame_area.y + (frame_area.height.saturating_sub(height)) / 2,
+        width,
+        height,
+    }
+    .intersection(frame_area);
+    if area.height < 5 || area.width < 10 {
+        return;
+    }
+    frame.render_widget(Clear, area);
+
+    let hints = if review.feedback.is_some() {
+        " feedback · Enter reject · Esc back "
+    } else {
+        " y approve · n reject · ↑↓ scroll "
+    };
+    let block = Block::bordered()
+        .border_type(BorderType::Rounded)
+        .border_style(dim())
+        .title(Line::from(vec![
+            Span::styled(" ✦", accent()),
+            Span::styled(" plan review ", Style::default().fg(TEXT_DIM)),
+        ]))
+        .title_bottom(Line::from(Span::styled(hints, dim())).centered());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Body: the plan, wrapped and scrolled; the bottom line is reserved for
+    // the feedback input while rejecting.
+    let body_area = if review.feedback.is_some() {
+        Rect {
+            height: inner.height.saturating_sub(1),
+            ..inner
+        }
+    } else {
+        inner
+    };
+    if body_area.height > 0 {
+        let lines = wrap_lines(render_markdown(&review.plan), body_area.width as usize);
+        let max_scroll = lines.len().saturating_sub(body_area.height as usize);
+        let scroll = (review.scroll as usize).min(max_scroll);
+        let visible: Vec<Line<'static>> = lines
+            .into_iter()
+            .skip(scroll)
+            .take(body_area.height as usize)
+            .collect();
+        frame.render_widget(Paragraph::new(Text::from(visible)), body_area);
+    }
+
+    if let Some(feedback) = &review.feedback {
+        let feedback_area = Rect {
+            y: inner.bottom().saturating_sub(1),
+            height: 1,
+            ..inner
+        };
+        let budget =
+            (feedback_area.width as usize).saturating_sub("rejection feedback ❯  ".width());
+        let shown: String = feedback
+            .chars()
+            .rev()
+            .take(budget)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("rejection feedback ❯ ", accent().bold()),
+                Span::raw(shown),
+                Span::styled("▍", dim()),
+            ])),
+            feedback_area,
+        );
+    }
 }
 
 /// Wrap styled lines at `width` display columns (wide CJK/emoji glyphs

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -616,7 +616,7 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
             let mut ghost = remainder.to_string();
             if !spec.args.is_empty() {
                 ghost.push(' ');
-                ghost.push_str(spec.args);
+                ghost.push_str(&spec.args);
             }
             let room = budget.saturating_sub(used_cols);
             if !ghost.is_empty() && room > 0 {
@@ -694,7 +694,7 @@ fn draw_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
                 Span::styled(marker, accent()),
                 Span::styled(format!("{usage:<usage_width$}"), name_style),
                 Span::styled(
-                    format!("  {}", truncate_width(spec.description, description_room)),
+                    format!("  {}", truncate_width(&spec.description, description_room)),
                     dim(),
                 ),
             ])

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 //! Ratatui rendering: pure functions from [`App`] state to widgets.
 //! Layout: chat transcript (with optional git diff sidebar) above the input
 //! line and a quiet status line. Floating layers: the command-suggestion
-//! popup, the model/mode picker, and the approval modal.
+//! popup and the model/mode picker.
 //!
 //! Design rules (do not regress):
 //! - **Transparent**: never paint a background color; everything renders on
@@ -79,14 +79,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
     draw_status_bar(frame, app, status_area);
 
     // Floating layers, back to front.
-    if app.picker.is_none() && app.pending_approval.is_none() {
+    if app.picker.is_none() {
         draw_suggestions(frame, app, input_area);
     }
     if app.picker.is_some() {
         draw_picker(frame, app);
-    }
-    if app.pending_approval.is_some() {
-        draw_approval_modal(frame, app);
     }
 }
 
@@ -466,9 +463,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
     // Contextual key hints, right-aligned in a sub-rect so the left side is
     // never overdrawn.
-    let hints = if app.pending_approval.is_some() {
-        "y approve · n deny"
-    } else if app.picker.is_some() {
+    let hints = if app.picker.is_some() {
         "↑↓ move · Enter select · Esc cancel"
     } else if !app.suggestions.is_empty() {
         "↑↓ select · Tab complete · Enter run"
@@ -504,25 +499,6 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
     let budget = (area.width as usize)
         .saturating_sub(pad + prompt_width + 1)
         .max(1);
-
-    if app.input_mode == InputMode::Approval {
-        let placeholder = "awaiting approval — y approve · n deny";
-        let line = Line::from(vec![
-            Span::raw(" "),
-            Span::styled("❯ ", dim().bold()),
-            Span::styled(placeholder, dim().italic()),
-        ]);
-        frame.render_widget(Paragraph::new(Text::from(vec![rule, line])), area);
-        // Input is disabled: park the cursor in the gap after the
-        // placeholder, never on top of it. Without this the cursor stays
-        // where the last editable frame left it — the placeholder's first
-        // cell — and terminals/recorders that ignore cursor-hide draw a
-        // block over the text ("❯ ▌waiting approval").
-        let after = (pad + prompt_width + placeholder.width() + 1) as u16;
-        let cursor_x = (area.x + after).min(area.right().saturating_sub(1));
-        frame.set_cursor_position(Position::new(cursor_x, area.y + 1));
-        return;
-    }
 
     let chars: Vec<char> = app.input.chars().collect();
     let widths: Vec<usize> = chars.iter().map(|c| c.width().unwrap_or(0)).collect();
@@ -729,70 +705,6 @@ fn draw_picker(frame: &mut Frame, app: &App) {
         .title_bottom(
             Line::from(Span::styled(" ↑↓ move · Enter select · Esc cancel ", dim())).centered(),
         );
-    frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
-}
-
-/// Centered modal asking the user to approve a gated tool call.
-fn draw_approval_modal(frame: &mut Frame, app: &App) {
-    let Some(pending) = &app.pending_approval else {
-        return;
-    };
-    let frame_area = frame.area();
-
-    let args = serde_json::to_string_pretty(&pending.call.function.arguments)
-        .unwrap_or_else(|_| "{}".to_string());
-    let arg_lines: Vec<&str> = args.lines().collect();
-
-    // Size the modal to its content: tool line + blank + argument block
-    // (+ overflow ellipsis) + blank + buttons, plus the borders; capped so
-    // it always fits the frame.
-    let max_args = frame_area.height.saturating_sub(7).max(3) as usize;
-    let shown = arg_lines.len().min(max_args);
-    let truncated = arg_lines.len() > shown;
-    let height = (shown + truncated as usize + 6) as u16;
-    let width = (frame_area.width as u32 * 70 / 100).max(1) as u16;
-    let area = Rect {
-        x: frame_area.x + (frame_area.width.saturating_sub(width)) / 2,
-        y: frame_area.y + (frame_area.height.saturating_sub(height)) / 2,
-        width,
-        height,
-    }
-    .intersection(frame_area);
-    frame.render_widget(Clear, area);
-
-    let mut lines: Vec<Line<'static>> = vec![
-        Line::from(vec![
-            Span::styled("tool ", dim()),
-            Span::styled(pending.call.function.name.clone(), accent().bold()),
-        ]),
-        Line::raw(""),
-    ];
-
-    for line in arg_lines.iter().take(shown) {
-        lines.push(Line::from(Span::styled(
-            line.to_string(),
-            Style::default().fg(TEXT_DIM),
-        )));
-    }
-    if truncated {
-        lines.push(Line::from(Span::styled("…", dim())));
-    }
-    lines.push(Line::raw(""));
-    lines.push(Line::from(vec![
-        Span::styled("y", Style::default().fg(Color::White).bold()),
-        Span::styled(" approve", dim()),
-        Span::raw("    "),
-        Span::styled("n", Style::default().fg(Color::White).bold()),
-        Span::styled(" deny", dim()),
-    ]));
-
-    let block = Block::bordered()
-        .border_type(BorderType::Rounded)
-        .border_style(accent())
-        .title(Line::from(vec![
-            Span::styled(" ✦", accent()),
-            Span::styled(" approve tool call? ", Style::default().fg(TEXT_DIM)),
-        ]));
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 //! Ratatui rendering: pure functions from [`App`] state to widgets.
 //! Layout: chat transcript (with optional git diff sidebar) above the input
 //! line and a quiet status line. Floating layers: the command-suggestion
-//! popup and the model/mode picker.
+//! popup and the model/mode/rewind picker.
 //!
 //! Design rules (do not regress):
 //! - **Transparent**: never paint a background color; everything renders on
@@ -707,7 +707,7 @@ fn draw_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 
-/// Centered modal for the model / mode picker.
+/// Centered modal for the model / mode / rewind picker.
 fn draw_picker(frame: &mut Frame, app: &App) {
     let Some(picker) = &app.picker else {
         return;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,12 +65,25 @@ pub fn draw(frame: &mut Frame, app: &App) {
     ])
     .areas(frame.area());
 
-    if app.show_diff {
-        let [chat_area, diff_area] =
+    if app.show_diff || app.show_todos {
+        let [chat_area, side_area] =
             Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)])
                 .areas(main_area);
         draw_transcript(frame, app, chat_area);
-        draw_diff_sidebar(frame, app, diff_area);
+        match (app.show_todos, app.show_diff) {
+            (true, true) => {
+                // Both panels share the sidebar: todos on top (sized to the
+                // list), the diff below.
+                let todo_height = (app.todos.len() as u16 + 1).clamp(2, side_area.height / 2);
+                let [todo_area, diff_area] =
+                    Layout::vertical([Constraint::Length(todo_height), Constraint::Min(1)])
+                        .areas(side_area);
+                draw_todo_sidebar(frame, app, todo_area);
+                draw_diff_sidebar(frame, app, diff_area);
+            }
+            (true, false) => draw_todo_sidebar(frame, app, side_area),
+            _ => draw_diff_sidebar(frame, app, side_area),
+        }
     } else {
         draw_transcript(frame, app, main_area);
     }
@@ -411,6 +424,47 @@ fn tool_card_lines(
     }
 }
 
+/// Todo side panel (`/todos`, auto-shown on the first todo update): the
+/// agent's working list with status glyphs — ✓ completed (dim,
+/// struck-through), ▸ in progress (accent), ☐ pending.
+fn draw_todo_sidebar(frame: &mut Frame, app: &App, area: Rect) {
+    let (done, total) = crate::tools::todo::progress(&app.todos);
+    let block = Block::new()
+        .borders(Borders::LEFT)
+        .border_style(dim())
+        .title(Line::from(vec![
+            Span::styled(" ≡ ", accent()),
+            Span::styled(
+                format!("todos {done}/{total}"),
+                Style::default().fg(TEXT_DIM),
+            ),
+        ]));
+    let inner_width = block.inner(area).width as usize;
+    let lines: Vec<Line<'static>> = if app.todos.is_empty() {
+        vec![Line::from(Span::styled("(empty)", dim().italic()))]
+    } else {
+        app.todos
+            .iter()
+            .map(|item| {
+                use crate::tools::todo::TodoStatus;
+                let (glyph_style, text_style) = match item.status {
+                    TodoStatus::Completed => (dim(), dim().add_modifier(Modifier::CROSSED_OUT)),
+                    TodoStatus::InProgress => (accent(), accent().bold()),
+                    TodoStatus::Pending => (dim(), Style::default().fg(TEXT_DIM)),
+                };
+                truncate_line(
+                    Line::from(vec![
+                        Span::styled(format!("{} ", item.status.glyph()), glyph_style),
+                        Span::styled(item.content.clone(), text_style),
+                    ]),
+                    inner_width,
+                )
+            })
+            .collect()
+    };
+    frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
+}
+
 /// Git diff sidebar (`/diff`): separated from the chat by a single dim
 /// rule, syntax-highlighted (foreground colors only). Lines wider than
 /// the sidebar are cut with a dim `…` instead of clipping silently.
@@ -444,6 +498,14 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     if app.plan_mode {
         spans.push(Span::styled(" · ", dim()));
         spans.push(Span::styled("PLAN", accent().bold()));
+    }
+    let token_total = app.status.prompt_tokens + app.status.completion_tokens;
+    if token_total > 0 {
+        spans.push(Span::styled(" · ", dim()));
+        spans.push(Span::styled(
+            crate::usage::format_tokens(token_total),
+            dim(),
+        ));
     }
     if let Some(label) = &app.rebuilding {
         spans.push(Span::styled(" · ", dim()));

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,247 @@
+//! Token-usage accounting: per-call counters accumulated by the agent loop,
+//! per-turn records appended to `~/.wizard/usage.jsonl`, and optional cost
+//! estimation from per-provider `usd_per_mtok_{in,out}` config.
+//!
+//! Counts come from [`ChatChunk`](crate::llm::ChatChunk)'s
+//! `prompt_eval_count` / `eval_count` fields (every provider reports them on
+//! its final chunk when the backend exposes usage). Backends that report
+//! nothing simply accumulate zeros and write no records.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Token counters for one agent. Atomics so the agent loop can record from
+/// `&self` mid-stream; the agent is single-threaded over these, so plain
+/// relaxed ordering suffices.
+#[derive(Debug, Default)]
+pub struct UsageTracker {
+    session_prompt: AtomicU64,
+    session_completion: AtomicU64,
+    turn_prompt: AtomicU64,
+    turn_completion: AtomicU64,
+    /// Prompt size of the most recent model call, +1 so 0 means "unknown"
+    /// (a genuinely 0-token prompt cannot occur: the system prompt counts).
+    last_prompt: AtomicU64,
+}
+
+impl UsageTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the usage of one model call. `None` fields (backend reported
+    /// nothing) leave the counters untouched.
+    pub fn record(&self, prompt_tokens: Option<u64>, completion_tokens: Option<u64>) {
+        if let Some(prompt) = prompt_tokens {
+            self.session_prompt.fetch_add(prompt, Ordering::Relaxed);
+            self.turn_prompt.fetch_add(prompt, Ordering::Relaxed);
+            self.last_prompt
+                .store(prompt.saturating_add(1), Ordering::Relaxed);
+        }
+        if let Some(completion) = completion_tokens {
+            self.session_completion
+                .fetch_add(completion, Ordering::Relaxed);
+            self.turn_completion
+                .fetch_add(completion, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset the per-turn counters (called at the top of every turn).
+    pub fn begin_turn(&self) {
+        self.turn_prompt.store(0, Ordering::Relaxed);
+        self.turn_completion.store(0, Ordering::Relaxed);
+    }
+
+    /// `(prompt, completion)` tokens of the current turn.
+    pub fn turn_totals(&self) -> (u64, u64) {
+        (
+            self.turn_prompt.load(Ordering::Relaxed),
+            self.turn_completion.load(Ordering::Relaxed),
+        )
+    }
+
+    /// `(prompt, completion)` tokens of the whole session.
+    pub fn session_totals(&self) -> (u64, u64) {
+        (
+            self.session_prompt.load(Ordering::Relaxed),
+            self.session_completion.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Prompt size of the most recent model call, when the backend reported
+    /// one. Drives token-aware compaction.
+    pub fn last_prompt_tokens(&self) -> Option<u64> {
+        match self.last_prompt.load(Ordering::Relaxed) {
+            0 => None,
+            stored => Some(stored - 1),
+        }
+    }
+
+    /// Forget the last prompt size (after compaction shrank the history, so
+    /// a stale large count does not re-trigger compaction immediately).
+    pub fn clear_last_prompt(&self) {
+        self.last_prompt.store(0, Ordering::Relaxed);
+    }
+}
+
+/// One line of `~/.wizard/usage.jsonl`: the token usage of one agent turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageRecord {
+    /// Unix seconds when the turn ended.
+    pub ts: u64,
+    /// Project root the agent worked in.
+    pub project: String,
+    pub model: String,
+    /// Configured provider name (e.g. `"local"`, `"anthropic"`).
+    pub provider: String,
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    /// Personality mode (`genie` / `sovereign`).
+    pub mode: String,
+}
+
+/// `~/.wizard/usage.jsonl`, or `None` when the home directory cannot be
+/// resolved (usage logging is then skipped, never fatal).
+pub fn default_log_path() -> Option<PathBuf> {
+    crate::config::Config::wizard_dir()
+        .ok()
+        .map(|dir| dir.join("usage.jsonl"))
+}
+
+/// Append one record to the JSONL usage log at `path`, creating the file
+/// (and its parent directory) as needed.
+pub fn append(path: &Path, record: &UsageRecord) -> Result<()> {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut line = serde_json::to_string(record).context("serializing usage record")?;
+    line.push('\n');
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .and_then(|mut file| file.write_all(line.as_bytes()))
+        .with_context(|| format!("appending to {}", path.display()))
+}
+
+/// Current time as unix seconds.
+pub fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+/// Estimated cost in USD for the given token totals, when at least one rate
+/// (`usd_per_mtok_in` / `usd_per_mtok_out`, dollars per million tokens) is
+/// configured for the provider. `None` means "no rates configured".
+pub fn cost_usd(
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    usd_per_mtok_in: Option<f64>,
+    usd_per_mtok_out: Option<f64>,
+) -> Option<f64> {
+    if usd_per_mtok_in.is_none() && usd_per_mtok_out.is_none() {
+        return None;
+    }
+    Some(
+        prompt_tokens as f64 / 1e6 * usd_per_mtok_in.unwrap_or(0.0)
+            + completion_tokens as f64 / 1e6 * usd_per_mtok_out.unwrap_or(0.0),
+    )
+}
+
+/// Compact human form of a token count for status lines: `842 tok`,
+/// `12.3k tok`, `4.2M tok`.
+pub fn format_tokens(count: u64) -> String {
+    if count < 1_000 {
+        format!("{count} tok")
+    } else if count < 1_000_000 {
+        format!("{:.1}k tok", count as f64 / 1e3)
+    } else {
+        format!("{:.1}M tok", count as f64 / 1e6)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracker_accumulates_turn_and_session_totals() {
+        let tracker = UsageTracker::new();
+        assert_eq!(tracker.session_totals(), (0, 0));
+        assert_eq!(tracker.last_prompt_tokens(), None);
+
+        tracker.record(Some(100), Some(20));
+        tracker.record(Some(150), Some(30));
+        assert_eq!(tracker.turn_totals(), (250, 50));
+        assert_eq!(tracker.session_totals(), (250, 50));
+        assert_eq!(tracker.last_prompt_tokens(), Some(150));
+
+        tracker.begin_turn();
+        assert_eq!(tracker.turn_totals(), (0, 0));
+        assert_eq!(tracker.session_totals(), (250, 50), "session survives");
+        assert_eq!(
+            tracker.last_prompt_tokens(),
+            Some(150),
+            "last prompt survives the turn boundary"
+        );
+
+        tracker.record(None, None);
+        assert_eq!(tracker.session_totals(), (250, 50), "None records nothing");
+
+        tracker.clear_last_prompt();
+        assert_eq!(tracker.last_prompt_tokens(), None);
+    }
+
+    #[test]
+    fn append_writes_one_json_line_per_record() {
+        let dir = std::env::temp_dir().join(format!("wizard-usage-{}", uuid::Uuid::new_v4()));
+        let path = dir.join("usage.jsonl");
+        let record = UsageRecord {
+            ts: 1_700_000_000,
+            project: "/tmp/proj".to_string(),
+            model: "qwen3-8b".to_string(),
+            provider: "local".to_string(),
+            prompt_tokens: 123,
+            completion_tokens: 45,
+            mode: "genie".to_string(),
+        };
+        append(&path, &record).expect("first append");
+        append(&path, &record).expect("second append");
+
+        let raw = std::fs::read_to_string(&path).expect("readable");
+        let lines: Vec<&str> = raw.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let parsed: UsageRecord = serde_json::from_str(lines[0]).expect("valid json");
+        assert_eq!(parsed.prompt_tokens, 123);
+        assert_eq!(parsed.completion_tokens, 45);
+        assert_eq!(parsed.model, "qwen3-8b");
+        assert_eq!(parsed.provider, "local");
+        assert_eq!(parsed.mode, "genie");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cost_requires_at_least_one_rate() {
+        assert_eq!(cost_usd(1_000_000, 1_000_000, None, None), None);
+        assert_eq!(
+            cost_usd(1_000_000, 2_000_000, Some(3.0), Some(15.0)),
+            Some(33.0)
+        );
+        assert_eq!(cost_usd(2_000_000, 500_000, Some(1.0), None), Some(2.0));
+        assert_eq!(cost_usd(0, 0, Some(3.0), Some(15.0)), Some(0.0));
+    }
+
+    #[test]
+    fn token_formatting_scales() {
+        assert_eq!(format_tokens(0), "0 tok");
+        assert_eq!(format_tokens(842), "842 tok");
+        assert_eq!(format_tokens(12_345), "12.3k tok");
+        assert_eq!(format_tokens(4_200_000), "4.2M tok");
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -54,12 +54,13 @@ fn help_prints_usage_and_documented_flags() {
     assert!(output.status.success(), "--help must exit 0");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Usage:"), "help shows usage:\n{stdout}");
+    // `--auto` is deprecated (approval gating was removed): still parsed for
+    // compatibility but hidden from help.
     for flag in [
         "--mode",
         "--prompt",
         "--evolve",
         "--deep",
-        "--auto",
         "--max-hours",
         "--loop",
         "--cwd",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -251,6 +251,89 @@ fn headless_mode_without_a_prompt_is_an_actionable_error() {
     );
 }
 
+#[test]
+fn schedule_add_list_remove_round_trip() {
+    let home = TempDir::new();
+    let cwd = home.0.to_string_lossy().to_string();
+
+    let output = run_wizard(
+        &home.0,
+        &[
+            "schedule",
+            "add",
+            "nightly",
+            "--cron",
+            "0 3 * * *",
+            "--prompt",
+            "tidy the repo",
+            "--cwd",
+            &cwd,
+        ],
+        &[],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "add must succeed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("next fire"),
+        "add must print the next fire time:\n{stdout}"
+    );
+    assert!(
+        home.0.join(".wizard").join("schedule.toml").exists(),
+        "add must persist schedule.toml"
+    );
+
+    let output = run_wizard(&home.0, &["schedule", "list"], &[]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("nightly") && stdout.contains("0 3 * * *"),
+        "list must show the entry:\n{stdout}"
+    );
+
+    let output = run_wizard(&home.0, &["schedule", "remove", "nightly"], &[]);
+    assert!(output.status.success(), "remove must succeed");
+
+    let output = run_wizard(&home.0, &["schedule", "list"], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no entries"),
+        "list after remove must be empty:\n{stdout}"
+    );
+
+    let output = run_wizard(&home.0, &["schedule", "remove", "nightly"], &[]);
+    assert!(
+        !output.status.success(),
+        "removing a missing entry must fail"
+    );
+}
+
+#[test]
+fn schedule_add_rejects_a_bad_cron_expression() {
+    let home = TempDir::new();
+    let cwd = home.0.to_string_lossy().to_string();
+    let output = run_wizard(
+        &home.0,
+        &[
+            "schedule", "add", "broken", "--cron", "whenever", "--prompt", "x", "--cwd", &cwd,
+        ],
+        &[],
+    );
+    assert!(!output.status.success(), "a bad cron must be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cron"),
+        "error must mention the cron expression:\n{stderr}"
+    );
+    assert!(
+        !home.0.join(".wizard").join("schedule.toml").exists(),
+        "nothing may be persisted on a failed add"
+    );
+}
+
 /// Real inference end to end: auto-spawn llama-server, load a GGUF, run one
 /// sovereign turn. Opt-in only — set `WIZARD_E2E_GGUF` to a local GGUF path
 /// (small models recommended); skipped otherwise so `cargo test` never loads


### PR DESCRIPTION
## What

Twelve commits bringing wizard to feature parity with Claude Code and beyond, with every feature working in all modes (genie TUI, sovereign, continuous, gateway):

- **Dispatch pipeline** (`src/dispatch.rs`): single funnel for every tool call — plan-mode gate → pre_tool_use hook → checkpoint snapshot → execute → post_tool_use hook. All approval/permission machinery removed; tool calls always execute directly.
- **Hooks** (`src/hooks/`): `hooks.toml` (global + project) with pre/post_tool_use, user_prompt_submit, session_start/end, turn_end; exit-2 blocks, stdout JSON can rewrite args.
- **Plan mode**: read-only gate + `exit_plan` tool; `/plan` and Shift+Tab in the TUI, two-phase `--plan` in sovereign, `plan_each_cycle` for continuous.
- **Token-aware compaction** (provider context-window tables), **usage/cost tracking** (`/cost`, `~/.wizard/usage.jsonl`), **instruction hierarchy** (WIZARD.md > AGENTS.md > CLAUDE.md per ancestor dir), **todo tool** with TUI panel.
- **Web tools**: `web_fetch` (HTML→markdown, SSRF guard) and `web_search` (DuckDuckGo default, Brave/Tavily backends).
- **Background tasks**: `run_in_background` on execute, `task_output`/`task_kill`, completed-task notifications injected each step.
- **Checkpoints/rewind**: per-file CoW snapshots, `/rewind` picker, `rollback_failed_cycles` for continuous.
- **Custom slash commands** (`.wizard/commands/*.md`, `$ARGUMENTS`/`$1..$9`), **@file references** (TUI + headless), **`--output-format text|json|stream-json`** with outcome exit codes (0/2/3/4/1), **`wizard doctor`** + `/status`.
- **Scheduler**: `~/.wizard/schedule.toml`, `wizard schedule add|list|remove|run`, `wizard scheduler` daemon (croner).
- **Fleet mode**: `wizard fleet run -n N -p "<mission>"` — planning turn decomposes the mission into a task queue, N sovereign workers in git worktrees on `fleet/*` branches, synthesis turn merges them; `fleet status`/`fleet stop`.

## Tests

- `cargo test`: 515 lib + 4 bench + 10 CLI passing; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- E2E smoke: `wizard -p ... --output-format stream-json` emits valid JSONL ending in `done`, exit 0; `wizard doctor` exit 0 with live provider probe; `wizard fleet run -n 2` in a scratch repo decomposed, ran two workers in worktrees, and merged both fleet branches cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)