### PR TITLE
fix: kill background tasks by process group so grandchildren die too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,7 @@ dependencies = [
  "globset",
  "htmd",
  "indicatif",
+ "libc",
  "pulldown-cmark",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ tracing-appender = "0.2"
 htmd = "0.5"
 scraper = "0.27"
 
+# Process-group kill for background tasks (`task_kill`, timeouts)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -187,6 +187,11 @@ impl Tool for ExecuteTool {
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .kill_on_drop(true);
+            // Own process group so task_kill and the timeout reach the whole
+            // tree: `sh -c` may fork the command rather than exec it, and a
+            // surviving grandchild would hold the output pipes open.
+            #[cfg(unix)]
+            command.process_group(0);
             let child = command.spawn().map_err(|err| ToolError::Execution {
                 tool: self.name().to_string(),
                 source: anyhow::Error::new(err).context("failed to spawn background process"),

--- a/src/tools/tasks.rs
+++ b/src/tools/tasks.rs
@@ -211,7 +211,7 @@ impl TaskRegistry {
             let status = match waited {
                 // Kill requested (task_kill / kill_all).
                 None => {
-                    let _ = child.kill().await;
+                    kill_tree(&mut child).await;
                     TaskStatus::Killed
                 }
                 Some(Ok(Ok(exit))) => TaskStatus::Done(exit.code().unwrap_or(-1)),
@@ -221,7 +221,7 @@ impl TaskRegistry {
                 }
                 // Timeout elapsed.
                 Some(Err(_)) => {
-                    let _ = child.kill().await;
+                    kill_tree(&mut child).await;
                     TaskStatus::TimedOut
                 }
             };
@@ -317,6 +317,21 @@ impl TaskRegistry {
         finished.sort_unstable_by_key(|task| task.id);
         finished
     }
+}
+
+/// Kill a background task's whole process tree and reap the child.
+///
+/// Background children are spawned as their own process-group leaders, so on
+/// Unix the SIGKILL goes to the group: `sh -c` may fork the command rather
+/// than exec it (dash does), and killing only the shell would leave a
+/// grandchild running — and holding the output pipes open, which blocks the
+/// monitor until the orphan exits.
+async fn kill_tree(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+    }
+    let _ = child.kill().await;
 }
 
 /// Stream a child's stdout or stderr into the task's tail buffer.
@@ -459,7 +474,9 @@ mod tests {
 
     use super::*;
 
-    /// Spawn `sh -c <script>` with piped stdio, ready for the registry.
+    /// Spawn `sh -c <script>` with piped stdio, ready for the registry —
+    /// same configuration as the `execute` tool's background branch,
+    /// including the own process group that `kill_tree` targets.
     fn spawn_sh(script: &str) -> tokio::process::Child {
         let mut command = tokio::process::Command::new("sh");
         command
@@ -469,6 +486,8 @@ mod tests {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
         command.spawn().expect("spawn test child")
     }
 


### PR DESCRIPTION
Fixes the two task tests failing in CI (`drain_skips_running_tasks`, `timeout_kills_the_task_and_marks_it_timed_out`).

## Root cause
On Ubuntu runners `sh` is dash, which **forks** `sh -c <cmd>` children instead of exec'ing them. `task_kill` and the background timeout SIGKILLed only the shell, leaving the orphaned grandchild (e.g. `sleep 30`) holding the stdout/stderr pipe write ends. The monitor waits for the output readers to hit EOF before recording a finished status, so the task stayed unfinished until the orphan exited — past the tests' 10s deadline. Locally `sh` is bash, which execs single `-c` commands, so the kill reached the command directly and the tests passed.

This was a real `task_kill` bug, not test flakiness: killing a background task left its process tree running.

## Fix
- Spawn background children as their own process-group leaders (`process_group(0)`, as `server.rs` already does for the llama server).
- On `task_kill`/timeout, SIGKILL the whole group, then reap the child.

## Verification
Reproduced the exact CI failure in a Debian `rust:1` container (dash as `sh`): 513 passed / 2 failed before the fix, 515 passed after. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.