### PR TITLE
Add /settings menu and Claude Code import; dashboard session manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/target-glibc/
 **/*.rs.bk
 *.pdb
 .DS_Store

--- a/WIZARD.md
+++ b/WIZARD.md
@@ -33,7 +33,7 @@ with no recompile.
 3. **Scripted tool.** A small, self-contained shell/Python/JS helper exposed
    as a tool.
 4. **Subagent.** A reusable specialist worker with its own prompt and tool
-   scope.
+   scope. See §2.5 for when and how to delegate to one.
 5. **Deep evolve (source).** None of the above fit and the capability must
    live in Wizard's own Rust. Use `evolve` with `deep=true`: it edits the
    source checkout, rebuilds, smoke-tests, and replaces the running binary,
@@ -62,6 +62,41 @@ absent, install it (a scripted tool or `execute`), or fall back to a scripted
 `curl`/`lynx` fetch tool for read-only tasks. **Try the real thing before
 declaring it impossible.** The same pattern covers databases (a
 Postgres/SQLite MCP server), search, and computer use.
+
+## 2.5. Delegating to subagents
+
+A subagent is an isolated worker spawned with `spawn_subagent(subagent, task)`.
+It runs its own loop with a fresh context, a scoped tool set, and its own step
+budget, then returns a single final report. Its intermediate steps never enter
+your context, so a ten-step sub-task costs you one turn. The user can browse the
+roster any time with `/agents`.
+
+**Delegate when:**
+
+- The work is **self-contained** and you can hand off everything it needs in one
+  task description (a focused investigation, a refactor, running and reading a
+  test suite, writing docs).
+- It would otherwise **flood your context** with output you don't need to keep —
+  grepping a large tree, reading many files to answer one question, sifting long
+  logs. Let the subagent absorb the noise and report the conclusion.
+- A **specialist** fits the job better than the generalist you are right now
+  (e.g. `reviewer` for a read-only code review, `tester` for the test loop).
+
+**Don't delegate** trivial one-tool actions (just call the tool), work that needs
+the user's input mid-flight (a subagent can't ask questions), or a task you can't
+yet describe completely — scope it out yourself first, then hand off the pieces.
+
+**Writing the task.** The subagent sees only the `task` string and its own system
+prompt — not your conversation. Make `task` self-contained: state the goal, the
+relevant paths/context, any constraints, and exactly what to report back. A vague
+task yields a vague report. Prefer one well-scoped task over a chain of follow-ups
+(you can't steer it once it's running).
+
+**Picking the subagent.** Match the job to a roster entry by its description; use
+`worker` (the general-purpose default) when nothing more specific fits. To browse
+what's installed and what each one does, run `/agents`. If you keep needing a
+specialist that doesn't exist, that's a cue to climb the ladder and `evolve` one
+into `~/.wizard/subagents/`.
 
 ## 3. Self-ownership: fork, then distribute
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -567,12 +567,6 @@ impl Agent {
         &self.usage
     }
 
-    /// Snapshot of all background tasks (running and finished) for the
-    /// dashboard's task list.
-    pub fn tasks(&self) -> Vec<crate::tools::tasks::Task> {
-        self.ctx.tasks.list()
-    }
-
     /// Number of background tasks (`execute` with `run_in_background`)
     /// still running, for `/status`.
     pub fn running_tasks(&self) -> usize {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1441,6 +1441,54 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<i32> {
         agent.set_plan_mode(true);
     }
 
+    // Dashboard-dispatched background session (`--bg`): register in the session
+    // registry and keep a heartbeat ticking so `/dashboard` shows it as a live
+    // "Working" row. The terminal state is written once the run ends, below.
+    let bg_stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mut bg_record: Option<crate::session_registry::SessionRecord> = None;
+    let mut bg_ticker: Option<tokio::task::JoinHandle<()>> = None;
+    if cli.bg {
+        let headline = goal
+            .lines()
+            .next()
+            .unwrap_or("background run")
+            .chars()
+            .take(48)
+            .collect::<String>();
+        let record = crate::session_registry::SessionRecord {
+            id: agent.session().id.clone(),
+            name: if headline.is_empty() {
+                "background run".to_string()
+            } else {
+                headline.clone()
+            },
+            cwd: project_root.display().to_string(),
+            model: model.clone(),
+            mode: "sovereign".to_string(),
+            state: crate::session_registry::SessionState::Working,
+            activity: format!("working: {headline}"),
+            pid: std::process::id(),
+            started_unix: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            updated_unix: 0,
+        };
+        crate::session_registry::write(&record);
+        let stop = Arc::clone(&bg_stop);
+        let ticker_record = record.clone();
+        bg_ticker = Some(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    break;
+                }
+                crate::session_registry::write(&ticker_record);
+            }
+        }));
+        bg_record = Some(record);
+    }
+
     // Busy spinner ("Conjuring…") shown while the model thinks or a tool
     // runs, hidden while output streams. Shared with the text sink; a
     // no-op when stderr is not a terminal. The structured formats never
@@ -1662,6 +1710,24 @@ pub async fn run_headless(config: Config, cli: Cli) -> Result<i32> {
         Err(err) => return Err(anyhow::anyhow!("output task panicked: {err}")),
     };
     spinner.finish();
+
+    // Background session: stop the heartbeat and record the terminal state so
+    // the dashboard shows the result (completed/failed) rather than the row
+    // vanishing. The terminal record is retained (not removed) by the registry.
+    if let Some(mut record) = bg_record.take() {
+        bg_stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(ticker) = bg_ticker.take() {
+            ticker.abort();
+        }
+        if run_error.is_some() {
+            record.state = crate::session_registry::SessionState::Failed;
+            record.activity = "failed".to_string();
+        } else {
+            record.state = crate::session_registry::SessionState::Completed;
+            record.activity = "completed".to_string();
+        }
+        crate::session_registry::write(&record);
+    }
 
     if reexec_after {
         use std::os::unix::process::CommandExt;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -121,6 +121,10 @@ pub enum AgentEvent {
     /// list; the TUI mirrors it in a side panel, headless prints a one-line
     /// summary, the gateway ignores it.
     TodoUpdated(Vec<crate::tools::todo::TodoItem>),
+    /// A background task (`execute` with `run_in_background`) was just
+    /// spawned. The TUI mirrors it into the dashboard's task list; other
+    /// surfaces ignore it.
+    TaskStarted { id: u32, command: String },
     /// A background task (`execute` with `run_in_background`) finished; its
     /// output tail was injected into history. The TUI and headless surfaces
     /// print a one-liner, the gateway ignores it.
@@ -561,6 +565,12 @@ impl Agent {
     /// Session token counters (prompt/completion totals, last prompt size).
     pub fn usage(&self) -> &crate::usage::UsageTracker {
         &self.usage
+    }
+
+    /// Snapshot of all background tasks (running and finished) for the
+    /// dashboard's task list.
+    pub fn tasks(&self) -> Vec<crate::tools::tasks::Task> {
+        self.ctx.tasks.list()
     }
 
     /// Number of background tasks (`execute` with `run_in_background`)

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -47,23 +47,52 @@ enum SessionLine {
 const MARKER_PROMPT_CHARS: usize = 120;
 
 /// Read the last `n` message lines of session `id` for the dashboard peek
-/// panel, as `(role, text)` pairs in file order. Best-effort: any error (no
-/// such session, unreadable, corrupt) yields an empty vec.
+/// panel, as `(role, text)` pairs in file order. Only the tail of the file is
+/// read (bounded by [`PEEK_TAIL_BYTES`]) so a huge transcript stays cheap to
+/// poll, and each message's text is clipped to [`PEEK_MSG_CHARS`]. Best-effort:
+/// any error (no such session, unreadable, corrupt) yields an empty vec.
 pub fn peek(id: &str, n: usize) -> Vec<(String, String)> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    /// Read at most this many bytes from the end of the session file.
+    const PEEK_TAIL_BYTES: u64 = 96 * 1024;
+    /// Clip each message's text so one huge tool result can't dominate.
+    const PEEK_MSG_CHARS: usize = 4000;
+
     let Ok(dir) = crate::config::Config::sessions_dir() else {
         return Vec::new();
     };
-    let Ok(file) = std::fs::File::open(dir.join(format!("{id}.jsonl"))) else {
+    let Ok(mut file) = std::fs::File::open(dir.join(format!("{id}.jsonl"))) else {
         return Vec::new();
     };
+    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let seeked = len > PEEK_TAIL_BYTES;
+    if seeked && file.seek(SeekFrom::Start(len - PEEK_TAIL_BYTES)).is_err() {
+        return Vec::new();
+    }
+    let mut bytes = Vec::new();
+    if file.read_to_end(&mut bytes).is_err() {
+        return Vec::new();
+    }
+    // The seek may land mid-codepoint; lossily decode and drop the first
+    // (partial) line.
+    let text = String::from_utf8_lossy(&bytes);
     let mut messages = Vec::new();
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
+    let mut lines = text.lines();
+    if seeked {
+        lines.next();
+    }
+    for line in lines {
         if line.trim().is_empty() {
             continue;
         }
-        if let Ok(SessionLine::Message(record)) = serde_json::from_str::<SessionLine>(&line) {
+        if let Ok(SessionLine::Message(record)) = serde_json::from_str::<SessionLine>(line) {
             let role = format!("{:?}", record.message.role).to_lowercase();
-            messages.push((role, record.message.content));
+            let mut content = record.message.content;
+            if content.chars().count() > PEEK_MSG_CHARS {
+                content = content.chars().take(PEEK_MSG_CHARS).collect::<String>() + " …";
+            }
+            messages.push((role, content));
         }
     }
     let start = messages.len().saturating_sub(n);

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -46,6 +46,30 @@ enum SessionLine {
 /// Cap on the prompt snippet stored in a [`TurnMarker`].
 const MARKER_PROMPT_CHARS: usize = 120;
 
+/// Read the last `n` message lines of session `id` for the dashboard peek
+/// panel, as `(role, text)` pairs in file order. Best-effort: any error (no
+/// such session, unreadable, corrupt) yields an empty vec.
+pub fn peek(id: &str, n: usize) -> Vec<(String, String)> {
+    let Ok(dir) = crate::config::Config::sessions_dir() else {
+        return Vec::new();
+    };
+    let Ok(file) = std::fs::File::open(dir.join(format!("{id}.jsonl"))) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(SessionLine::Message(record)) = serde_json::from_str::<SessionLine>(&line) {
+            let role = format!("{:?}", record.message.role).to_lowercase();
+            messages.push((role, record.message.content));
+        }
+    }
+    let start = messages.len().saturating_sub(n);
+    messages.split_off(start)
+}
+
 /// Handle to one session file. Append-only; cheap to clone the path out of.
 #[derive(Debug, Clone)]
 pub struct Session {

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -331,12 +331,32 @@ impl SpawnSubagentTool {
     ) -> Self {
         let roster = configs
             .iter()
-            .map(|c| format!("`{}` ({})", c.name, c.description))
-            .collect::<Vec<_>>()
-            .join("; ");
+            .map(|c| {
+                let scope = match &c.tool_scope {
+                    None => "all tools".to_string(),
+                    Some(names) => names.join(", "),
+                };
+                format!(
+                    "\n  - `{}` — {} (tools: {}; up to {} steps)",
+                    c.name, c.description, scope, c.max_steps
+                )
+            })
+            .collect::<String>();
         let description = format!(
-            "Delegate a self-contained sub-task to an isolated subagent with its own context \
-             and step budget. Returns the subagent's final answer. Available subagents: {roster}"
+            "Delegate a self-contained sub-task to an isolated subagent. It runs its own loop \
+             with a fresh context and scoped tools, then returns one final report — its \
+             intermediate steps never enter your context, so a multi-step sub-task costs you a \
+             single turn.\n\n\
+             Delegate when the work is self-contained, when it would otherwise flood your \
+             context with output you don't need to keep (large greps, reading many files, long \
+             logs), or when a specialist fits better than you do. Don't delegate trivial \
+             one-tool actions, work that needs the user mid-flight (the subagent can't ask \
+             questions), or a task you can't yet describe in full.\n\n\
+             `task` is the ONLY context the subagent gets besides its own prompt — make it \
+             self-contained: state the goal, the relevant paths/context, any constraints, and \
+             exactly what to report back. You can't steer it once it's running, so prefer one \
+             well-scoped task over a chain of follow-ups.\n\n\
+             Available subagents:{roster}"
         );
         Self {
             configs,

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -176,9 +176,12 @@ pub async fn spawn(
         ChatMessage::user(task.to_string()),
     ];
 
-    // Subagents share the parent's cwd and task registry but get their own
-    // todo list (their working notes must not clobber the parent's) and no
-    // event channel — their activity surfaces as one tool result.
+    // The subagent reports back to the model as one tool result, but its
+    // individual tool calls are surfaced to the UI (prefixed with the
+    // subagent's name) on the parent's event channel so the user can watch
+    // what it's doing. Nested tools run with `events: None` so they don't
+    // double-emit (todos, background tasks); we emit our own start/finish pair.
+    let progress = ctx.events.clone();
     let ctx = ToolContext {
         todos: Arc::new(std::sync::Mutex::new(crate::tools::todo::TodoList::new())),
         events: None,
@@ -252,6 +255,19 @@ pub async fn spawn(
         for call in tool_calls {
             let name = call.function.name.clone();
             let mut args = normalize_args(&call.function.arguments);
+            // Surface this call to the UI as `<subagent> ▸ <tool>` so the user
+            // sees what the subagent is doing while it runs.
+            let label = format!("{} ▸ {}", config.name, name);
+            if let Some(events) = &progress {
+                super::emit(
+                    events,
+                    crate::agent::AgentEvent::ToolStarted {
+                        name: label.clone(),
+                        args: args.clone(),
+                    },
+                )
+                .await;
+            }
             // Same hook pipeline as the parent's dispatcher: pre-hooks may
             // rewrite the arguments or veto, post-hooks may append context.
             let output = match hooks
@@ -282,6 +298,16 @@ pub async fn spawn(
                     output
                 }
             };
+            if let Some(events) = &progress {
+                super::emit(
+                    events,
+                    crate::agent::AgentEvent::ToolFinished {
+                        name: label.clone(),
+                        output: output.clone(),
+                    },
+                )
+                .await;
+            }
             let body = if output.is_error {
                 format!("Error: {}", output.content)
             } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,6 +105,9 @@ pub enum SlashCommand {
     /// `/rewind [turn]` — restore file checkpoints and truncate history.
     /// `None` opens the turn picker; `Some` rewinds to before that turn.
     Rewind(Option<u64>),
+    /// `/agents` — open the subagent roster picker (browse the available
+    /// subagents and what each does; Enter pre-fills a delegation request).
+    Agents,
     /// Toggle the git diff sidebar.
     Diff,
     /// Toggle the todo side panel.
@@ -267,6 +270,7 @@ impl SlashCommand {
                     .map(|turn| Self::Rewind(Some(turn)))
                     .map_err(|_| "usage: /rewind [turn]".to_string()),
             },
+            "agents" | "subagents" => Ok(Self::Agents),
             "diff" => Ok(Self::Diff),
             "todos" => Ok(Self::Todos),
             "cost" => Ok(Self::Cost),
@@ -338,6 +342,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "rewind",
         args: "[turn]",
         description: "rewind files and conversation to before a turn",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "agents",
+        args: "",
+        description: "browse subagents and delegate to one",
         takes_args: false,
     },
     CommandSpec {
@@ -489,6 +499,10 @@ pub enum PickerKind {
     Mode,
     /// A turn to rewind to (item values are turn ids).
     Rewind,
+    /// A subagent to delegate to (item values are subagent names). Selecting
+    /// one pre-fills the input with a delegation request rather than running a
+    /// command, since subagents are invoked by the model, not directly.
+    Subagent,
 }
 
 /// One selectable row in a picker popup.
@@ -589,7 +603,7 @@ pub struct App {
     pub custom_commands: Vec<CustomCommand>,
     /// Project root `@file` references resolve against.
     pub project_root: PathBuf,
-    /// Open selection popup (model / mode / rewind picker), if any.
+    /// Open selection popup (model / mode / rewind / subagent picker), if any.
     pub picker: Option<Picker>,
     /// Whether plan mode is active (mirrors the agent's flag for the status
     /// bar; toggled by `/plan` and Shift+Tab).
@@ -1028,6 +1042,13 @@ impl App {
                                 return Ok(None);
                             };
                             AppAction::Command(SlashCommand::Rewind(Some(turn)))
+                        }
+                        PickerKind::Subagent => {
+                            // Subagents are spawned by the model, not run as a
+                            // command. Pre-fill a delegation request so the user
+                            // just types the task and submits.
+                            self.set_input(format!("Use the {} subagent to ", item.value));
+                            return Ok(None);
                         }
                     };
                     return Ok(Some(action));
@@ -1740,6 +1761,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /genie · /sovereign         switch mode directly\n  \
 /plan                       toggle plan mode (read-only until a plan is approved)\n  \
 /rewind [turn]              rewind files and conversation to before a turn\n  \
+/agents                     browse subagents and delegate to one\n  \
 /evolve [--deep] <desc>     self-extension (skill / MCP / scripted tool)\n  \
 /publish [branch]           fork Wizard to your GitHub, get a one-line installer\n  \
 /provider [list|use|...]    add, remove, or switch LLM providers (llamacpp/ollama/openai/anthropic/openrouter/xai/xaioauth)\n  \
@@ -2181,6 +2203,7 @@ impl CommandContext<'_> {
             SlashCommand::Plan => self.toggle_plan(),
             SlashCommand::Rewind(None) => self.open_rewind_picker(),
             SlashCommand::Rewind(Some(turn)) => self.rewind(turn),
+            SlashCommand::Agents => self.open_agents_picker(),
             SlashCommand::Reload => self.reload().await,
             SlashCommand::Evolve { deep, description } => self.evolve(deep, description),
             SlashCommand::Publish { branch } => self.publish(branch),
@@ -2422,6 +2445,42 @@ impl CommandContext<'_> {
             title: " select mode ".to_string(),
             items,
             selected,
+        });
+    }
+
+    /// `/agents`: open the subagent roster picker. Lists the built-in and
+    /// user-defined subagents with their purpose, tool scope, and step budget.
+    /// Selecting one pre-fills a delegation request (subagents are spawned by
+    /// the model, so this isn't a direct command).
+    fn open_agents_picker(&mut self) {
+        let dir = Config::subagents_dir().unwrap_or_default();
+        let configs = subagent::available_configs(&dir);
+        if configs.is_empty() {
+            self.app.notice("no subagents available");
+            return;
+        }
+        let items: Vec<PickerItem> = configs
+            .into_iter()
+            .map(|config| {
+                let scope = match &config.tool_scope {
+                    None => "all tools".to_string(),
+                    Some(names) => names.join(", "),
+                };
+                PickerItem {
+                    detail: format!(
+                        "{} · {scope} · {} steps",
+                        config.description, config.max_steps
+                    ),
+                    value: config.name,
+                    current: false,
+                }
+            })
+            .collect();
+        self.app.picker = Some(Picker {
+            kind: PickerKind::Subagent,
+            title: " delegate to subagent ".to_string(),
+            items,
+            selected: 0,
         });
     }
 
@@ -3476,6 +3535,48 @@ mod tests {
         let action = press(&mut app, KeyCode::Esc);
         assert!(action.is_none());
         assert!(app.picker.is_none(), "Esc closed the picker");
+    }
+
+    #[test]
+    fn agents_and_subagents_parse_to_the_agents_command() {
+        assert!(matches!(
+            SlashCommand::parse("/agents"),
+            Some(Ok(SlashCommand::Agents))
+        ));
+        assert!(matches!(
+            SlashCommand::parse("/subagents"),
+            Some(Ok(SlashCommand::Agents))
+        ));
+    }
+
+    #[test]
+    fn subagent_picker_selection_prefills_a_delegation_request() {
+        let mut app = app();
+        app.picker = Some(Picker {
+            kind: PickerKind::Subagent,
+            title: " delegate to subagent ".to_string(),
+            items: vec![
+                PickerItem {
+                    value: "worker".to_string(),
+                    detail: "general-purpose".to_string(),
+                    current: false,
+                },
+                PickerItem {
+                    value: "reviewer".to_string(),
+                    detail: "code review".to_string(),
+                    current: false,
+                },
+            ],
+            selected: 0,
+        });
+        press(&mut app, KeyCode::Down);
+        let action = press(&mut app, KeyCode::Enter);
+        // Subagents are model-invoked, so Enter pre-fills input instead of
+        // emitting a command.
+        assert!(action.is_none());
+        assert!(app.picker.is_none(), "the picker closed");
+        assert_eq!(app.input, "Use the reviewer subagent to ");
+        assert_eq!(app.cursor, app.input.chars().count());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -626,6 +626,9 @@ pub struct App {
     /// Dispatch input at the bottom of the dashboard (the prompt for a new
     /// background session).
     pub dashboard_input: String,
+    /// Recent transcript of the selected session (role, text), shown in the
+    /// dashboard's peek panel; refreshed as the selection moves.
+    pub peek_lines: Vec<(String, String)>,
     /// Transcript scroll offset from the bottom (0 = pinned to latest).
     pub scroll: u16,
     pub should_quit: bool,
@@ -707,6 +710,7 @@ impl App {
             sessions: Vec::new(),
             dashboard_selected: 0,
             dashboard_input: String::new(),
+            peek_lines: Vec::new(),
             scroll: 0,
             should_quit: false,
             tick: 0,
@@ -790,12 +794,21 @@ impl App {
     }
 
     /// Reload the live-session list from the registry, keeping the selection
-    /// in range.
+    /// in range, and refresh the peek panel for the selected row.
     pub fn refresh_sessions(&mut self) {
         self.sessions = session_registry::list();
         if self.dashboard_selected >= self.sessions.len() {
             self.dashboard_selected = self.sessions.len().saturating_sub(1);
         }
+        self.refresh_peek();
+    }
+
+    /// Reload the peek panel with the selected session's recent transcript.
+    fn refresh_peek(&mut self) {
+        self.peek_lines = match self.sessions.get(self.dashboard_selected) {
+            Some(session) => crate::agent::session::peek(&session.id, 80),
+            None => Vec::new(),
+        };
     }
 
     /// Spawn a detached background session for `prompt`: a headless sovereign
@@ -871,6 +884,7 @@ impl App {
             _ if self.dashboard_selected >= last => 0,
             _ => self.dashboard_selected + 1,
         };
+        self.refresh_peek();
     }
 
     /// Recompute [`InputMode`] from the input text, then refresh the command

--- a/src/app.rs
+++ b/src/app.rs
@@ -108,6 +108,9 @@ pub enum SlashCommand {
     /// `/agents` — open the subagent roster picker (browse the available
     /// subagents and what each does; Enter pre-fills a delegation request).
     Agents,
+    /// `/subagents` — toggle the in-session subagent monitor: the subagents
+    /// that have run (or are running) this session, with live status.
+    Subagents,
     /// Toggle the git diff sidebar.
     Diff,
     /// Toggle the todo side panel.
@@ -273,7 +276,8 @@ impl SlashCommand {
                     .map(|turn| Self::Rewind(Some(turn)))
                     .map_err(|_| "usage: /rewind [turn]".to_string()),
             },
-            "agents" | "subagents" => Ok(Self::Agents),
+            "agents" => Ok(Self::Agents),
+            "subagents" => Ok(Self::Subagents),
             "diff" => Ok(Self::Diff),
             "todos" => Ok(Self::Todos),
             "dashboard" => Ok(Self::Dashboard),
@@ -352,6 +356,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "agents",
         args: "",
         description: "browse subagents and delegate to one",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "subagents",
+        args: "",
+        description: "monitor the subagents running in this session",
         takes_args: false,
     },
     CommandSpec {
@@ -608,6 +618,8 @@ pub struct App {
     todos_seen: bool,
     /// Full-screen agent dashboard visibility (toggled by `/dashboard`).
     pub show_dashboard: bool,
+    /// In-session subagent monitor visibility (toggled by `/subagents`).
+    pub show_subagents: bool,
     /// Background tasks mirrored from [`AgentEvent::TaskStarted`] /
     /// [`AgentEvent::TaskFinished`], newest last, for the dashboard.
     pub bg_tasks: Vec<BgTask>,
@@ -685,6 +697,7 @@ impl App {
             todos: Vec::new(),
             todos_seen: false,
             show_dashboard: false,
+            show_subagents: false,
             bg_tasks: Vec::new(),
             scroll: 0,
             should_quit: false,
@@ -1018,12 +1031,13 @@ impl App {
             }
         }
 
-        // The dashboard is a modal view: while it's open, Esc / Enter / q
-        // close it and other keys are swallowed (global chords above still
-        // work). The view itself refreshes from live App state every frame.
-        if self.show_dashboard {
+        // The dashboard and subagent monitor are modal views: while one is
+        // open, Esc / Enter / q close it and other keys are swallowed (global
+        // chords above still work). They refresh from live App state each frame.
+        if self.show_dashboard || self.show_subagents {
             if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
                 self.show_dashboard = false;
+                self.show_subagents = false;
             }
             return Ok(None);
         }
@@ -1816,6 +1830,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /plan                       toggle plan mode (read-only until a plan is approved)\n  \
 /rewind [turn]              rewind files and conversation to before a turn\n  \
 /agents                     browse subagents and delegate to one\n  \
+/subagents                  monitor the subagents running in this session\n  \
 /evolve [--deep] <desc>     self-extension (skill / MCP / scripted tool)\n  \
 /publish [branch]           fork Wizard to your GitHub, get a one-line installer\n  \
 /provider [list|use|...]    add, remove, or switch LLM providers (llamacpp/ollama/openai/anthropic/openrouter/xai/xaioauth)\n  \
@@ -2247,6 +2262,7 @@ impl CommandContext<'_> {
             SlashCommand::Diff => self.toggle_diff().await,
             SlashCommand::Todos => self.toggle_todos(),
             SlashCommand::Dashboard => self.toggle_dashboard(),
+            SlashCommand::Subagents => self.toggle_subagents(),
             SlashCommand::Cost => self.cost(),
             SlashCommand::Memory => self.memory(),
             SlashCommand::Doctor => self.doctor().await,
@@ -2324,6 +2340,15 @@ impl CommandContext<'_> {
                 }
             }
             self.app.bg_tasks.sort_by_key(|t| t.id);
+        }
+    }
+
+    /// `/subagents`: toggle the in-session subagent monitor.
+    fn toggle_subagents(&mut self) {
+        self.app.show_subagents = !self.app.show_subagents;
+        // Mutually exclusive with the dashboard so only one modal is up.
+        if self.app.show_subagents {
+            self.app.show_dashboard = false;
         }
     }
 
@@ -3617,14 +3642,16 @@ mod tests {
     }
 
     #[test]
-    fn agents_and_subagents_parse_to_the_agents_command() {
+    fn agents_and_subagents_parse_to_distinct_commands() {
+        // /agents opens the roster picker; /subagents opens the in-session
+        // monitor — they are no longer aliases.
         assert!(matches!(
             SlashCommand::parse("/agents"),
             Some(Ok(SlashCommand::Agents))
         ));
         assert!(matches!(
             SlashCommand::parse("/subagents"),
-            Some(Ok(SlashCommand::Agents))
+            Some(Ok(SlashCommand::Subagents))
         ));
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2151,8 +2151,11 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
         .filter(|line| !line.is_empty())
         .map(|line| line.chars().take(48).collect::<String>())
         .unwrap_or_else(|| {
-            let short: String = session_id.chars().take(8).collect();
-            format!("session {short}")
+            // No prompt: name the session after its working directory.
+            project_root
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "session".to_string())
         });
 
     let mut app = App::new(config);

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ use crate::llm::provider::LlmProvider;
 use crate::mcp::{McpConfig, McpManager};
 use crate::memory::MemoryStore;
 use crate::server;
+use crate::session_registry::{self, SessionRecord, SessionState};
 use crate::skills::Skill;
 use crate::tools::registry::ToolRegistry;
 use crate::tools::todo::TodoItem;
@@ -115,8 +116,8 @@ pub enum SlashCommand {
     Diff,
     /// Toggle the todo side panel.
     Todos,
-    /// Toggle the full-screen agent dashboard (session, in-flight tools and
-    /// subagents, todos, background tasks, subagent roster).
+    /// Toggle the machine-wide session manager: every live Wizard session on
+    /// the machine, grouped by state.
     Dashboard,
     /// Show session token usage (and cost when rates are configured).
     Cost,
@@ -409,7 +410,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "dashboard",
         args: "",
-        description: "toggle the agent dashboard (tasks, subagents, todos)",
+        description: "session manager: all live wizard sessions on this machine",
         takes_args: false,
     },
     CommandSpec {
@@ -546,15 +547,6 @@ pub struct Picker {
     pub selected: usize,
 }
 
-/// A background task as mirrored into the dashboard. Built from
-/// [`AgentEvent::TaskStarted`] and updated by [`AgentEvent::TaskFinished`].
-#[derive(Debug, Clone)]
-pub struct BgTask {
-    pub id: u32,
-    pub command: String,
-    pub status: crate::tools::tasks::TaskStatus,
-}
-
 /// In-flight plan review (plan mode): the model called `exit_plan` and the
 /// turn is paused inside the tool until a [`PlanVerdict`] is sent back.
 #[derive(Debug)]
@@ -620,9 +612,17 @@ pub struct App {
     pub show_dashboard: bool,
     /// In-session subagent monitor visibility (toggled by `/subagents`).
     pub show_subagents: bool,
-    /// Background tasks mirrored from [`AgentEvent::TaskStarted`] /
-    /// [`AgentEvent::TaskFinished`], newest last, for the dashboard.
-    pub bg_tasks: Vec<BgTask>,
+    /// This session's id (heartbeat filename + dashboard identity).
+    pub session_id: String,
+    /// This session's display name (from the first prompt, or the id).
+    pub session_name: String,
+    /// Unix start time, stamped once at registration.
+    pub session_started_unix: u64,
+    /// Live sessions on the machine, refreshed from the registry while the
+    /// dashboard is open.
+    pub sessions: Vec<SessionRecord>,
+    /// Selected row in the dashboard list.
+    pub dashboard_selected: usize,
     /// Transcript scroll offset from the bottom (0 = pinned to latest).
     pub scroll: u16,
     pub should_quit: bool,
@@ -698,7 +698,11 @@ impl App {
             todos_seen: false,
             show_dashboard: false,
             show_subagents: false,
-            bg_tasks: Vec::new(),
+            session_id: String::new(),
+            session_name: String::new(),
+            session_started_unix: 0,
+            sessions: Vec::new(),
+            dashboard_selected: 0,
             scroll: 0,
             should_quit: false,
             tick: 0,
@@ -731,6 +735,78 @@ impl App {
     pub fn notice(&mut self, message: impl Into<String>) {
         self.transcript
             .push(TranscriptEntry::Notice(message.into()));
+    }
+
+    /// Current state for this session's heartbeat: needs-input when paused on a
+    /// plan review, working while a turn streams, otherwise idle.
+    fn session_state(&self) -> SessionState {
+        if self.plan_review.is_some() {
+            SessionState::NeedsInput
+        } else if self.status.busy {
+            SessionState::Working
+        } else {
+            SessionState::Idle
+        }
+    }
+
+    /// One-line summary of what this session is doing, for the dashboard row.
+    fn session_activity(&self) -> String {
+        if self.plan_review.is_some() {
+            return "waiting for plan approval".to_string();
+        }
+        if !self.status.busy {
+            return "idle".to_string();
+        }
+        // The newest in-flight tool call reads best; fall back to the verb.
+        for entry in self.transcript.iter().rev() {
+            if let TranscriptEntry::ToolCard {
+                name, output: None, ..
+            } = entry
+            {
+                return name.clone();
+            }
+        }
+        format!("{}…", self.spinner_verb)
+    }
+
+    /// Build this session's heartbeat record from current state.
+    pub fn session_record(&self) -> SessionRecord {
+        SessionRecord {
+            id: self.session_id.clone(),
+            name: self.session_name.clone(),
+            cwd: self.project_root.display().to_string(),
+            model: self.status.model.clone(),
+            mode: self.mode.to_string(),
+            state: self.session_state(),
+            activity: self.session_activity(),
+            pid: std::process::id(),
+            started_unix: self.session_started_unix,
+            updated_unix: 0, // stamped by session_registry::write
+        }
+    }
+
+    /// Reload the live-session list from the registry, keeping the selection
+    /// in range.
+    pub fn refresh_sessions(&mut self) {
+        self.sessions = session_registry::list();
+        if self.dashboard_selected >= self.sessions.len() {
+            self.dashboard_selected = self.sessions.len().saturating_sub(1);
+        }
+    }
+
+    /// Move the dashboard selection up/down, clamped to the session list.
+    fn dashboard_select(&mut self, delta: isize) {
+        let len = self.sessions.len();
+        if len == 0 {
+            self.dashboard_selected = 0;
+            return;
+        }
+        let last = len - 1;
+        self.dashboard_selected = match delta {
+            d if d < 0 => self.dashboard_selected.checked_sub(1).unwrap_or(last),
+            _ if self.dashboard_selected >= last => 0,
+            _ => self.dashboard_selected + 1,
+        };
     }
 
     /// Recompute [`InputMode`] from the input text, then refresh the command
@@ -958,6 +1034,10 @@ impl App {
             Event::Resize(_, _) => Ok(None),
             Event::Tick => {
                 self.tick = self.tick.wrapping_add(1);
+                // Keep the dashboard's session list current while it's open.
+                if self.show_dashboard && self.tick.is_multiple_of(4) {
+                    self.refresh_sessions();
+                }
                 Ok(None)
             }
             Event::Agent(agent_event) => {
@@ -1031,12 +1111,22 @@ impl App {
             }
         }
 
-        // The dashboard and subagent monitor are modal views: while one is
-        // open, Esc / Enter / q close it and other keys are swallowed (global
-        // chords above still work). They refresh from live App state each frame.
-        if self.show_dashboard || self.show_subagents {
+        // The dashboard is modal: ↑/↓ move the selection, Esc/q close it.
+        // (Enter will attach in a later milestone; it's a no-op for now.)
+        if self.show_dashboard {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => self.show_dashboard = false,
+                KeyCode::Up | KeyCode::BackTab => self.dashboard_select(-1),
+                KeyCode::Down | KeyCode::Tab => self.dashboard_select(1),
+                _ => {}
+            }
+            return Ok(None);
+        }
+
+        // The subagent monitor is modal too: Esc / Enter / q close it; other
+        // keys are swallowed. It refreshes from live App state each frame.
+        if self.show_subagents {
             if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
-                self.show_dashboard = false;
                 self.show_subagents = false;
             }
             return Ok(None);
@@ -1518,29 +1608,14 @@ impl App {
                 self.status.prompt_tokens += prompt_tokens;
                 self.status.completion_tokens += completion_tokens;
             }
-            AgentEvent::TaskStarted { id, command } => {
-                self.bg_tasks.push(BgTask {
-                    id,
-                    command,
-                    status: crate::tools::tasks::TaskStatus::Running,
-                });
-            }
+            // TaskStarted is mirrored to the gateway's JSON stream (see
+            // output.rs); the TUI surfaces only the finish notice.
+            AgentEvent::TaskStarted { .. } => {}
             AgentEvent::TaskFinished {
                 id,
                 command,
                 status,
             } => {
-                // Update the mirrored task (or record it if we never saw the
-                // start) so the dashboard reflects the final state.
-                if let Some(task) = self.bg_tasks.iter_mut().find(|t| t.id == id) {
-                    task.status = status;
-                } else {
-                    self.bg_tasks.push(BgTask {
-                        id,
-                        command: command.clone(),
-                        status,
-                    });
-                }
                 self.notice(format!(
                     "background task #{id} finished ({}): {command}",
                     status.describe()
@@ -1839,7 +1914,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /reload                     reload skills, scripted tools, and MCP servers\n  \
 /diff                       toggle the git diff sidebar\n  \
 /todos                      toggle the todo side panel\n  \
-/dashboard                  toggle the agent dashboard (tasks, subagents, todos)\n  \
+/dashboard                  session manager: all live wizard sessions on this machine\n  \
 /cost                       show session token usage and cost\n  \
 /memory                     show saved project memories\n  \
 /status                     show session status (model, usage, todos, tasks)\n  \
@@ -2063,9 +2138,34 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
     // sovereign in-session.
     let genie_max_steps = config.max_steps;
 
+    // Identity for this session's dashboard heartbeat.
+    let session_id = agent_slot
+        .as_ref()
+        .map(|agent| agent.session().id.clone())
+        .unwrap_or_default();
+    let session_name = cli
+        .prompt
+        .as_deref()
+        .and_then(|prompt| prompt.lines().next())
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .map(|line| line.chars().take(48).collect::<String>())
+        .unwrap_or_else(|| {
+            let short: String = session_id.chars().take(8).collect();
+            format!("session {short}")
+        });
+
     let mut app = App::new(config);
     app.project_root = project_root.clone();
     app.custom_commands = crate::commands::load(&project_root);
+    app.session_id = session_id.clone();
+    app.session_name = session_name;
+    app.session_started_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Register this session so other sessions' /dashboard can see it.
+    crate::session_registry::write(&app.session_record());
     if let Some(prompt) = cli.prompt.clone() {
         app.set_input(prompt);
     }
@@ -2089,8 +2189,16 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
     let mut terminal = setup_terminal()?;
     let _guard = TerminalGuard;
 
+    let mut last_heartbeat = Instant::now();
+
     loop {
         terminal.draw(|frame| crate::ui::draw(frame, &app))?;
+
+        // Refresh this session's heartbeat so other dashboards see it live.
+        if last_heartbeat.elapsed() >= Duration::from_secs(3) {
+            session_registry::write(&app.session_record());
+            last_heartbeat = Instant::now();
+        }
 
         let Some(event) = events.next().await else {
             break;
@@ -2234,6 +2342,9 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
         agent.fire_session_end(None).await;
     }
 
+    // Drop this session's heartbeat so it leaves the dashboard immediately.
+    session_registry::remove(&app.session_id);
+
     drop(_guard);
     restore_terminal_best_effort();
     Ok(0)
@@ -2320,26 +2431,14 @@ impl CommandContext<'_> {
         }
     }
 
-    /// `/dashboard`: toggle the full-screen agent view. When opening while the
-    /// agent is idle, refresh the background-task mirror from the live registry
-    /// so tasks spawned before the dashboard was first shown still appear.
+    /// `/dashboard`: toggle the machine-wide session manager. On open, refresh
+    /// the live-session list from the registry; the event loop keeps it current
+    /// while it's up.
     fn toggle_dashboard(&mut self) {
         self.app.show_dashboard = !self.app.show_dashboard;
-        if self.app.show_dashboard
-            && let Some(agent) = self.agent_slot.as_ref()
-        {
-            for task in agent.tasks() {
-                if let Some(existing) = self.app.bg_tasks.iter_mut().find(|t| t.id == task.id) {
-                    existing.status = task.status;
-                } else {
-                    self.app.bg_tasks.push(BgTask {
-                        id: task.id,
-                        command: task.command,
-                        status: task.status,
-                    });
-                }
-            }
-            self.app.bg_tasks.sort_by_key(|t| t.id);
+        if self.app.show_dashboard {
+            self.app.show_subagents = false;
+            self.app.refresh_sessions();
         }
     }
 
@@ -3694,29 +3793,48 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_mirrors_background_tasks_and_esc_closes() {
-        use crate::tools::tasks::TaskStatus;
+    fn dashboard_navigates_and_esc_closes() {
+        use crate::session_registry::{SessionRecord, SessionState};
         let mut app = app();
-        app.handle_agent_event(AgentEvent::TaskStarted {
-            id: 1,
-            command: "sleep 5".to_string(),
-        });
-        assert_eq!(app.bg_tasks.len(), 1);
-        assert_eq!(app.bg_tasks[0].status, TaskStatus::Running);
-
-        // Finishing updates the existing row rather than adding a new one.
-        app.handle_agent_event(AgentEvent::TaskFinished {
-            id: 1,
-            command: "sleep 5".to_string(),
-            status: TaskStatus::Done(0),
-        });
-        assert_eq!(app.bg_tasks.len(), 1);
-        assert_eq!(app.bg_tasks[0].status, TaskStatus::Done(0));
-
-        // The dashboard is modal: Esc closes it.
+        let make = |id: &str, state: SessionState| SessionRecord {
+            id: id.to_string(),
+            name: id.to_string(),
+            cwd: "/tmp".to_string(),
+            model: "m".to_string(),
+            mode: "genie".to_string(),
+            state,
+            activity: String::new(),
+            pid: 1,
+            started_unix: 0,
+            updated_unix: 0,
+        };
+        app.sessions = vec![
+            make("a", SessionState::Working),
+            make("b", SessionState::Idle),
+        ];
         app.show_dashboard = true;
+
+        // ↓ moves the selection and wraps; ↑ wraps back.
+        press(&mut app, KeyCode::Down);
+        assert_eq!(app.dashboard_selected, 1);
+        press(&mut app, KeyCode::Down);
+        assert_eq!(app.dashboard_selected, 0, "wraps to the top");
+        press(&mut app, KeyCode::Up);
+        assert_eq!(app.dashboard_selected, 1, "wraps to the bottom");
+
+        // Esc closes the modal.
         press(&mut app, KeyCode::Esc);
         assert!(!app.show_dashboard);
+    }
+
+    #[test]
+    fn session_record_reflects_state() {
+        let mut app = app();
+        app.session_id = "sess-1".to_string();
+        app.session_name = "fix bug".to_string();
+        assert_eq!(app.session_record().state, SessionState::Idle);
+        app.status.busy = true;
+        assert_eq!(app.session_record().state, SessionState::Working);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ use crate::config::{Config, Mode, ProviderConfig, ProviderKind};
 use crate::event::{Event, EventLoop};
 use crate::evolve::{EvolveOutcome, EvolveRequest, EvolveTier, Evolver, PublishRequest, publish};
 use crate::hooks::HookEngine;
+use crate::import_claude::{self, ImportSelection};
 use crate::llm::provider::LlmProvider;
 use crate::mcp::{McpConfig, McpManager};
 use crate::memory::MemoryStore;
@@ -139,6 +140,12 @@ pub enum SlashCommand {
     /// `/login <provider>`: OAuth sign-in for providers that support it
     /// (currently `xai`).
     Login(String),
+    /// `/settings` — open the in-app settings menu (a reusable picker).
+    Settings,
+    /// Import the selected artifacts from Claude Code (`~/.claude/`). Not a
+    /// typed command; dispatched from the `/settings` import picker, which is
+    /// why it carries the [`ImportSelection`].
+    ImportClaude(ImportSelection),
     Quit,
 }
 
@@ -295,6 +302,7 @@ impl SlashCommand {
                 Some(provider) => Ok(Self::Login((*provider).to_string())),
                 None => Err("usage: /login xai".to_string()),
             },
+            "settings" => Ok(Self::Settings),
             "quit" | "q" | "exit" => Ok(Self::Quit),
             other => Err(format!("unknown command '/{other}' — try /help")),
         };
@@ -432,6 +440,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        name: "settings",
+        args: "",
+        description: "open the settings menu (change config anytime)",
+        takes_args: false,
+    },
+    CommandSpec {
         name: "doctor",
         args: "",
         description: "diagnose config, providers, MCP, hooks, state dirs",
@@ -524,6 +538,12 @@ pub enum PickerKind {
     /// one pre-fills the input with a delegation request rather than running a
     /// command, since subagents are invoked by the model, not directly.
     Subagent,
+    /// The settings menu. Rows are dispatched by index against
+    /// [`App::settings_rows`]; toggles mutate config inline and re-open.
+    Settings,
+    /// "Import from Claude Code": a multi-select where Space toggles a row
+    /// (MCP servers / commands / spinner verbs) and Enter runs the import.
+    ClaudeImport,
 }
 
 /// One selectable row in a picker popup.
@@ -673,6 +693,10 @@ pub struct App {
     /// Number of verb rolls so far, mixed into the roll seed so back-to-back
     /// turns starting on the same tick still draw fresh verbs.
     verb_rolls: u64,
+    /// Set by the `/settings` "Open config file" row; the main loop (which owns
+    /// the terminal) suspends the TUI, opens `$EDITOR` on the config file, then
+    /// reloads config. Cleared once handled.
+    pub pending_edit_config: bool,
 }
 
 impl App {
@@ -731,6 +755,7 @@ impl App {
             rebuilding: None,
             spinner_verb,
             verb_rolls: 0,
+            pending_edit_config: false,
         }
     }
 
@@ -746,6 +771,176 @@ impl App {
     pub fn notice(&mut self, message: impl Into<String>) {
         self.transcript
             .push(TranscriptEntry::Notice(message.into()));
+    }
+
+    /// The settings menu rows, in display order: `(action id, label, current
+    /// value)`. [`open_settings_picker`](Self::open_settings_picker) renders
+    /// the label/value and [`apply_setting`](Self::apply_setting) dispatches by
+    /// the row index, so both share this single ordered source of truth.
+    ///
+    /// Numeric/list fields (`max_steps`, retry/compaction knobs, spinner verbs,
+    /// gateway, …) are intentionally absent — the overlay has no text input, so
+    /// they live behind the "Open config file" row.
+    fn settings_rows(&self) -> Vec<(&'static str, String, String)> {
+        let on = |b: bool| if b { "on" } else { "off" }.to_string();
+        let providers = self.config.providers.len();
+        let import_detail = if import_claude::claude_home().is_some() {
+            "MCP servers, commands, spinner verbs".to_string()
+        } else {
+            "no ~/.claude found".to_string()
+        };
+        let config_path = Config::path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "~/.wizard/config.toml".to_string());
+        vec![
+            ("model", "Model".to_string(), self.config.active().model),
+            ("mode", "Mode".to_string(), self.mode.to_string()),
+            (
+                "plan_first",
+                "Plan mode at startup".to_string(),
+                on(self.config.plan_first),
+            ),
+            (
+                "continuous",
+                "Continuous (sovereign)".to_string(),
+                on(self.config.continuous),
+            ),
+            (
+                "plan_each_cycle",
+                "Plan each cycle".to_string(),
+                on(self.config.plan_each_cycle),
+            ),
+            (
+                "rollback",
+                "Rollback failed cycles".to_string(),
+                on(self.config.rollback_failed_cycles),
+            ),
+            (
+                "web_backend",
+                "Web search backend".to_string(),
+                self.config.web.search_backend.clone(),
+            ),
+            (
+                "web_allow_local",
+                "Web: allow localhost".to_string(),
+                on(self.config.web.allow_local),
+            ),
+            (
+                "fleet_synthesize",
+                "Fleet: synthesis turn".to_string(),
+                on(self.config.fleet.synthesize),
+            ),
+            ("import", "Import from Claude Code".to_string(), import_detail),
+            (
+                "provider",
+                "Manage providers…".to_string(),
+                format!("{providers} configured"),
+            ),
+            ("config_file", "Open config file…".to_string(), config_path),
+        ]
+    }
+
+    /// Open the `/settings` menu as a [`Picker`]. Re-callable: toggles re-open
+    /// it so the new value is visible.
+    pub fn open_settings_picker(&mut self) {
+        let items: Vec<PickerItem> = self
+            .settings_rows()
+            .into_iter()
+            .map(|(_, label, detail)| PickerItem {
+                value: label,
+                detail,
+                current: false,
+            })
+            .collect();
+        self.picker = Some(Picker {
+            kind: PickerKind::Settings,
+            title: " settings · ↑/↓ move · enter select · esc close ".to_string(),
+            items,
+            selected: 0,
+        });
+    }
+
+    /// Dispatch the settings row at `selected`. Routing rows return an
+    /// [`AppAction`] to run a command; inline toggle/cycle rows mutate config,
+    /// persist, and re-open the menu (keeping the cursor on the same row).
+    fn apply_setting(&mut self, selected: usize) -> Option<AppAction> {
+        let rows = self.settings_rows();
+        let (id, _, _) = rows.get(selected)?;
+        match *id {
+            "model" => return Some(AppAction::Command(SlashCommand::Model(None))),
+            "mode" => return Some(AppAction::Command(SlashCommand::Mode(None))),
+            "provider" => {
+                return Some(AppAction::Command(SlashCommand::Provider(
+                    ProviderAction::List,
+                )));
+            }
+            "import" => {
+                self.open_claude_import_picker();
+                return None;
+            }
+            "config_file" => {
+                // Handled by the main loop, which owns the terminal.
+                self.pending_edit_config = true;
+                return None;
+            }
+            "plan_first" => self.config.plan_first = !self.config.plan_first,
+            "continuous" => self.config.continuous = !self.config.continuous,
+            "plan_each_cycle" => self.config.plan_each_cycle = !self.config.plan_each_cycle,
+            "rollback" => {
+                self.config.rollback_failed_cycles = !self.config.rollback_failed_cycles;
+            }
+            "web_allow_local" => self.config.web.allow_local = !self.config.web.allow_local,
+            "fleet_synthesize" => self.config.fleet.synthesize = !self.config.fleet.synthesize,
+            "web_backend" => {
+                self.config.web.search_backend = cycle_backend(&self.config.web.search_backend);
+            }
+            _ => return None,
+        }
+        // Inline change: persist and re-open, restoring the cursor so repeated
+        // toggles stay on the same row. (These flags take effect at the next
+        // cycle / startup, not mid-session.)
+        if let Err(err) = self.config.save() {
+            self.notice(format!("could not save config: {err:#}"));
+        }
+        self.open_settings_picker();
+        if let Some(picker) = self.picker.as_mut() {
+            picker.selected = selected.min(picker.items.len().saturating_sub(1));
+        }
+        None
+    }
+
+    /// Open the "import from Claude Code" multi-select. Each row is a toggleable
+    /// artifact (Space toggles, Enter runs); order is mcp / commands / verbs to
+    /// match the [`ImportSelection`] built in the Enter handler.
+    fn open_claude_import_picker(&mut self) {
+        if import_claude::claude_home().is_none() {
+            self.notice("no Claude Code install found (~/.claude)");
+            return;
+        }
+        let (mcp, commands, verbs) = import_claude::counts();
+        let items = vec![
+            PickerItem {
+                value: format!("MCP servers ({mcp})"),
+                detail: "merge into ~/.wizard/mcp.toml".to_string(),
+                current: false,
+            },
+            PickerItem {
+                value: format!("Custom commands ({commands})"),
+                detail: "copy into ~/.wizard/commands/".to_string(),
+                current: false,
+            },
+            PickerItem {
+                value: format!("Spinner verbs ({verbs})"),
+                detail: "adopt Claude Code's spinner verbs".to_string(),
+                current: false,
+            },
+        ];
+        self.picker = Some(Picker {
+            kind: PickerKind::ClaudeImport,
+            title: " import from claude code · space toggles · enter runs ".to_string(),
+            items,
+            selected: 0,
+        });
     }
 
     /// Current state for this session's heartbeat: needs-input when paused on a
@@ -1289,6 +1484,12 @@ impl App {
                         picker.selected + 1
                     };
                 }
+                // Space toggles a checkbox row in the Claude-import multi-select.
+                KeyCode::Char(' ') if picker.kind == PickerKind::ClaudeImport => {
+                    if let Some(item) = picker.items.get_mut(picker.selected) {
+                        item.current = !item.current;
+                    }
+                }
                 KeyCode::Esc => {
                     self.picker = None;
                 }
@@ -1322,6 +1523,28 @@ impl App {
                             // just types the task and submits.
                             self.set_input(format!("Use the {} subagent to ", item.value));
                             return Ok(None);
+                        }
+                        PickerKind::Settings => {
+                            let selected = picker.selected;
+                            return Ok(self.apply_setting(selected));
+                        }
+                        PickerKind::ClaudeImport => {
+                            // Build the selection from the toggled rows (order
+                            // matches `open_claude_import_picker`: mcp, commands,
+                            // verbs) and hand off to the command handler, which
+                            // has the live MCP manager.
+                            let flags: Vec<bool> =
+                                picker.items.iter().map(|i| i.current).collect();
+                            let selection = ImportSelection {
+                                mcp: flags.first().copied().unwrap_or(false),
+                                commands: flags.get(1).copied().unwrap_or(false),
+                                verbs: flags.get(2).copied().unwrap_or(false),
+                            };
+                            if selection.is_empty() {
+                                self.notice("nothing selected to import");
+                                return Ok(None);
+                            }
+                            AppAction::Command(SlashCommand::ImportClaude(selection))
                         }
                     };
                     return Ok(Some(action));
@@ -1816,6 +2039,70 @@ fn setup_terminal() -> Result<Tui> {
     Terminal::new(CrosstermBackend::new(stdout)).context("creating terminal")
 }
 
+/// Suspend the TUI, open `$VISUAL`/`$EDITOR` on `~/.wizard/config.toml`, then
+/// restore the TUI and reload the edited config. Driven by the `/settings`
+/// "Open config file" row; runs from the main loop because it owns `terminal`.
+/// Falls back to a path notice when no editor is configured.
+fn edit_config_file(app: &mut App, terminal: &mut Tui) {
+    let path = match Config::path() {
+        Ok(path) => path,
+        Err(err) => {
+            app.notice(format!("could not locate config: {err:#}"));
+            return;
+        }
+    };
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_default();
+    if editor.trim().is_empty() {
+        app.notice(format!(
+            "no $EDITOR set — edit {} by hand, then /reload",
+            path.display()
+        ));
+        return;
+    }
+
+    // Leave the alternate screen so the editor draws on the real terminal.
+    if let Err(err) = restore_terminal() {
+        app.notice(format!("could not suspend the TUI: {err:#}"));
+        return;
+    }
+    // `sh -c` so editors with flags ("code --wait", "emacsclient -t") work.
+    let status = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("{editor} \"{}\"", path.display()))
+        .status();
+
+    // Re-enter the TUI regardless of how the editor exited.
+    match setup_terminal() {
+        Ok(new_terminal) => {
+            *terminal = new_terminal;
+            let _ = terminal.clear();
+        }
+        Err(err) => {
+            app.notice(format!("could not restore the TUI: {err:#} — /quit and relaunch"));
+            return;
+        }
+    }
+
+    match status {
+        Ok(status) if status.success() => match Config::load() {
+            Ok(config) => {
+                app.config = config;
+                app.mode = app.config.mode;
+                app.status.mode = app.config.mode;
+                app.status.model = app.config.active().model;
+                app.notice(
+                    "config reloaded — restart for provider/model changes to take effect",
+                );
+            }
+            Err(err) => app.notice(format!("config not reloaded (parse error): {err:#}")),
+        },
+        Ok(_) => app.notice("editor exited without success — config not reloaded"),
+        Err(err) => app.notice(format!("could not launch editor: {err:#}")),
+    }
+}
+
 fn restore_terminal() -> Result<()> {
     crossterm::execute!(
         std::io::stdout(),
@@ -2054,6 +2341,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /cost                       show session token usage and cost\n  \
 /memory                     show saved project memories\n  \
 /status                     show session status (model, usage, todos, tasks)\n  \
+/settings                   open the settings menu (change config anytime)\n  \
 /doctor                     diagnose config, providers, MCP, hooks, state dirs\n  \
 /quit                       exit\n\
 keys:\n  \
@@ -2072,6 +2360,17 @@ Ctrl-C                      quit";
 /// True for backends that run on this machine (no API key, no cloud).
 fn is_local_kind(kind: ProviderKind) -> bool {
     matches!(kind, ProviderKind::LlamaCpp | ProviderKind::Ollama)
+}
+
+/// Rotate the `web_search` backend for the settings menu's cycle row:
+/// duckduckgo → brave → tavily → duckduckgo.
+fn cycle_backend(current: &str) -> String {
+    match current {
+        "duckduckgo" => "brave",
+        "brave" => "tavily",
+        _ => "duckduckgo",
+    }
+    .to_string()
 }
 
 /// Build `provider`'s client and prove it usable: for local llama.cpp this
@@ -2478,6 +2777,13 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
             }
         }
 
+        // The `/settings` "Open config file" row asks the main loop (the
+        // terminal owner) to suspend the TUI and run an external editor.
+        if app.pending_edit_config {
+            app.pending_edit_config = false;
+            edit_config_file(&mut app, &mut terminal);
+        }
+
         if turn_done && let Some(handle) = agent_task.take() {
             match handle.await {
                 Ok(agent) => agent_slot = Some(agent),
@@ -2585,6 +2891,8 @@ impl CommandContext<'_> {
             SlashCommand::Provider(action) => self.provider(action).await,
             SlashCommand::Server(action) => self.server(action).await,
             SlashCommand::Login(provider) => self.login(provider),
+            SlashCommand::Settings => self.app.open_settings_picker(),
+            SlashCommand::ImportClaude(selection) => self.import_claude(selection).await,
         }
     }
 
@@ -3009,6 +3317,8 @@ impl CommandContext<'_> {
             }
         }
         self.app.status.max_steps = self.app.config.max_steps;
+        // Persist so the mode survives a restart (consistent with /provider).
+        self.persist_config();
         self.app.notice(format!("switched to {mode} mode"));
     }
 
@@ -3051,6 +3361,61 @@ impl CommandContext<'_> {
             }
             Err(err) => self.app.notice(format!("reload failed: {err:#}")),
         }
+    }
+
+    /// Run a Claude Code import (dispatched from the `/settings` import
+    /// picker), then reload custom commands + MCP servers live so the imported
+    /// artifacts take effect without a restart.
+    async fn import_claude(&mut self, selection: ImportSelection) {
+        if self.agent_unavailable("import from Claude Code") {
+            return;
+        }
+        let outcome = match import_claude::run_import(&selection) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                self.app.notice(format!("Claude Code import failed: {err:#}"));
+                return;
+            }
+        };
+
+        // Adopt the imported spinner verbs (replacing the active list).
+        if !outcome.spinner_verbs.is_empty() {
+            self.app.config.ui.spinner_verbs = outcome.spinner_verbs.clone();
+            self.persist_config();
+        }
+
+        // Reload custom commands + MCP servers and rebuild the live tool
+        // registry (mirrors `reload`) so imports are usable immediately.
+        self.app.custom_commands = crate::commands::load(self.project_root);
+        let mut manager = self.manager.lock().await;
+        match McpConfig::load(self.mcp_path) {
+            Ok(mcp_config) => {
+                if let Err(err) = manager.reload(&mcp_config).await {
+                    self.app.notice(format!("MCP reload warning: {err:#}"));
+                }
+            }
+            Err(err) => self
+                .app
+                .notice(format!("could not reload MCP config: {err:#}")),
+        }
+        if let Some(hooks) = self
+            .agent_slot
+            .as_ref()
+            .map(|agent| Arc::clone(agent.hooks()))
+            && let Ok(registry) = build_registry(&manager, self.client, &hooks).await
+            && let Some(agent) = self.agent_slot.as_mut()
+        {
+            agent.set_registry(registry);
+            agent.set_skills(self.skills.clone());
+        }
+        drop(manager);
+
+        let summary = outcome.summary();
+        self.app.notice(if summary.is_empty() {
+            "nothing to import from Claude Code".to_string()
+        } else {
+            format!("imported from Claude Code:\n{summary}")
+        });
     }
 
     fn evolve(&mut self, deep: bool, description: String) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -112,6 +112,9 @@ pub enum SlashCommand {
     Diff,
     /// Toggle the todo side panel.
     Todos,
+    /// Toggle the full-screen agent dashboard (session, in-flight tools and
+    /// subagents, todos, background tasks, subagent roster).
+    Dashboard,
     /// Show session token usage (and cost when rates are configured).
     Cost,
     /// Show the saved project memories.
@@ -273,6 +276,7 @@ impl SlashCommand {
             "agents" | "subagents" => Ok(Self::Agents),
             "diff" => Ok(Self::Diff),
             "todos" => Ok(Self::Todos),
+            "dashboard" => Ok(Self::Dashboard),
             "cost" => Ok(Self::Cost),
             "memory" => Ok(Self::Memory),
             "doctor" => Ok(Self::Doctor),
@@ -390,6 +394,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "todos",
         args: "",
         description: "toggle the todo side panel",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "dashboard",
+        args: "",
+        description: "toggle the agent dashboard (tasks, subagents, todos)",
         takes_args: false,
     },
     CommandSpec {
@@ -526,6 +536,15 @@ pub struct Picker {
     pub selected: usize,
 }
 
+/// A background task as mirrored into the dashboard. Built from
+/// [`AgentEvent::TaskStarted`] and updated by [`AgentEvent::TaskFinished`].
+#[derive(Debug, Clone)]
+pub struct BgTask {
+    pub id: u32,
+    pub command: String,
+    pub status: crate::tools::tasks::TaskStatus,
+}
+
 /// In-flight plan review (plan mode): the model called `exit_plan` and the
 /// turn is paused inside the tool until a [`PlanVerdict`] is sent back.
 #[derive(Debug)]
@@ -587,6 +606,11 @@ pub struct App {
     /// Whether a todo update has arrived yet (drives the one-time
     /// auto-show).
     todos_seen: bool,
+    /// Full-screen agent dashboard visibility (toggled by `/dashboard`).
+    pub show_dashboard: bool,
+    /// Background tasks mirrored from [`AgentEvent::TaskStarted`] /
+    /// [`AgentEvent::TaskFinished`], newest last, for the dashboard.
+    pub bg_tasks: Vec<BgTask>,
     /// Transcript scroll offset from the bottom (0 = pinned to latest).
     pub scroll: u16,
     pub should_quit: bool,
@@ -660,6 +684,8 @@ impl App {
             show_todos: false,
             todos: Vec::new(),
             todos_seen: false,
+            show_dashboard: false,
+            bg_tasks: Vec::new(),
             scroll: 0,
             should_quit: false,
             tick: 0,
@@ -990,6 +1016,16 @@ impl App {
                 }
                 _ => {}
             }
+        }
+
+        // The dashboard is a modal view: while it's open, Esc / Enter / q
+        // close it and other keys are swallowed (global chords above still
+        // work). The view itself refreshes from live App state every frame.
+        if self.show_dashboard {
+            if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
+                self.show_dashboard = false;
+            }
+            return Ok(None);
         }
 
         // An open plan review captures all keys: the turn is paused inside
@@ -1468,11 +1504,29 @@ impl App {
                 self.status.prompt_tokens += prompt_tokens;
                 self.status.completion_tokens += completion_tokens;
             }
+            AgentEvent::TaskStarted { id, command } => {
+                self.bg_tasks.push(BgTask {
+                    id,
+                    command,
+                    status: crate::tools::tasks::TaskStatus::Running,
+                });
+            }
             AgentEvent::TaskFinished {
                 id,
                 command,
                 status,
             } => {
+                // Update the mirrored task (or record it if we never saw the
+                // start) so the dashboard reflects the final state.
+                if let Some(task) = self.bg_tasks.iter_mut().find(|t| t.id == id) {
+                    task.status = status;
+                } else {
+                    self.bg_tasks.push(BgTask {
+                        id,
+                        command: command.clone(),
+                        status,
+                    });
+                }
                 self.notice(format!(
                     "background task #{id} finished ({}): {command}",
                     status.describe()
@@ -1770,6 +1824,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /reload                     reload skills, scripted tools, and MCP servers\n  \
 /diff                       toggle the git diff sidebar\n  \
 /todos                      toggle the todo side panel\n  \
+/dashboard                  toggle the agent dashboard (tasks, subagents, todos)\n  \
 /cost                       show session token usage and cost\n  \
 /memory                     show saved project memories\n  \
 /status                     show session status (model, usage, todos, tasks)\n  \
@@ -2191,6 +2246,7 @@ impl CommandContext<'_> {
             SlashCommand::Quit => self.app.should_quit = true,
             SlashCommand::Diff => self.toggle_diff().await,
             SlashCommand::Todos => self.toggle_todos(),
+            SlashCommand::Dashboard => self.toggle_dashboard(),
             SlashCommand::Cost => self.cost(),
             SlashCommand::Memory => self.memory(),
             SlashCommand::Doctor => self.doctor().await,
@@ -2245,6 +2301,29 @@ impl CommandContext<'_> {
         if self.app.show_todos && self.app.todos.is_empty() {
             self.app
                 .notice("todo list is empty — the agent fills it via the `todo` tool");
+        }
+    }
+
+    /// `/dashboard`: toggle the full-screen agent view. When opening while the
+    /// agent is idle, refresh the background-task mirror from the live registry
+    /// so tasks spawned before the dashboard was first shown still appear.
+    fn toggle_dashboard(&mut self) {
+        self.app.show_dashboard = !self.app.show_dashboard;
+        if self.app.show_dashboard
+            && let Some(agent) = self.agent_slot.as_ref()
+        {
+            for task in agent.tasks() {
+                if let Some(existing) = self.app.bg_tasks.iter_mut().find(|t| t.id == task.id) {
+                    existing.status = task.status;
+                } else {
+                    self.app.bg_tasks.push(BgTask {
+                        id: task.id,
+                        command: task.command,
+                        status: task.status,
+                    });
+                }
+            }
+            self.app.bg_tasks.sort_by_key(|t| t.id);
         }
     }
 
@@ -3577,6 +3656,40 @@ mod tests {
         assert!(app.picker.is_none(), "the picker closed");
         assert_eq!(app.input, "Use the reviewer subagent to ");
         assert_eq!(app.cursor, app.input.chars().count());
+    }
+
+    #[test]
+    fn dashboard_command_parses() {
+        assert!(matches!(
+            SlashCommand::parse("/dashboard"),
+            Some(Ok(SlashCommand::Dashboard))
+        ));
+    }
+
+    #[test]
+    fn dashboard_mirrors_background_tasks_and_esc_closes() {
+        use crate::tools::tasks::TaskStatus;
+        let mut app = app();
+        app.handle_agent_event(AgentEvent::TaskStarted {
+            id: 1,
+            command: "sleep 5".to_string(),
+        });
+        assert_eq!(app.bg_tasks.len(), 1);
+        assert_eq!(app.bg_tasks[0].status, TaskStatus::Running);
+
+        // Finishing updates the existing row rather than adding a new one.
+        app.handle_agent_event(AgentEvent::TaskFinished {
+            id: 1,
+            command: "sleep 5".to_string(),
+            status: TaskStatus::Done(0),
+        });
+        assert_eq!(app.bg_tasks.len(), 1);
+        assert_eq!(app.bg_tasks[0].status, TaskStatus::Done(0));
+
+        // The dashboard is modal: Esc closes it.
+        app.show_dashboard = true;
+        press(&mut app, KeyCode::Esc);
+        assert!(!app.show_dashboard);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -623,6 +623,9 @@ pub struct App {
     pub sessions: Vec<SessionRecord>,
     /// Selected row in the dashboard list.
     pub dashboard_selected: usize,
+    /// Dispatch input at the bottom of the dashboard (the prompt for a new
+    /// background session).
+    pub dashboard_input: String,
     /// Transcript scroll offset from the bottom (0 = pinned to latest).
     pub scroll: u16,
     pub should_quit: bool,
@@ -703,6 +706,7 @@ impl App {
             session_started_unix: 0,
             sessions: Vec::new(),
             dashboard_selected: 0,
+            dashboard_input: String::new(),
             scroll: 0,
             should_quit: false,
             tick: 0,
@@ -792,6 +796,66 @@ impl App {
         if self.dashboard_selected >= self.sessions.len() {
             self.dashboard_selected = self.sessions.len().saturating_sub(1);
         }
+    }
+
+    /// Spawn a detached background session for `prompt`: a headless sovereign
+    /// `wizard --bg` run that registers in the session registry, so it shows up
+    /// in every dashboard on the machine and survives this session exiting.
+    fn dispatch_session(&mut self, prompt: String) {
+        use std::os::unix::process::CommandExt;
+        let exe = match std::env::current_exe() {
+            Ok(exe) => exe,
+            Err(err) => {
+                self.notice(format!("could not locate the wizard binary: {err}"));
+                return;
+            }
+        };
+        let spawned = std::process::Command::new(exe)
+            .arg("--bg")
+            .arg("--mode")
+            .arg("sovereign")
+            .arg("-p")
+            .arg(&prompt)
+            .arg("--cwd")
+            .arg(&self.project_root)
+            .current_dir(&self.project_root)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            // Own process group: detached from the TUI's job control, and
+            // killable as a group when stopped.
+            .process_group(0)
+            .spawn();
+        match spawned {
+            Ok(_) => {
+                self.notice(format!("dispatched background session: {prompt}"));
+                self.refresh_sessions();
+            }
+            Err(err) => self.notice(format!("dispatch failed: {err}")),
+        }
+    }
+
+    /// Stop the selected background session (Ctrl-X): SIGTERM its process group
+    /// and drop its registry row. Refuses to stop the session you're in.
+    fn stop_selected_session(&mut self) {
+        let Some(session) = self.sessions.get(self.dashboard_selected) else {
+            return;
+        };
+        if session.id == self.session_id {
+            self.notice("that's this session — use /quit to leave it");
+            return;
+        }
+        let (id, name, pid) = (session.id.clone(), session.name.clone(), session.pid as i32);
+        // Signal the whole group (dispatched sessions are group leaders, so
+        // their tool subprocesses die too); fall back to the bare pid.
+        unsafe {
+            if libc::kill(-pid, libc::SIGTERM) != 0 {
+                libc::kill(pid, libc::SIGTERM);
+            }
+        }
+        session_registry::remove(&id);
+        self.notice(format!("stopped session: {name}"));
+        self.refresh_sessions();
     }
 
     /// Move the dashboard selection up/down, clamped to the session list.
@@ -1111,13 +1175,34 @@ impl App {
             }
         }
 
-        // The dashboard is modal: ↑/↓ move the selection, Esc/q close it.
-        // (Enter will attach in a later milestone; it's a no-op for now.)
+        // The dashboard is modal: ↑/↓ move the selection, typing fills the
+        // dispatch input, Enter dispatches a background session, Ctrl-X stops
+        // the selected one, Esc clears the input or closes. (Enter will also
+        // attach to the selected session once the supervisor lands.)
         if self.show_dashboard {
+            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
             match key.code {
-                KeyCode::Esc | KeyCode::Char('q') => self.show_dashboard = false,
                 KeyCode::Up | KeyCode::BackTab => self.dashboard_select(-1),
                 KeyCode::Down | KeyCode::Tab => self.dashboard_select(1),
+                KeyCode::Char('x') if ctrl => self.stop_selected_session(),
+                KeyCode::Enter => {
+                    let prompt = self.dashboard_input.trim().to_string();
+                    if !prompt.is_empty() {
+                        self.dashboard_input.clear();
+                        self.dispatch_session(prompt);
+                    }
+                }
+                KeyCode::Backspace => {
+                    self.dashboard_input.pop();
+                }
+                KeyCode::Esc => {
+                    if self.dashboard_input.is_empty() {
+                        self.show_dashboard = false;
+                    } else {
+                        self.dashboard_input.clear();
+                    }
+                }
+                KeyCode::Char(c) if !ctrl => self.dashboard_input.push(c),
                 _ => {}
             }
             return Ok(None);
@@ -3826,6 +3911,24 @@ mod tests {
         assert_eq!(app.dashboard_selected, 1, "wraps to the bottom");
 
         // Esc closes the modal.
+        press(&mut app, KeyCode::Esc);
+        assert!(!app.show_dashboard);
+    }
+
+    #[test]
+    fn dashboard_input_composes_and_esc_clears_then_closes() {
+        let mut app = app();
+        app.show_dashboard = true;
+        press(&mut app, KeyCode::Char('h'));
+        press(&mut app, KeyCode::Char('i'));
+        assert_eq!(app.dashboard_input, "hi");
+        press(&mut app, KeyCode::Backspace);
+        assert_eq!(app.dashboard_input, "h");
+        // Esc with text clears it but keeps the modal open.
+        press(&mut app, KeyCode::Esc);
+        assert_eq!(app.dashboard_input, "");
+        assert!(app.show_dashboard);
+        // Esc again, now empty, closes the modal.
         press(&mut app, KeyCode::Esc);
         assert!(!app.show_dashboard);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -621,6 +621,8 @@ pub struct App {
     /// Live sessions on the machine, refreshed from the registry while the
     /// dashboard is open.
     pub sessions: Vec<SessionRecord>,
+    /// Armed by a first Ctrl-C; a second one exits. Disarmed by any other key.
+    pub ctrl_c_armed: bool,
     /// Selected row in the dashboard list.
     pub dashboard_selected: usize,
     /// Dispatch input at the bottom of the dashboard (the prompt for a new
@@ -708,6 +710,7 @@ impl App {
             session_name: String::new(),
             session_started_unix: 0,
             sessions: Vec::new(),
+            ctrl_c_armed: false,
             dashboard_selected: 0,
             dashboard_input: String::new(),
             peek_lines: Vec::new(),
@@ -794,19 +797,21 @@ impl App {
     }
 
     /// Reload the live-session list from the registry, keeping the selection
-    /// in range, and refresh the peek panel for the selected row.
+    /// in range. Cheap (a few small files); safe to poll. The peek panel is
+    /// refreshed separately on a slower cadence — see [`App::refresh_peek`].
     pub fn refresh_sessions(&mut self) {
         self.sessions = session_registry::list();
         if self.dashboard_selected >= self.sessions.len() {
             self.dashboard_selected = self.sessions.len().saturating_sub(1);
         }
-        self.refresh_peek();
     }
 
     /// Reload the peek panel with the selected session's recent transcript.
-    fn refresh_peek(&mut self) {
+    /// Reads only the tail of the session file, so it is cheap enough to call
+    /// on selection changes and a ~1s poll, but not every frame.
+    pub fn refresh_peek(&mut self) {
         self.peek_lines = match self.sessions.get(self.dashboard_selected) {
-            Some(session) => crate::agent::session::peek(&session.id, 80),
+            Some(session) => crate::agent::session::peek(&session.id, 50),
             None => Vec::new(),
         };
     }
@@ -1113,8 +1118,15 @@ impl App {
             Event::Tick => {
                 self.tick = self.tick.wrapping_add(1);
                 // Keep the dashboard's session list current while it's open.
-                if self.show_dashboard && self.tick.is_multiple_of(4) {
-                    self.refresh_sessions();
+                if self.show_dashboard {
+                    // List is cheap (small files); peek reads a transcript tail
+                    // so poll it less often.
+                    if self.tick.is_multiple_of(4) {
+                        self.refresh_sessions();
+                    }
+                    if self.tick.is_multiple_of(10) {
+                        self.refresh_peek();
+                    }
                 }
                 Ok(None)
             }
@@ -1139,10 +1151,32 @@ impl App {
             return Ok(None);
         }
 
+        // Any key other than Ctrl-C disarms the "press again to exit" latch.
+        let is_ctrl_c =
+            key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c');
+        if !is_ctrl_c {
+            self.ctrl_c_armed = false;
+        }
+
         // Global chords, regardless of input mode.
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
-                KeyCode::Char('c') | KeyCode::Char('d') => {
+                KeyCode::Char('c') => {
+                    // Once interrupts a running turn; pressed again (while
+                    // armed) it exits. Idle: first press arms, second exits.
+                    if self.ctrl_c_armed {
+                        self.should_quit = true;
+                        return Ok(None);
+                    }
+                    self.ctrl_c_armed = true;
+                    if self.status.busy {
+                        self.notice("interrupting… (Ctrl-C again to exit)");
+                        return Ok(Some(AppAction::Interrupt));
+                    }
+                    self.notice("press Ctrl-C again to exit");
+                    return Ok(None);
+                }
+                KeyCode::Char('d') => {
                     self.should_quit = true;
                     return Ok(None);
                 }
@@ -1758,6 +1792,9 @@ pub enum AppAction {
     Submit(String),
     /// Execute a parsed slash command.
     Command(SlashCommand),
+    /// Interrupt the running turn (Ctrl-C): abort the turn task and rebuild
+    /// the agent from the last session.
+    Interrupt,
 }
 
 // ---------------------------------------------------------------------------
@@ -2268,6 +2305,12 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
         .unwrap_or(0);
     // Register this session so other sessions' /dashboard can see it.
     crate::session_registry::write(&app.session_record());
+    // `wizard agents` opens straight into the dashboard.
+    if matches!(cli.command, Some(crate::cli::Command::Agents)) {
+        app.show_dashboard = true;
+        app.refresh_sessions();
+        app.refresh_peek();
+    }
     if let Some(prompt) = cli.prompt.clone() {
         app.set_input(prompt);
     }
@@ -2384,6 +2427,53 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
                     }
                     .run(command)
                     .await;
+                }
+                AppAction::Interrupt => {
+                    // Cancel the running turn by aborting its task; the agent
+                    // moved into it is lost, so rebuild from the last session
+                    // (same path as crash recovery).
+                    if let Some(handle) = agent_task.take() {
+                        handle.abort();
+                        app.flush_streaming();
+                        app.status.busy = false;
+                        app.status.step = 0;
+                        app.turn_started = None;
+                        app.notice("interrupted");
+                        app.rebuilding = Some("restarting agent".to_string());
+                        let client = client.clone();
+                        let config = app.config.clone();
+                        let skills = skills.clone();
+                        let project_root = project_root.clone();
+                        let manager = Arc::clone(&manager);
+                        let notify = events.sender();
+                        tokio::spawn(async move {
+                            let manager = manager.lock().await;
+                            let rebuild = match build_agent(
+                                &client,
+                                &config,
+                                &skills,
+                                &project_root,
+                                &manager,
+                                true,
+                            )
+                            .await
+                            {
+                                Ok(agent) => AgentRebuild {
+                                    agent: Some(agent),
+                                    model: None,
+                                    notice: "ready".to_string(),
+                                },
+                                Err(err) => AgentRebuild {
+                                    agent: None,
+                                    model: None,
+                                    notice: format!(
+                                        "could not restart the agent: {err:#} — /quit and relaunch"
+                                    ),
+                                },
+                            };
+                            let _ = notify.send(Event::AgentRebuilt(Box::new(rebuild))).await;
+                        });
+                    }
                 }
             }
         }
@@ -2541,6 +2631,7 @@ impl CommandContext<'_> {
         if self.app.show_dashboard {
             self.app.show_subagents = false;
             self.app.refresh_sessions();
+            self.app.refresh_peek();
         }
     }
 
@@ -3404,6 +3495,11 @@ mod tests {
             .expect("key handled")
     }
 
+    fn press_ctrl(app: &mut App, c: char) -> Option<AppAction> {
+        app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
+            .expect("key handled")
+    }
+
     fn type_str(app: &mut App, text: &str) {
         for c in text.chars() {
             press(app, KeyCode::Char(c));
@@ -3884,6 +3980,43 @@ mod tests {
         assert!(app.picker.is_none(), "the picker closed");
         assert_eq!(app.input, "Use the reviewer subagent to ");
         assert_eq!(app.cursor, app.input.chars().count());
+    }
+
+    #[test]
+    fn ctrl_c_idle_arms_then_exits() {
+        let mut app = app();
+        assert!(press_ctrl(&mut app, 'c').is_none());
+        assert!(app.ctrl_c_armed);
+        assert!(!app.should_quit, "first press only arms");
+        assert!(press_ctrl(&mut app, 'c').is_none());
+        assert!(app.should_quit, "second press exits");
+    }
+
+    #[test]
+    fn ctrl_c_busy_interrupts_then_exits() {
+        let mut app = app();
+        app.status.busy = true;
+        // First press while busy interrupts the turn, doesn't quit.
+        assert!(matches!(
+            press_ctrl(&mut app, 'c'),
+            Some(AppAction::Interrupt)
+        ));
+        assert!(!app.should_quit);
+        // Armed now: a second press exits even while busy.
+        assert!(press_ctrl(&mut app, 'c').is_none());
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn any_other_key_disarms_ctrl_c() {
+        let mut app = app();
+        press_ctrl(&mut app, 'c');
+        assert!(app.ctrl_c_armed);
+        press(&mut app, KeyCode::Char('x'));
+        assert!(!app.ctrl_c_armed);
+        // So the next Ctrl-C re-arms rather than quitting.
+        assert!(press_ctrl(&mut app, 'c').is_none());
+        assert!(!app.should_quit);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,11 @@ pub enum Command {
         #[command(subcommand)]
         cmd: FleetCmd,
     },
+
+    /// Open the agent dashboard: every running Wizard session on the machine.
+    /// Dispatch background sessions, watch their state, peek their output, and
+    /// stop them. Same view as `/dashboard` inside a session.
+    Agents,
 }
 
 /// `wizard fleet` subcommands. `run` loads config (the coordinator drives a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,12 @@ pub struct Cli {
     #[arg(long)]
     pub continuous: bool,
 
+    /// Internal: this headless run was dispatched from `/dashboard`, so it
+    /// registers in the session registry and persists its terminal state for
+    /// the dashboard to display.
+    #[arg(long, hide = true)]
+    pub bg: bool,
+
     /// Output format for headless (sovereign `-p`) runs: `text` streams
     /// human-readable output (default), `json` emits one final JSON summary
     /// object, `stream-json` emits one JSON object per line as events

--- a/src/config.rs
+++ b/src/config.rs
@@ -593,6 +593,7 @@ impl Config {
             Self::subagents_dir()?,
             Self::memory_dir()?,
             Self::logs_dir()?,
+            Self::wizard_dir()?.join("running"),
         ] {
             std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
         }

--- a/src/import_claude.rs
+++ b/src/import_claude.rs
@@ -1,0 +1,500 @@
+//! Import artifacts from an existing Claude Code install (`~/.claude/`).
+//!
+//! Wizard and Claude Code overlap in three concepts a user is likely to have
+//! already configured: MCP servers, custom slash commands, and spinner verbs.
+//! This module reads those out of `~/.claude.json` / `~/.claude/` and folds
+//! them into Wizard's own state, **never clobbering** anything that already
+//! exists (servers and command files are skipped by name).
+//!
+//! The module is split into **pure parsing/mapping** (fully unit-tested
+//! without touching the filesystem) and a thin [`run_import`] orchestrator that
+//! does the actual IO. Both the blocking onboarding TUI
+//! ([`crate::onboarding`]) and the in-app `/settings` menu call [`run_import`],
+//! so the import behaves identically wherever it is triggered.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::config::Config;
+use crate::mcp::{McpConfig, McpServerConfig, McpTransport};
+
+/// Which Claude Code artifacts to bring over. Each flag maps to one section of
+/// [`run_import`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ImportSelection {
+    /// MCP servers from `~/.claude.json` → `~/.wizard/mcp.toml`.
+    pub mcp: bool,
+    /// Custom commands from `~/.claude/commands/` → `~/.wizard/commands/`.
+    pub commands: bool,
+    /// Spinner verbs from `~/.claude/settings.json` → `config.ui.spinner_verbs`.
+    pub verbs: bool,
+}
+
+impl ImportSelection {
+    /// True when nothing was selected (the caller can short-circuit).
+    pub fn is_empty(self) -> bool {
+        !self.mcp && !self.commands && !self.verbs
+    }
+}
+
+/// What an import actually did, for a user-facing summary. Counts are of items
+/// added; `*_skipped` names anything left untouched (already present, or — for
+/// MCP — an unsupported transport).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportOutcome {
+    /// Spinner verbs read from Claude Code (empty unless `verbs` was selected).
+    /// The caller folds these into `config.ui.spinner_verbs`.
+    pub spinner_verbs: Vec<String>,
+    pub mcp_added: usize,
+    /// MCP servers skipped: already-present names and `sse`/unsupported ones.
+    pub mcp_skipped: Vec<String>,
+    pub cmds_added: usize,
+    /// Command files skipped because a same-named file already existed.
+    pub cmds_skipped: Vec<String>,
+}
+
+impl ImportOutcome {
+    /// A one-line-per-artifact summary suitable for a notice / onboarding
+    /// printout. Empty string when nothing happened.
+    pub fn summary(&self) -> String {
+        let mut lines = Vec::new();
+        if self.mcp_added > 0 || !self.mcp_skipped.is_empty() {
+            let mut line = format!("MCP servers: {} imported", self.mcp_added);
+            if !self.mcp_skipped.is_empty() {
+                line.push_str(&format!(" ({} skipped: {})", self.mcp_skipped.len(), self.mcp_skipped.join(", ")));
+            }
+            lines.push(line);
+        }
+        if self.cmds_added > 0 || !self.cmds_skipped.is_empty() {
+            let mut line = format!("commands: {} imported", self.cmds_added);
+            if !self.cmds_skipped.is_empty() {
+                line.push_str(&format!(" ({} already present)", self.cmds_skipped.len()));
+            }
+            lines.push(line);
+        }
+        if !self.spinner_verbs.is_empty() {
+            lines.push(format!("spinner verbs: {} imported", self.spinner_verbs.len()));
+        }
+        lines.join("\n")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/// `~/.claude` if it exists — the marker that Claude Code is installed.
+pub fn claude_home() -> Option<PathBuf> {
+    let dir = dirs::home_dir()?.join(".claude");
+    dir.is_dir().then_some(dir)
+}
+
+/// `~/.claude.json` if it exists (Claude Code's primary config, holds
+/// `mcpServers`).
+pub fn claude_json_path() -> Option<PathBuf> {
+    let path = dirs::home_dir()?.join(".claude.json");
+    path.is_file().then_some(path)
+}
+
+/// `~/.claude/commands/*.md`, sorted; empty when the directory is absent.
+pub fn claude_command_files() -> Vec<PathBuf> {
+    let Some(home) = claude_home() else {
+        return Vec::new();
+    };
+    md_files(&home.join("commands"))
+}
+
+/// How many MCP servers, command files, and spinner verbs are available to
+/// import — used to label the picker rows (`"MCP servers (12)"`).
+pub fn counts() -> (usize, usize, usize) {
+    let mcp = claude_json_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .map(|json| parse_mcp_servers(&json).0.len())
+        .unwrap_or(0);
+    let commands = claude_command_files().len();
+    let verbs = claude_home()
+        .and_then(|home| std::fs::read_to_string(home.join("settings.json")).ok())
+        .map(|raw| parse_spinner_verbs(&raw).len())
+        .unwrap_or(0);
+    (mcp, commands, verbs)
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsing / mapping (unit-tested)
+// ---------------------------------------------------------------------------
+
+/// Parse Claude Code's `mcpServers` (both the top-level map and every
+/// `projects.<path>.mcpServers` map) into [`McpServerConfig`] entries.
+///
+/// Returns `(servers, unsupported)` where `unsupported` names servers that
+/// could not be represented — `sse` transports and entries with no usable
+/// `command`/`url` (Wizard's [`McpTransport`] has only `Stdio` and `Http`, and
+/// [`McpServerConfig`] has no `headers` field, so SSE servers and HTTP headers
+/// are dropped). Duplicate names across maps keep the first occurrence.
+pub fn parse_mcp_servers(claude_json: &Value) -> (Vec<McpServerConfig>, Vec<String>) {
+    let mut servers = Vec::new();
+    let mut unsupported = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let mut ingest = |map: &serde_json::Map<String, Value>| {
+        for (name, spec) in map {
+            if !seen.insert(name.clone()) {
+                continue; // first definition wins
+            }
+            match map_server(name, spec) {
+                Some(server) => servers.push(server),
+                None => unsupported.push(name.clone()),
+            }
+        }
+    };
+
+    if let Some(map) = claude_json.get("mcpServers").and_then(Value::as_object) {
+        ingest(map);
+    }
+    if let Some(projects) = claude_json.get("projects").and_then(Value::as_object) {
+        for project in projects.values() {
+            if let Some(map) = project.get("mcpServers").and_then(Value::as_object) {
+                ingest(map);
+            }
+        }
+    }
+    (servers, unsupported)
+}
+
+/// Map one Claude Code MCP server entry to a [`McpServerConfig`], or `None`
+/// when the transport is unsupported (`sse`) or the entry is malformed.
+fn map_server(name: &str, spec: &Value) -> Option<McpServerConfig> {
+    let kind = spec.get("type").and_then(Value::as_str);
+    if kind == Some("sse") {
+        return None; // Wizard has no SSE transport
+    }
+
+    let command = spec.get("command").and_then(Value::as_str);
+    let url = spec.get("url").and_then(Value::as_str);
+
+    // HTTP when explicitly typed http, or when only a url is present.
+    if kind == Some("http") || (command.is_none() && url.is_some()) {
+        let url = url?.to_string();
+        return Some(McpServerConfig {
+            name: name.to_string(),
+            transport: McpTransport::Http,
+            command: None,
+            args: Vec::new(),
+            url: Some(url),
+            env: HashMap::new(),
+        });
+    }
+
+    // Otherwise stdio: needs a command.
+    let command = command?.to_string();
+    let args = spec
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let env = spec
+        .get("env")
+        .and_then(Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(McpServerConfig {
+        name: name.to_string(),
+        transport: McpTransport::Stdio,
+        command: Some(command),
+        args,
+        url: None,
+        env,
+    })
+}
+
+/// Read `spinnerVerbs.verbs` out of a Claude Code `settings.json`. Tolerant of
+/// missing keys / wrong shapes (returns an empty list).
+pub fn parse_spinner_verbs(settings_json: &str) -> Vec<String> {
+    let Ok(json) = serde_json::from_str::<Value>(settings_json) else {
+        return Vec::new();
+    };
+    json.get("spinnerVerbs")
+        .and_then(|sv| sv.get("verbs"))
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Merge `incoming` MCP servers into `existing`, **skipping any whose name is
+/// already present** (Wizard's config wins — an import never overwrites a
+/// server the user configured). Returns `(merged, added, skipped_names)`.
+pub fn merge_mcp(
+    existing: &McpConfig,
+    incoming: Vec<McpServerConfig>,
+) -> (McpConfig, usize, Vec<String>) {
+    let mut merged = existing.clone();
+    let present: std::collections::HashSet<String> =
+        merged.servers.iter().map(|s| s.name.clone()).collect();
+    let mut added = 0;
+    let mut skipped = Vec::new();
+    for server in incoming {
+        if present.contains(&server.name) {
+            skipped.push(server.name);
+            continue;
+        }
+        merged.servers.push(server);
+        added += 1;
+    }
+    (merged, added, skipped)
+}
+
+/// Decide which `*.md` command files to copy into `dst_dir`, **skipping any
+/// whose filename already exists there**. Returns `(to_copy, skipped_names)`.
+pub fn plan_command_copies(src_files: &[PathBuf], dst_dir: &Path) -> (Vec<PathBuf>, Vec<String>) {
+    let mut to_copy = Vec::new();
+    let mut skipped = Vec::new();
+    for src in src_files {
+        let Some(name) = src.file_name() else {
+            continue;
+        };
+        if dst_dir.join(name).exists() {
+            skipped.push(name.to_string_lossy().into_owned());
+        } else {
+            to_copy.push(src.clone());
+        }
+    }
+    (to_copy, skipped)
+}
+
+/// List `*.md` files in `dir`, sorted by name. Empty when the directory is
+/// missing or unreadable.
+fn md_files(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+// ---------------------------------------------------------------------------
+// IO orchestration
+// ---------------------------------------------------------------------------
+
+/// Perform the import described by `sel`, returning what it did. Writes
+/// `~/.wizard/mcp.toml` and `~/.wizard/commands/` as needed; spinner verbs are
+/// returned in the outcome for the caller to fold into `config.ui` (so this
+/// function never touches `config.toml`).
+///
+/// Errors only on hard IO failures (e.g. an unreadable/locked target); a
+/// missing source is treated as "nothing to import".
+pub fn run_import(sel: &ImportSelection) -> Result<ImportOutcome> {
+    let mut outcome = ImportOutcome::default();
+
+    if sel.mcp {
+        import_mcp(&mut outcome)?;
+    }
+    if sel.commands {
+        import_commands(&mut outcome)?;
+    }
+    if sel.verbs {
+        outcome.spinner_verbs = claude_home()
+            .and_then(|home| std::fs::read_to_string(home.join("settings.json")).ok())
+            .map(|raw| parse_spinner_verbs(&raw))
+            .unwrap_or_default();
+    }
+
+    Ok(outcome)
+}
+
+fn import_mcp(outcome: &mut ImportOutcome) -> Result<()> {
+    let Some(path) = claude_json_path() else {
+        return Ok(());
+    };
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+        return Ok(()); // not our place to hard-fail on Claude's config
+    };
+    let (incoming, unsupported) = parse_mcp_servers(&json);
+
+    let mcp_path = Config::mcp_config_path()?;
+    let existing = McpConfig::load(&mcp_path)?;
+    let (merged, added, mut skipped) = merge_mcp(&existing, incoming);
+    skipped.extend(unsupported);
+    if added > 0 {
+        merged.save(&mcp_path)?;
+    }
+    outcome.mcp_added = added;
+    outcome.mcp_skipped = skipped;
+    Ok(())
+}
+
+fn import_commands(outcome: &mut ImportOutcome) -> Result<()> {
+    let src_files = claude_command_files();
+    if src_files.is_empty() {
+        return Ok(());
+    }
+    let dst_dir = Config::wizard_dir()?.join("commands");
+    std::fs::create_dir_all(&dst_dir)
+        .with_context(|| format!("creating {}", dst_dir.display()))?;
+    let (to_copy, skipped) = plan_command_copies(&src_files, &dst_dir);
+    for src in &to_copy {
+        if let Some(name) = src.file_name() {
+            std::fs::copy(src, dst_dir.join(name))
+                .with_context(|| format!("copying {}", src.display()))?;
+        }
+    }
+    outcome.cmds_added = to_copy.len();
+    outcome.cmds_skipped = skipped;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_mcp_maps_stdio_with_args_and_env() {
+        let json = json!({
+            "mcpServers": {
+                "fs": {
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                    "env": { "FOO": "bar" }
+                }
+            }
+        });
+        let (servers, unsupported) = parse_mcp_servers(&json);
+        assert!(unsupported.is_empty());
+        assert_eq!(servers.len(), 1);
+        let s = &servers[0];
+        assert_eq!(s.name, "fs");
+        assert_eq!(s.transport, McpTransport::Stdio);
+        assert_eq!(s.command.as_deref(), Some("npx"));
+        assert_eq!(s.args.len(), 3);
+        assert_eq!(s.env.get("FOO").map(String::as_str), Some("bar"));
+    }
+
+    #[test]
+    fn parse_mcp_maps_http_by_type_or_bare_url() {
+        let json = json!({
+            "mcpServers": {
+                "typed": { "type": "http", "url": "https://a.example/mcp" },
+                "bare":  { "url": "https://b.example/mcp" }
+            }
+        });
+        let (mut servers, unsupported) = parse_mcp_servers(&json);
+        assert!(unsupported.is_empty());
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(servers.len(), 2);
+        assert!(servers.iter().all(|s| s.transport == McpTransport::Http));
+        assert_eq!(servers[0].url.as_deref(), Some("https://b.example/mcp"));
+    }
+
+    #[test]
+    fn parse_mcp_skips_sse_and_reports_it() {
+        let json = json!({
+            "mcpServers": {
+                "stream": { "type": "sse", "url": "https://c.example/sse" }
+            }
+        });
+        let (servers, unsupported) = parse_mcp_servers(&json);
+        assert!(servers.is_empty());
+        assert_eq!(unsupported, vec!["stream".to_string()]);
+    }
+
+    #[test]
+    fn parse_mcp_merges_toplevel_and_per_project() {
+        let json = json!({
+            "mcpServers": { "global": { "command": "g" } },
+            "projects": {
+                "/home/u/proj": { "mcpServers": { "local": { "command": "l" } } }
+            }
+        });
+        let (mut servers, _) = parse_mcp_servers(&json);
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["global", "local"]);
+    }
+
+    #[test]
+    fn parse_mcp_empty_when_no_servers() {
+        let (servers, unsupported) = parse_mcp_servers(&json!({}));
+        assert!(servers.is_empty());
+        assert!(unsupported.is_empty());
+    }
+
+    #[test]
+    fn parse_spinner_verbs_reads_list() {
+        let raw = r#"{ "spinnerVerbs": { "mode": "replace", "verbs": ["A", "B"] } }"#;
+        assert_eq!(parse_spinner_verbs(raw), vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn parse_spinner_verbs_tolerates_missing_and_garbage() {
+        assert!(parse_spinner_verbs("{}").is_empty());
+        assert!(parse_spinner_verbs(r#"{ "spinnerVerbs": {} }"#).is_empty());
+        assert!(parse_spinner_verbs("not json").is_empty());
+    }
+
+    fn server(name: &str) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            transport: McpTransport::Stdio,
+            command: Some("x".to_string()),
+            args: Vec::new(),
+            url: None,
+            env: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn merge_mcp_skips_existing_names() {
+        let existing = McpConfig {
+            servers: vec![server("keep")],
+        };
+        let (merged, added, skipped) =
+            merge_mcp(&existing, vec![server("keep"), server("new")]);
+        assert_eq!(added, 1);
+        assert_eq!(skipped, vec!["keep".to_string()]);
+        let names: Vec<&str> = merged.servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["keep", "new"]);
+    }
+
+    #[test]
+    fn plan_command_copies_skips_existing_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("dup.md"), b"x").expect("write");
+        let src = tempfile::tempdir().expect("src tempdir");
+        let a = src.path().join("new.md");
+        let b = src.path().join("dup.md");
+        std::fs::write(&a, b"x").expect("write");
+        std::fs::write(&b, b"x").expect("write");
+
+        let (to_copy, skipped) = plan_command_copies(&[a.clone(), b], dir.path());
+        assert_eq!(to_copy, vec![a]);
+        assert_eq!(skipped, vec!["dup.md".to_string()]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod output;
 pub mod progress;
 pub mod schedule;
 pub mod server;
+pub mod session_registry;
 pub mod skills;
 pub mod tools;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fleet;
 pub mod gateway;
 pub mod hardware;
 pub mod hooks;
+pub mod import_claude;
 pub mod instructions;
 pub mod llm;
 pub mod local_setup;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,12 @@ pub async fn run(cli: cli::Cli) -> Result<i32> {
         return gateway::run(config, cli).await.map(|()| 0);
     }
 
+    // `wizard agents` always opens the TUI dashboard, regardless of the
+    // configured default mode.
+    if matches!(cli.command, Some(cli::Command::Agents)) {
+        return app::run_tui(config, cli).await;
+    }
+
     match config.mode {
         Mode::Genie => app::run_tui(config, cli).await,
         Mode::Sovereign => agent::run_headless(config, cli).await,

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -27,6 +27,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
 
 use crate::config::{Config, GatewayConfig, GatewayKind, Mode, ProviderConfig, ProviderKind};
 use crate::hardware::{self, GgufModel};
+use crate::import_claude::{self, ImportSelection};
 
 /// White accent, matching [`crate::ui`].
 const ACCENT: Color = Color::White;
@@ -88,6 +89,11 @@ pub struct Answers {
     pub gateway_allowed_chat_ids: Vec<i64>,
     /// Personality mode.
     pub mode: Mode,
+    /// Artifacts to import from an existing Claude Code install, if any. The
+    /// actual import (file writes + spinner verbs) runs in [`run_blocking`]
+    /// after [`Answers::into_config`], so this is consumed there rather than in
+    /// the pure config mapping.
+    pub claude_import: Option<ImportSelection>,
 }
 
 impl Answers {
@@ -222,9 +228,35 @@ fn run_blocking() -> Result<Option<Config>> {
         Err(err) => return Err(err),
     };
 
-    let config = answers.into_config();
+    let import = answers.claude_import;
+    let mut config = answers.into_config();
+
+    // Perform the Claude Code import (MCP/commands file writes + spinner verbs)
+    // before saving, so the verbs land in the same config write.
+    let import_summary = match import {
+        Some(selection) => match import_claude::run_import(&selection) {
+            Ok(outcome) => {
+                if !outcome.spinner_verbs.is_empty() {
+                    config.ui.spinner_verbs = outcome.spinner_verbs.clone();
+                }
+                Some(outcome.summary())
+            }
+            Err(err) => Some(format!("import failed: {err:#}")),
+        },
+        None => None,
+    };
+
     config.save().context("saving config from onboarding")?;
     print_summary(&config);
+    if let Some(summary) = import_summary
+        && !summary.is_empty()
+    {
+        println!("Imported from Claude Code:");
+        for line in summary.lines() {
+            println!("  • {line}");
+        }
+        println!();
+    }
     Ok(Some(config))
 }
 
@@ -375,6 +407,15 @@ fn collect_answers(terminal: &mut Tui) -> Result<Option<Answers>> {
         None => return Ok(None),
     };
 
+    // Step 5 — optional: import artifacts from an existing Claude Code install.
+    // Only shown when `~/.claude` exists. Esc here skips the import (the rest of
+    // the config is already complete) rather than aborting onboarding.
+    let claude_import = if import_claude::claude_home().is_some() {
+        collect_claude_import(terminal)?
+    } else {
+        None
+    };
+
     Ok(Some(Answers {
         provider: collected.provider,
         provider_name: collected.provider_name,
@@ -387,7 +428,44 @@ fn collect_answers(terminal: &mut Tui) -> Result<Option<Answers>> {
         gateway_token_env,
         gateway_allowed_chat_ids,
         mode,
+        claude_import,
     }))
+}
+
+/// Optional final step: offer to import artifacts from an existing Claude Code
+/// install (`~/.claude`). Returns the chosen selection, or `None` to skip (Esc,
+/// or nothing toggled).
+fn collect_claude_import(terminal: &mut Tui) -> Result<Option<ImportSelection>> {
+    let (mcp, commands, verbs) = import_claude::counts();
+    let options = [
+        Opt::new(
+            format!("MCP servers ({mcp})"),
+            "merge into ~/.wizard/mcp.toml",
+        ),
+        Opt::new(
+            format!("Custom commands ({commands})"),
+            "copy into ~/.wizard/commands/",
+        ),
+        Opt::new(
+            format!("Spinner verbs ({verbs})"),
+            "adopt Claude Code's spinner verbs",
+        ),
+    ];
+    let checked = match multi_select(
+        terminal,
+        "Import from Claude Code",
+        "Found ~/.claude — bring over any of these?",
+        &options,
+    )? {
+        Some(checked) => checked,
+        None => return Ok(None), // skipped
+    };
+    let selection = ImportSelection {
+        mcp: checked.first().copied().unwrap_or(false),
+        commands: checked.get(1).copied().unwrap_or(false),
+        verbs: checked.get(2).copied().unwrap_or(false),
+    };
+    Ok((!selection.is_empty()).then_some(selection))
 }
 
 /// Per-provider answers gathered in step 2.
@@ -1004,6 +1082,7 @@ fn print_summary(config: &Config) {
     }
 
     println!("  • start Wizard:    wizard");
+    println!("  • change settings: run /settings anytime inside Wizard");
     println!();
 }
 
@@ -1085,6 +1164,49 @@ fn select(
                 };
             }
             KeyCode::Enter => return Ok(Some(selected)),
+            _ => {}
+        }
+    }
+}
+
+/// Render a checklist of options; ↑/↓ move, Space toggles the current row,
+/// Enter confirms. Returns the per-row checked state, or `None` on Esc/Ctrl-C.
+/// All rows start unchecked.
+fn multi_select(
+    terminal: &mut Tui,
+    title: &str,
+    subtitle: &str,
+    options: &[Opt],
+) -> Result<Option<Vec<bool>>> {
+    let mut checked = vec![false; options.len()];
+    let mut selected = 0usize;
+    loop {
+        terminal.draw(|frame| draw_multi_select(frame, title, subtitle, options, &checked, selected))?;
+        let Some(key) = next_key()? else { continue };
+        if is_cancel(&key) {
+            return Ok(None);
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::BackTab => {
+                selected = if selected == 0 {
+                    options.len().saturating_sub(1)
+                } else {
+                    selected - 1
+                };
+            }
+            KeyCode::Down | KeyCode::Tab => {
+                selected = if selected + 1 >= options.len() {
+                    0
+                } else {
+                    selected + 1
+                };
+            }
+            KeyCode::Char(' ') => {
+                if let Some(slot) = checked.get_mut(selected) {
+                    *slot = !*slot;
+                }
+            }
+            KeyCode::Enter => return Ok(Some(checked)),
             _ => {}
         }
     }
@@ -1236,6 +1358,50 @@ fn draw_select(
     frame.render_widget(Paragraph::new(Text::from(lines)), inner);
 }
 
+fn draw_multi_select(
+    frame: &mut ratatui::Frame,
+    title: &str,
+    subtitle: &str,
+    options: &[Opt],
+    checked: &[bool],
+    selected: usize,
+) {
+    let inner = frame_body(
+        frame,
+        title,
+        subtitle,
+        "↑/↓ move · space toggle · enter confirm · esc skip",
+    );
+    let mut lines = Vec::with_capacity(options.len());
+    for (index, option) in options.iter().enumerate() {
+        let active = index == selected;
+        let marker = if active { "▸ " } else { "  " };
+        let box_ = if checked.get(index).copied().unwrap_or(false) {
+            "[x]"
+        } else {
+            "[ ]"
+        };
+        let label_style = if active {
+            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(TEXT_DIM)
+        };
+        let mut spans = vec![
+            Span::styled(format!(" {marker}"), Style::default().fg(ACCENT)),
+            Span::styled(format!("{box_} "), Style::default().fg(ACCENT)),
+            Span::styled(option.label.clone(), label_style),
+        ];
+        if !option.detail.is_empty() {
+            spans.push(Span::styled(
+                format!("   {}", option.detail),
+                Style::default().fg(DIM),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), inner);
+}
+
 fn draw_input(
     frame: &mut ratatui::Frame,
     title: &str,
@@ -1319,6 +1485,7 @@ mod tests {
             gateway_token_env: None,
             gateway_allowed_chat_ids: Vec::new(),
             mode: Mode::Genie,
+            claude_import: None,
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -148,6 +148,7 @@ impl EventSink for TextSink {
                 self.spinner
                     .println(&crate::tools::todo::summary_line(&items));
             }
+            AgentEvent::TaskStarted { .. } => {}
             AgentEvent::TaskFinished {
                 id,
                 command,
@@ -262,6 +263,7 @@ impl<W: Write + Send> EventSink for JsonSink<W> {
             AgentEvent::ThinkingDelta(_)
             | AgentEvent::HookFired { .. }
             | AgentEvent::TodoUpdated(_)
+            | AgentEvent::TaskStarted { .. }
             | AgentEvent::TaskFinished { .. } => {}
         }
     }
@@ -380,6 +382,13 @@ impl<W: Write + Send> EventSink for StreamJsonSink<W> {
                 self.emit(json!({
                     "type": "todo",
                     "items": serde_json::to_value(&items).unwrap_or_default(),
+                }));
+            }
+            AgentEvent::TaskStarted { id, command } => {
+                self.emit(json!({
+                    "type": "task_started",
+                    "id": id,
+                    "command": command,
                 }));
             }
             AgentEvent::TaskFinished {

--- a/src/session_registry.rs
+++ b/src/session_registry.rs
@@ -1,0 +1,161 @@
+//! Cross-process session registry.
+//!
+//! Every running Wizard TUI heartbeats a small JSON record to
+//! `~/.wizard/running/<id>.json`, refreshed every few seconds. The
+//! `/dashboard` reads the directory to list every live session on the machine
+//! (Milestone 1 of the agent-view feature). Records whose last heartbeat is
+//! older than [`STALE`] are treated as exited and pruned — a clean exit removes
+//! its own file, and a crash ages out.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+
+/// A session whose heartbeat is older than this is considered gone.
+pub const STALE_SECS: u64 = 12;
+
+/// What a session is currently doing, for the dashboard's grouping and icon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionState {
+    /// Actively running tools or generating a response.
+    Working,
+    /// Paused waiting on the user (plan approval, a gate).
+    NeedsInput,
+    /// Nothing to do; ready for the next prompt.
+    Idle,
+    /// A background/autonomous run finished successfully.
+    Completed,
+    /// A background/autonomous run ended with an error.
+    Failed,
+}
+
+impl SessionState {
+    /// Dashboard group header this state sorts under.
+    pub fn group(self) -> &'static str {
+        match self {
+            SessionState::NeedsInput => "Needs input",
+            SessionState::Working => "Working",
+            SessionState::Idle => "Idle",
+            SessionState::Completed | SessionState::Failed => "Completed",
+        }
+    }
+
+    /// Sort key: the ones that need you first, finished last.
+    pub fn order(self) -> u8 {
+        match self {
+            SessionState::NeedsInput => 0,
+            SessionState::Working => 1,
+            SessionState::Idle => 2,
+            SessionState::Completed => 3,
+            SessionState::Failed => 4,
+        }
+    }
+}
+
+/// One running session's heartbeat record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecord {
+    /// Session id (also the heartbeat filename stem).
+    pub id: String,
+    /// Human label, derived from the first prompt (or the id).
+    pub name: String,
+    /// Working directory the session runs in.
+    pub cwd: String,
+    pub model: String,
+    /// `"genie"` or `"sovereign"`.
+    pub mode: String,
+    pub state: SessionState,
+    /// One-line summary of what the session is doing.
+    pub activity: String,
+    /// OS process id, for later attach/stop.
+    pub pid: u32,
+    pub started_unix: u64,
+    pub updated_unix: u64,
+}
+
+/// `~/.wizard/running/` — heartbeat files live here.
+pub fn running_dir() -> Option<PathBuf> {
+    Config::wizard_dir().ok().map(|dir| dir.join("running"))
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Write (or refresh) `record`'s heartbeat, stamping `updated_unix` to now.
+/// Best-effort: a registry write failure must never take down the session, so
+/// errors are logged and dropped.
+pub fn write(record: &SessionRecord) {
+    let Some(dir) = running_dir() else { return };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let record = SessionRecord {
+        updated_unix: now_unix(),
+        ..record.clone()
+    };
+    let path = dir.join(format!("{}.json", record.id));
+    let tmp = dir.join(format!(".{}.tmp", record.id));
+    match serde_json::to_vec(&record) {
+        Ok(bytes) => {
+            // Write to a temp file and rename so a reader never sees a partial
+            // record.
+            if std::fs::write(&tmp, &bytes).is_ok() {
+                let _ = std::fs::rename(&tmp, &path);
+            }
+        }
+        Err(err) => tracing::warn!("serializing session record: {err}"),
+    }
+}
+
+/// Remove a session's heartbeat (called on clean exit).
+pub fn remove(id: &str) {
+    if let Some(dir) = running_dir() {
+        let _ = std::fs::remove_file(dir.join(format!("{id}.json")));
+    }
+}
+
+/// Every live session on the machine, sorted by state (needs-input first) then
+/// most-recently-active. Stale records are skipped and their files pruned.
+pub fn list() -> Vec<SessionRecord> {
+    let Some(dir) = running_dir() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let now = now_unix();
+    let mut records: Vec<SessionRecord> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_str::<SessionRecord>(&raw) else {
+            continue;
+        };
+        if now.saturating_sub(record.updated_unix) > STALE_SECS {
+            // Aged out — the session exited without cleaning up. Prune it.
+            let _ = std::fs::remove_file(&path);
+            continue;
+        }
+        records.push(record);
+    }
+    records.sort_by(|a, b| {
+        a.state
+            .order()
+            .cmp(&b.state.order())
+            .then(b.updated_unix.cmp(&a.updated_unix))
+    });
+    records
+}

--- a/src/session_registry.rs
+++ b/src/session_registry.rs
@@ -14,8 +14,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 
-/// A session whose heartbeat is older than this is considered gone.
+/// A non-terminal session whose heartbeat is older than this is considered
+/// gone (its process died without cleaning up).
 pub const STALE_SECS: u64 = 12;
+
+/// Terminal records (completed/failed background sessions) are kept this long
+/// so the result stays visible in the dashboard, then aged out.
+pub const RETAIN_SECS: u64 = 24 * 60 * 60;
 
 /// What a session is currently doing, for the dashboard's grouping and icon.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,6 +47,11 @@ impl SessionState {
             SessionState::Idle => "Idle",
             SessionState::Completed | SessionState::Failed => "Completed",
         }
+    }
+
+    /// A finished background session (no live process behind it).
+    pub fn is_terminal(self) -> bool {
+        matches!(self, SessionState::Completed | SessionState::Failed)
     }
 
     /// Sort key: the ones that need you first, finished last.
@@ -144,8 +154,16 @@ pub fn list() -> Vec<SessionRecord> {
         let Ok(record) = serde_json::from_str::<SessionRecord>(&raw) else {
             continue;
         };
-        if now.saturating_sub(record.updated_unix) > STALE_SECS {
-            // Aged out — the session exited without cleaning up. Prune it.
+        let age = now.saturating_sub(record.updated_unix);
+        // Terminal records (finished background runs) persist so their result
+        // stays visible, then age out after RETAIN_SECS. A non-terminal record
+        // older than STALE_SECS means its process died without cleaning up.
+        let expired = if record.state.is_terminal() {
+            age > RETAIN_SECS
+        } else {
+            age > STALE_SECS
+        };
+        if expired {
             let _ = std::fs::remove_file(&path);
             continue;
         }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -197,6 +197,16 @@ impl Tool for ExecuteTool {
                 source: anyhow::Error::new(err).context("failed to spawn background process"),
             })?;
             let id = ctx.tasks.spawn(&args.command, child);
+            // Mirror the new task to the UI dashboard (TaskFinished follows
+            // when it ends). Surfaces that don't care just drop it.
+            if let Some(events) = &ctx.events {
+                let _ = events
+                    .send(crate::agent::AgentEvent::TaskStarted {
+                        id,
+                        command: args.command.clone(),
+                    })
+                    .await;
+            }
             return Ok(ToolOutput::ok(format!(
                 "Background task #{id} started: {}\nYou will be notified when it finishes; \
                  use task_output to inspect it or task_kill to stop it.",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -876,9 +876,22 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
     if outer.width < 8 || outer.height < 5 {
         return;
     }
+    // On a wide terminal, a peek panel of the selected session sits on the
+    // right; the list and dispatch input take the left.
+    let (body_area, peek_area) = if outer.width >= 80 {
+        let [left, right] =
+            Layout::horizontal([Constraint::Percentage(58), Constraint::Percentage(42)])
+                .areas(outer);
+        (left, Some(right))
+    } else {
+        (outer, None)
+    };
+    if let Some(peek_area) = peek_area {
+        draw_peek(frame, app, peek_area);
+    }
     // Reserve the bottom rows for the dispatch input.
     let [inner, input_area] =
-        Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(outer);
+        Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(body_area);
     let width = inner.width as usize;
     let spinner = SPINNER[(app.tick as usize) % SPINNER.len()];
     let now = now_unix();
@@ -968,6 +981,59 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
         Paragraph::new(Text::from(vec![prompt_line, hint])),
         input_area,
     );
+}
+
+/// The dashboard's peek panel: the selected session's recent transcript,
+/// role-prefixed, pinned to the latest output. Read-only.
+fn draw_peek(frame: &mut Frame, app: &App, area: Rect) {
+    let title = app
+        .sessions
+        .get(app.dashboard_selected)
+        .map(|session| format!(" peek · {} ", session.name))
+        .unwrap_or_else(|| " peek ".to_string());
+    let pblock = Block::new()
+        .borders(Borders::LEFT)
+        .border_style(dim())
+        .title(Line::from(Span::styled(title, accent())));
+    let pinner = pblock.inner(area);
+    frame.render_widget(pblock, area);
+    if pinner.width < 2 || pinner.height < 1 {
+        return;
+    }
+    let pwidth = pinner.width as usize;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if app.peek_lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "(no transcript yet)",
+            dim().italic(),
+        )));
+    } else {
+        for (role, text) in &app.peek_lines {
+            let role_style = match role.as_str() {
+                "user" => accent().add_modifier(Modifier::BOLD),
+                "assistant" => Style::default().fg(TEXT_DIM).add_modifier(Modifier::BOLD),
+                _ => dim().add_modifier(Modifier::BOLD),
+            };
+            lines.push(Line::from(Span::styled(role.clone(), role_style)));
+            for line in text.lines() {
+                lines.push(truncate_line(
+                    Line::from(Span::styled(
+                        line.to_string(),
+                        Style::default().fg(TEXT_DIM),
+                    )),
+                    pwidth,
+                ));
+            }
+        }
+    }
+    // Pin to the latest: keep the tail that fits.
+    let height = pinner.height as usize;
+    if lines.len() > height {
+        let start = lines.len() - height;
+        lines.drain(..start);
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), pinner);
 }
 
 /// In-session subagent monitor (`/subagents`): the subagents that have run or

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,7 +92,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     draw_status_bar(frame, app, status_area);
 
     // Floating layers, back to front.
-    if app.picker.is_none() && app.plan_review.is_none() {
+    if app.picker.is_none() && app.plan_review.is_none() && !app.show_dashboard {
         draw_suggestions(frame, app, input_area);
     }
     if app.picker.is_some() {
@@ -100,6 +100,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
     if app.plan_review.is_some() {
         draw_plan_review(frame, app);
+    }
+    // The dashboard is modal and full-screen, so it paints last (on top).
+    if app.show_dashboard {
+        draw_dashboard(frame, app);
     }
 }
 
@@ -367,6 +371,30 @@ fn transcript_text(app: &App) -> Text<'static> {
     Text::from(lines)
 }
 
+/// Human label + one-line summary for a tool call. `spawn_subagent` reads as
+/// "subagent <name> · <task>" so the user can see which subagent is working
+/// and on what; every other tool is its own name plus its JSON args. The
+/// summary is returned untruncated — callers clip it to their width.
+fn tool_label(name: &str, args: &serde_json::Value) -> (String, String) {
+    if name == "spawn_subagent" {
+        let who = args.get("subagent").and_then(|v| v.as_str()).unwrap_or("?");
+        let task = args.get("task").and_then(|v| v.as_str()).unwrap_or("");
+        let summary = if task.is_empty() {
+            who.to_string()
+        } else {
+            format!("{who} · {task}")
+        };
+        ("subagent".to_string(), summary)
+    } else if args.is_null() {
+        (name.to_string(), String::new())
+    } else {
+        (
+            name.to_string(),
+            serde_json::to_string(args).unwrap_or_default(),
+        )
+    }
+}
+
 /// Render one tool invocation as a compact single-line card: status glyph,
 /// tool name in accent, truncated args in dim. Output expands below only
 /// when relevant (errors, or Ctrl-T).
@@ -390,25 +418,8 @@ fn tool_card_lines(
         (Some(_), true) => Span::styled("✗", Style::default().fg(Color::White).bold()),
     };
 
-    // `spawn_subagent` reads better as "subagent <name> · <task>" than as raw
-    // JSON, so the user can see which subagent is working and on what.
-    let (label, summary) = if name == "spawn_subagent" {
-        let who = args.get("subagent").and_then(|v| v.as_str()).unwrap_or("?");
-        let task = args.get("task").and_then(|v| v.as_str()).unwrap_or("");
-        let summary = if task.is_empty() {
-            who.to_string()
-        } else {
-            format!("{who} · {task}")
-        };
-        ("subagent".to_string(), truncate_width(&summary, 64))
-    } else if args.is_null() {
-        (name.to_string(), String::new())
-    } else {
-        (
-            name.to_string(),
-            truncate_width(&serde_json::to_string(args).unwrap_or_default(), 64),
-        )
-    };
+    let (label, summary) = tool_label(name, args);
+    let summary = truncate_width(&summary, 64);
     let mut card = vec![glyph, Span::raw(" "), Span::styled(label, accent())];
     if !summary.is_empty() {
         card.push(Span::styled(format!("  {summary}"), dim()));
@@ -800,6 +811,201 @@ fn draw_picker(frame: &mut Frame, app: &App) {
             Line::from(Span::styled(" ↑↓ move · Enter select · Esc cancel ", dim())).centered(),
         );
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
+}
+
+/// One "key: value" row in the dashboard, clipped to `width`.
+fn dash_kv(key: &str, value: &str, width: usize) -> Line<'static> {
+    truncate_line(
+        Line::from(vec![
+            Span::styled(format!("{key}: "), dim()),
+            Span::styled(value.to_string(), Style::default().fg(TEXT_DIM)),
+        ]),
+        width,
+    )
+}
+
+/// A dim "· text" placeholder row for an empty dashboard section.
+fn dash_bullet(text: &str, style: Style) -> Line<'static> {
+    Line::from(Span::styled(format!("· {text}"), style))
+}
+
+/// Full-screen agent dashboard (`/dashboard`): a live, at-a-glance view of the
+/// session, in-flight tools and subagents, the todo list, and background
+/// tasks. Modal — Esc/Enter/q close it — and rendered purely from mirrored
+/// [`App`] state, so it refreshes every frame.
+fn draw_dashboard(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    frame.render_widget(Clear, area);
+
+    let block = Block::bordered()
+        .border_type(BorderType::Rounded)
+        .border_style(dim())
+        .title(Line::from(vec![
+            Span::styled(" ✦ ", accent()),
+            Span::styled(
+                "agent dashboard",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]))
+        .title_bottom(Line::from(Span::styled(" Esc close · refreshes live ", dim())).centered());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width < 8 || inner.height < 4 {
+        return;
+    }
+    let width = inner.width as usize;
+    let spinner = SPINNER[(app.tick as usize) % SPINNER.len()];
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let header = |lines: &mut Vec<Line<'static>>, text: &str| {
+        if !lines.is_empty() {
+            lines.push(Line::raw(""));
+        }
+        lines.push(Line::from(Span::styled(
+            text.to_string(),
+            accent().add_modifier(Modifier::BOLD),
+        )));
+    };
+
+    // -- Session ----------------------------------------------------------
+    header(&mut lines, "SESSION");
+    let provider = app.config.active();
+    lines.push(dash_kv("model", &app.status.model, width));
+    lines.push(dash_kv(
+        "provider",
+        &format!("{} ({:?})", provider.name, provider.kind),
+        width,
+    ));
+    lines.push(dash_kv(
+        "mode",
+        &format!(
+            "{}{}",
+            app.status.mode,
+            if app.plan_mode { " · plan mode" } else { "" }
+        ),
+        width,
+    ));
+    let activity = if app.status.busy {
+        let elapsed = app
+            .turn_started
+            .map(|t| format!(" · {}s", t.elapsed().as_secs()))
+            .unwrap_or_default();
+        format!(
+            "{spinner} {}… · step {}/{}{elapsed}",
+            app.spinner_verb, app.status.step, app.status.max_steps
+        )
+    } else {
+        "idle".to_string()
+    };
+    lines.push(dash_kv("activity", &activity, width));
+    lines.push(dash_kv(
+        "tokens",
+        &format!(
+            "{} prompt · {} completion",
+            app.status.prompt_tokens, app.status.completion_tokens
+        ),
+        width,
+    ));
+
+    // -- Now running: in-flight tool calls and subagent steps -------------
+    header(&mut lines, "NOW RUNNING");
+    let mut any_running = false;
+    for entry in &app.transcript {
+        if let TranscriptEntry::ToolCard {
+            name,
+            args,
+            output: None,
+            ..
+        } = entry
+        {
+            any_running = true;
+            let (label, summary) = tool_label(name, args);
+            let text = if summary.is_empty() {
+                label
+            } else {
+                format!("{label}  {summary}")
+            };
+            lines.push(truncate_line(
+                Line::from(vec![
+                    Span::styled(format!("{spinner} "), accent()),
+                    Span::styled(text, Style::default().fg(TEXT_DIM)),
+                ]),
+                width,
+            ));
+        }
+    }
+    if !any_running {
+        lines.push(dash_bullet(
+            if app.status.busy {
+                "thinking…"
+            } else {
+                "nothing running"
+            },
+            dim().italic(),
+        ));
+    }
+
+    // -- Todos ------------------------------------------------------------
+    let (done, total) = crate::tools::todo::progress(&app.todos);
+    header(&mut lines, &format!("TODOS  {done}/{total}"));
+    if app.todos.is_empty() {
+        lines.push(dash_bullet("none", dim().italic()));
+    } else {
+        use crate::tools::todo::TodoStatus;
+        for item in app.todos.iter().take(12) {
+            let (glyph_style, text_style) = match item.status {
+                TodoStatus::Completed => (dim(), dim().add_modifier(Modifier::CROSSED_OUT)),
+                TodoStatus::InProgress => (accent(), accent().bold()),
+                TodoStatus::Pending => (dim(), Style::default().fg(TEXT_DIM)),
+            };
+            lines.push(truncate_line(
+                Line::from(vec![
+                    Span::styled(format!("{} ", item.status.glyph()), glyph_style),
+                    Span::styled(item.content.clone(), text_style),
+                ]),
+                width,
+            ));
+        }
+    }
+
+    // -- Background tasks -------------------------------------------------
+    header(&mut lines, "BACKGROUND TASKS");
+    if app.bg_tasks.is_empty() {
+        lines.push(dash_bullet("none", dim().italic()));
+    } else {
+        use crate::tools::tasks::TaskStatus;
+        for task in app.bg_tasks.iter().rev().take(12) {
+            let (glyph, style) = match task.status {
+                TaskStatus::Running => (spinner.to_string(), accent()),
+                TaskStatus::Done(0) => ("✓".to_string(), Style::default().fg(TEXT_DIM)),
+                _ => ("✗".to_string(), Style::default().fg(Color::White).bold()),
+            };
+            lines.push(truncate_line(
+                Line::from(vec![
+                    Span::styled(format!("{glyph} "), style),
+                    Span::styled(
+                        format!("#{} {}", task.id, task.command),
+                        Style::default().fg(TEXT_DIM),
+                    ),
+                    Span::styled(format!("  {}", task.status.describe()), dim()),
+                ]),
+                width,
+            ));
+        }
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        "/agents to browse and delegate to subagents",
+        dim().italic(),
+    )));
+
+    // No scrolling — the dashboard is a glance, not a log; clip to height.
+    let max = inner.height as usize;
+    if lines.len() > max {
+        lines.truncate(max);
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), inner);
 }
 
 /// Plan-review modal (plan mode): the plan markdown with a verdict footer.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 //! Ratatui rendering: pure functions from [`App`] state to widgets.
 //! Layout: chat transcript (with optional git diff sidebar) above the input
 //! line and a quiet status line. Floating layers: the command-suggestion
-//! popup and the model/mode/rewind picker.
+//! popup and the model/mode/rewind/subagent picker.
 //!
 //! Design rules (do not regress):
 //! - **Transparent**: never paint a background color; everything renders on
@@ -390,16 +390,26 @@ fn tool_card_lines(
         (Some(_), true) => Span::styled("✗", Style::default().fg(Color::White).bold()),
     };
 
-    let summary = if args.is_null() {
-        String::new()
+    // `spawn_subagent` reads better as "subagent <name> · <task>" than as raw
+    // JSON, so the user can see which subagent is working and on what.
+    let (label, summary) = if name == "spawn_subagent" {
+        let who = args.get("subagent").and_then(|v| v.as_str()).unwrap_or("?");
+        let task = args.get("task").and_then(|v| v.as_str()).unwrap_or("");
+        let summary = if task.is_empty() {
+            who.to_string()
+        } else {
+            format!("{who} · {task}")
+        };
+        ("subagent".to_string(), truncate_width(&summary, 64))
+    } else if args.is_null() {
+        (name.to_string(), String::new())
     } else {
-        truncate_width(&serde_json::to_string(args).unwrap_or_default(), 64)
+        (
+            name.to_string(),
+            truncate_width(&serde_json::to_string(args).unwrap_or_default(), 64),
+        )
     };
-    let mut card = vec![
-        glyph,
-        Span::raw(" "),
-        Span::styled(name.to_string(), accent()),
-    ];
+    let mut card = vec![glyph, Span::raw(" "), Span::styled(label, accent())];
     if !summary.is_empty() {
         card.push(Span::styled(format!("  {summary}"), dim()));
     }
@@ -707,7 +717,7 @@ fn draw_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 
-/// Centered modal for the model / mode / rewind picker.
+/// Centered modal for the model / mode / rewind / subagent picker.
 fn draw_picker(frame: &mut Frame, app: &App) {
     let Some(picker) = &app.picker else {
         return;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,7 +92,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
     draw_status_bar(frame, app, status_area);
 
     // Floating layers, back to front.
-    if app.picker.is_none() && app.plan_review.is_none() && !app.show_dashboard {
+    if app.picker.is_none()
+        && app.plan_review.is_none()
+        && !app.show_dashboard
+        && !app.show_subagents
+    {
         draw_suggestions(frame, app, input_area);
     }
     if app.picker.is_some() {
@@ -101,9 +105,13 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.plan_review.is_some() {
         draw_plan_review(frame, app);
     }
-    // The dashboard is modal and full-screen, so it paints last (on top).
+    // The dashboard and subagent monitor are modal and full-screen, so they
+    // paint last (on top). Only one is ever open at a time.
     if app.show_dashboard {
         draw_dashboard(frame, app);
+    }
+    if app.show_subagents {
+        draw_subagents(frame, app);
     }
 }
 
@@ -1001,6 +1009,152 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
     )));
 
     // No scrolling — the dashboard is a glance, not a log; clip to height.
+    let max = inner.height as usize;
+    if lines.len() > max {
+        lines.truncate(max);
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), inner);
+}
+
+/// In-session subagent monitor (`/subagents`): the subagents that have run or
+/// are running this session, with live status. Modal — Esc/Enter/q close it —
+/// and reconstructed from the transcript each frame: a `spawn_subagent` card is
+/// one run, and the `<name> ▸ <tool>` cards that follow it are its steps.
+fn draw_subagents(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    frame.render_widget(Clear, area);
+
+    // Walk the transcript once, grouping nested `▸` steps under their run.
+    struct Run {
+        name: String,
+        task: String,
+        /// 0 = running, 1 = completed, 2 = failed / hit budget.
+        state: u8,
+        steps: usize,
+        current: Option<String>,
+    }
+    let mut runs: Vec<Run> = Vec::new();
+    for entry in &app.transcript {
+        let TranscriptEntry::ToolCard {
+            name,
+            args,
+            output,
+            is_error,
+            ..
+        } = entry
+        else {
+            continue;
+        };
+        if name == "spawn_subagent" {
+            let who = args
+                .get("subagent")
+                .and_then(|v| v.as_str())
+                .unwrap_or("subagent");
+            let task = args.get("task").and_then(|v| v.as_str()).unwrap_or("");
+            let state = match output {
+                None => 0,
+                Some(_) if *is_error => 2,
+                Some(_) => 1,
+            };
+            runs.push(Run {
+                name: who.to_string(),
+                task: task.to_string(),
+                state,
+                steps: 0,
+                current: None,
+            });
+        } else if let Some(tool) = name.split(" ▸ ").nth(1) {
+            // A nested subagent step belongs to the most recent run.
+            if let Some(run) = runs.last_mut() {
+                run.steps += 1;
+                run.current = if output.is_none() {
+                    Some(tool.to_string())
+                } else {
+                    None
+                };
+            }
+        }
+    }
+
+    let block = Block::bordered()
+        .border_type(BorderType::Rounded)
+        .border_style(dim())
+        .title(Line::from(vec![
+            Span::styled(" ✦ ", accent()),
+            Span::styled(
+                "subagents · this session",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]))
+        .title_bottom(Line::from(Span::styled(" Esc close · refreshes live ", dim())).centered());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width < 8 || inner.height < 4 {
+        return;
+    }
+    let width = inner.width as usize;
+    let spinner = SPINNER[(app.tick as usize) % SPINNER.len()];
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if runs.is_empty() {
+        lines.push(dash_bullet(
+            "no subagents have run this session",
+            dim().italic(),
+        ));
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            "the agent delegates via spawn_subagent · /agents to browse the roster",
+            dim().italic(),
+        )));
+    } else {
+        // Running first (there is at most one at a time), then finished newest
+        // first so the latest result is on top.
+        let mut order: Vec<usize> = (0..runs.len()).filter(|&i| runs[i].state == 0).collect();
+        order.extend((0..runs.len()).filter(|&i| runs[i].state != 0).rev());
+        for i in order {
+            let run = &runs[i];
+            let (glyph, style) = match run.state {
+                0 => (spinner.to_string(), accent()),
+                1 => ("✓".to_string(), Style::default().fg(TEXT_DIM)),
+                _ => ("✗".to_string(), Style::default().fg(Color::White).bold()),
+            };
+            let suffix = match run.state {
+                0 => format!(" · step {}", run.steps.max(1)),
+                2 => format!(" · stopped at {} steps", run.steps),
+                _ => format!(" · {} steps", run.steps),
+            };
+            lines.push(truncate_line(
+                Line::from(vec![
+                    Span::styled(format!("{glyph} "), style),
+                    Span::styled(
+                        run.name.clone(),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(suffix, dim()),
+                ]),
+                width,
+            ));
+            if !run.task.is_empty() {
+                lines.push(truncate_line(
+                    Line::from(Span::styled(
+                        format!("    {}", run.task),
+                        Style::default().fg(TEXT_DIM),
+                    )),
+                    width,
+                ));
+            }
+            if let Some(current) = &run.current {
+                lines.push(truncate_line(
+                    Line::from(vec![
+                        Span::styled("    ▸ ", accent()),
+                        Span::styled(current.clone(), dim()),
+                    ]),
+                    width,
+                ));
+            }
+        }
+    }
+
     let max = inner.height as usize;
     if lines.len() > max {
         lines.truncate(max);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use pulldown_cmark::{CodeBlockKind, Event as MdEvent, Options, Parser, Tag, TagEnd};
 use ratatui::Frame;
@@ -33,6 +34,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{App, InputMode, TranscriptEntry};
 use crate::config::Mode;
+use crate::session_registry::SessionState;
 
 const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -821,41 +823,52 @@ fn draw_picker(frame: &mut Frame, app: &App) {
     frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 
-/// One "key: value" row in the dashboard, clipped to `width`.
-fn dash_kv(key: &str, value: &str, width: usize) -> Line<'static> {
-    truncate_line(
-        Line::from(vec![
-            Span::styled(format!("{key}: "), dim()),
-            Span::styled(value.to_string(), Style::default().fg(TEXT_DIM)),
-        ]),
-        width,
-    )
-}
-
-/// A dim "· text" placeholder row for an empty dashboard section.
+/// A dim "· text" placeholder row for an empty modal section.
 fn dash_bullet(text: &str, style: Style) -> Line<'static> {
     Line::from(Span::styled(format!("· {text}"), style))
 }
 
-/// Full-screen agent dashboard (`/dashboard`): a live, at-a-glance view of the
-/// session, in-flight tools and subagents, the todo list, and background
-/// tasks. Modal — Esc/Enter/q close it — and rendered purely from mirrored
-/// [`App`] state, so it refreshes every frame.
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Compact "how long ago" label: `12s`, `4m`, `2h`, `3d`.
+fn fmt_age(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86_400)
+    }
+}
+
+/// Machine-wide session manager (`/dashboard`): every live Wizard session on
+/// the machine, grouped by state, refreshed from the registry while open.
+/// Modal — ↑/↓ move the selection, Esc/q close. Dispatch and attach arrive in
+/// later milestones.
 fn draw_dashboard(frame: &mut Frame, app: &App) {
     let area = frame.area();
     frame.render_widget(Clear, area);
 
+    let count = app.sessions.len();
     let block = Block::bordered()
         .border_type(BorderType::Rounded)
         .border_style(dim())
         .title(Line::from(vec![
             Span::styled(" ✦ ", accent()),
             Span::styled(
-                "agent dashboard",
+                "wizard sessions",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
+            Span::styled(format!("  ({count} live on this machine)"), dim()),
         ]))
-        .title_bottom(Line::from(Span::styled(" Esc close · refreshes live ", dim())).centered());
+        .title_bottom(Line::from(Span::styled(" ↑↓ move · Esc close ", dim())).centered());
     let inner = block.inner(area);
     frame.render_widget(block, area);
     if inner.width < 8 || inner.height < 4 {
@@ -863,152 +876,67 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
     }
     let width = inner.width as usize;
     let spinner = SPINNER[(app.tick as usize) % SPINNER.len()];
+    let now = now_unix();
 
     let mut lines: Vec<Line<'static>> = Vec::new();
-    let header = |lines: &mut Vec<Line<'static>>, text: &str| {
-        if !lines.is_empty() {
-            lines.push(Line::raw(""));
-        }
+    if app.sessions.is_empty() {
+        lines.push(dash_bullet("no running sessions", dim().italic()));
+        lines.push(Line::raw(""));
         lines.push(Line::from(Span::styled(
-            text.to_string(),
-            accent().add_modifier(Modifier::BOLD),
-        )));
-    };
-
-    // -- Session ----------------------------------------------------------
-    header(&mut lines, "SESSION");
-    let provider = app.config.active();
-    lines.push(dash_kv("model", &app.status.model, width));
-    lines.push(dash_kv(
-        "provider",
-        &format!("{} ({:?})", provider.name, provider.kind),
-        width,
-    ));
-    lines.push(dash_kv(
-        "mode",
-        &format!(
-            "{}{}",
-            app.status.mode,
-            if app.plan_mode { " · plan mode" } else { "" }
-        ),
-        width,
-    ));
-    let activity = if app.status.busy {
-        let elapsed = app
-            .turn_started
-            .map(|t| format!(" · {}s", t.elapsed().as_secs()))
-            .unwrap_or_default();
-        format!(
-            "{spinner} {}… · step {}/{}{elapsed}",
-            app.spinner_verb, app.status.step, app.status.max_steps
-        )
-    } else {
-        "idle".to_string()
-    };
-    lines.push(dash_kv("activity", &activity, width));
-    lines.push(dash_kv(
-        "tokens",
-        &format!(
-            "{} prompt · {} completion",
-            app.status.prompt_tokens, app.status.completion_tokens
-        ),
-        width,
-    ));
-
-    // -- Now running: in-flight tool calls and subagent steps -------------
-    header(&mut lines, "NOW RUNNING");
-    let mut any_running = false;
-    for entry in &app.transcript {
-        if let TranscriptEntry::ToolCard {
-            name,
-            args,
-            output: None,
-            ..
-        } = entry
-        {
-            any_running = true;
-            let (label, summary) = tool_label(name, args);
-            let text = if summary.is_empty() {
-                label
-            } else {
-                format!("{label}  {summary}")
-            };
-            lines.push(truncate_line(
-                Line::from(vec![
-                    Span::styled(format!("{spinner} "), accent()),
-                    Span::styled(text, Style::default().fg(TEXT_DIM)),
-                ]),
-                width,
-            ));
-        }
-    }
-    if !any_running {
-        lines.push(dash_bullet(
-            if app.status.busy {
-                "thinking…"
-            } else {
-                "nothing running"
-            },
+            "every running wizard registers here — start another to see it appear",
             dim().italic(),
-        ));
-    }
-
-    // -- Todos ------------------------------------------------------------
-    let (done, total) = crate::tools::todo::progress(&app.todos);
-    header(&mut lines, &format!("TODOS  {done}/{total}"));
-    if app.todos.is_empty() {
-        lines.push(dash_bullet("none", dim().italic()));
+        )));
     } else {
-        use crate::tools::todo::TodoStatus;
-        for item in app.todos.iter().take(12) {
-            let (glyph_style, text_style) = match item.status {
-                TodoStatus::Completed => (dim(), dim().add_modifier(Modifier::CROSSED_OUT)),
-                TodoStatus::InProgress => (accent(), accent().bold()),
-                TodoStatus::Pending => (dim(), Style::default().fg(TEXT_DIM)),
+        // Sessions arrive pre-sorted by state then recency; emit a group header
+        // whenever the state group changes.
+        let mut current_group = "";
+        for (i, session) in app.sessions.iter().enumerate() {
+            let group = session.state.group();
+            if group != current_group {
+                if !lines.is_empty() {
+                    lines.push(Line::raw(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    group.to_string(),
+                    accent().add_modifier(Modifier::BOLD),
+                )));
+                current_group = group;
+            }
+
+            let selected = i == app.dashboard_selected;
+            let marker = if selected { "❯ " } else { "  " };
+            let (icon, icon_style) = match session.state {
+                SessionState::Working => (spinner.to_string(), accent()),
+                SessionState::NeedsInput => ("?".to_string(), accent().bold()),
+                SessionState::Idle => ("·".to_string(), dim()),
+                SessionState::Completed => ("✓".to_string(), Style::default().fg(TEXT_DIM)),
+                SessionState::Failed => ("✗".to_string(), Style::default().fg(Color::White).bold()),
             };
+            let name_style = if selected {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(TEXT_DIM)
+            };
+            // Mark this very session so the user can spot which row is them.
+            let you = if session.id == app.session_id {
+                " (this one)"
+            } else {
+                ""
+            };
+            let age = fmt_age(now.saturating_sub(session.updated_unix));
             lines.push(truncate_line(
                 Line::from(vec![
-                    Span::styled(format!("{} ", item.status.glyph()), glyph_style),
-                    Span::styled(item.content.clone(), text_style),
+                    Span::styled(marker, accent()),
+                    Span::styled(format!("{icon} "), icon_style),
+                    Span::styled(format!("{}{you}", session.name), name_style),
+                    Span::styled(format!("  {}", session.activity), dim()),
+                    Span::styled(format!("  · {} · {age}", session.mode), dim()),
                 ]),
                 width,
             ));
         }
     }
 
-    // -- Background tasks -------------------------------------------------
-    header(&mut lines, "BACKGROUND TASKS");
-    if app.bg_tasks.is_empty() {
-        lines.push(dash_bullet("none", dim().italic()));
-    } else {
-        use crate::tools::tasks::TaskStatus;
-        for task in app.bg_tasks.iter().rev().take(12) {
-            let (glyph, style) = match task.status {
-                TaskStatus::Running => (spinner.to_string(), accent()),
-                TaskStatus::Done(0) => ("✓".to_string(), Style::default().fg(TEXT_DIM)),
-                _ => ("✗".to_string(), Style::default().fg(Color::White).bold()),
-            };
-            lines.push(truncate_line(
-                Line::from(vec![
-                    Span::styled(format!("{glyph} "), style),
-                    Span::styled(
-                        format!("#{} {}", task.id, task.command),
-                        Style::default().fg(TEXT_DIM),
-                    ),
-                    Span::styled(format!("  {}", task.status.describe()), dim()),
-                ]),
-                width,
-            ));
-        }
-    }
-
-    lines.push(Line::raw(""));
-    lines.push(Line::from(Span::styled(
-        "/agents to browse and delegate to subagents",
-        dim().italic(),
-    )));
-
-    // No scrolling — the dashboard is a glance, not a log; clip to height.
     let max = inner.height as usize;
     if lines.len() > max {
         lines.truncate(max);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1001,38 +1001,45 @@ fn draw_peek(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
     let pwidth = pinner.width as usize;
+    let height = pinner.height as usize;
 
-    let mut lines: Vec<Line<'static>> = Vec::new();
     if app.peek_lines.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "(no transcript yet)",
-            dim().italic(),
-        )));
-    } else {
-        for (role, text) in &app.peek_lines {
-            let role_style = match role.as_str() {
-                "user" => accent().add_modifier(Modifier::BOLD),
-                "assistant" => Style::default().fg(TEXT_DIM).add_modifier(Modifier::BOLD),
-                _ => dim().add_modifier(Modifier::BOLD),
-            };
-            lines.push(Line::from(Span::styled(role.clone(), role_style)));
-            for line in text.lines() {
-                lines.push(truncate_line(
-                    Line::from(Span::styled(
-                        line.to_string(),
-                        Style::default().fg(TEXT_DIM),
-                    )),
-                    pwidth,
-                ));
+        frame.render_widget(
+            Paragraph::new(Span::styled("(no transcript yet)", dim().italic())),
+            pinner,
+        );
+        return;
+    }
+
+    // Build only the visible tail: walk messages newest-first, emit each
+    // message's lines bottom-up, and stop once the panel is full. This keeps
+    // rendering O(panel height) instead of O(whole transcript).
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    'outer: for (role, text) in app.peek_lines.iter().rev() {
+        let role_style = match role.as_str() {
+            "user" => accent().add_modifier(Modifier::BOLD),
+            "assistant" => Style::default().fg(TEXT_DIM).add_modifier(Modifier::BOLD),
+            _ => dim().add_modifier(Modifier::BOLD),
+        };
+        let mut block: Vec<Line<'static>> =
+            vec![Line::from(Span::styled(role.clone(), role_style))];
+        for line in text.lines() {
+            block.push(truncate_line(
+                Line::from(Span::styled(
+                    line.to_string(),
+                    Style::default().fg(TEXT_DIM),
+                )),
+                pwidth,
+            ));
+        }
+        for line in block.into_iter().rev() {
+            lines.push(line);
+            if lines.len() >= height {
+                break 'outer;
             }
         }
     }
-    // Pin to the latest: keep the tail that fits.
-    let height = pinner.height as usize;
-    if lines.len() > height {
-        let start = lines.len() - height;
-        lines.drain(..start);
-    }
+    lines.reverse();
     frame.render_widget(Paragraph::new(Text::from(lines)), pinner);
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -766,15 +766,24 @@ fn draw_picker(frame: &mut Frame, app: &App) {
             // Ellipsize long model tags so the current marker stays visible.
             let suffix = if item.current { " ●".width() } else { 0 };
             let value_room = inner_width.saturating_sub(2 + suffix + 1);
+            let value = truncate_width(&item.value, value_room);
+            // Width consumed so far: marker (2) + value + the current-marker.
+            let consumed = 2 + value.width() + suffix;
             let mut spans = vec![
                 Span::styled(marker, accent()),
-                Span::styled(truncate_width(&item.value, value_room), value_style),
+                Span::styled(value, value_style),
             ];
             if item.current {
                 spans.push(Span::styled(" ●", Style::default().fg(Color::White)));
             }
+            // Truncate the detail to the room left on the line (after a two-space
+            // gap) so long descriptions never spill past the modal border.
             if !item.detail.is_empty() {
-                spans.push(Span::styled(format!("  {}", item.detail), dim()));
+                let room = inner_width.saturating_sub(consumed + 2);
+                if room > 0 {
+                    let detail = truncate_width(&item.detail, room);
+                    spans.push(Span::styled(format!("  {detail}"), dim()));
+                }
             }
             Line::from(spans)
         })

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -868,12 +868,17 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
             ),
             Span::styled(format!("  ({count} live on this machine)"), dim()),
         ]))
-        .title_bottom(Line::from(Span::styled(" ↑↓ move · Esc close ", dim())).centered());
-    let inner = block.inner(area);
+        .title_bottom(
+            Line::from(Span::styled(" ↑↓ select · Ctrl-X stop · Esc close ", dim())).centered(),
+        );
+    let outer = block.inner(area);
     frame.render_widget(block, area);
-    if inner.width < 8 || inner.height < 4 {
+    if outer.width < 8 || outer.height < 5 {
         return;
     }
+    // Reserve the bottom rows for the dispatch input.
+    let [inner, input_area] =
+        Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(outer);
     let width = inner.width as usize;
     let spinner = SPINNER[(app.tick as usize) % SPINNER.len()];
     let now = now_unix();
@@ -942,6 +947,27 @@ fn draw_dashboard(frame: &mut Frame, app: &App) {
         lines.truncate(max);
     }
     frame.render_widget(Paragraph::new(Text::from(lines)), inner);
+
+    // Dispatch input: type a task + Enter to spawn a background session.
+    let prompt_line = truncate_line(
+        Line::from(vec![
+            Span::styled("› ", accent()),
+            if app.dashboard_input.is_empty() {
+                Span::styled("dispatch a task…", dim().italic())
+            } else {
+                Span::styled(app.dashboard_input.clone(), Style::default().fg(CODE))
+            },
+        ]),
+        input_area.width as usize,
+    );
+    let hint = Line::from(Span::styled(
+        "Enter dispatch · type to compose",
+        dim().italic(),
+    ));
+    frame.render_widget(
+        Paragraph::new(Text::from(vec![prompt_line, hint])),
+        input_area,
+    );
 }
 
 /// In-session subagent monitor (`/subagents`): the subagents that have run or


### PR DESCRIPTION
## Summary
- Adds a `/settings` menu (in-session settings UI) and Claude Code import (`src/import_claude.rs`).
- Brings in the dashboard session-manager line of work: machine-wide session registry, background dispatch/stop, read-only transcript peek, `wizard agents`, Ctrl-C interrupt, and the `/subagents` monitor.

## Changes
- 14 source files, ~2,499 insertions / 27 deletions.
- New: `import_claude.rs`, `session_registry.rs`; substantial `app.rs` and `ui.rs` work.

## Housekeeping
- Purged 2,283 accidentally-committed `target-glibc/` build artifacts (~512 MB) from branch history.
- Added `/target-glibc/` to `.gitignore`.

## Verification
- `cargo build --release` — clean.
- `cargo test` — all suites pass (4 unit + 11 CLI integration, 0 failures).