### PR TITLE
Plan-mode interview + omakase (chef's-choice) mode

### DIFF
--- a/docs/modes.md
+++ b/docs/modes.md
@@ -149,14 +149,28 @@ While plan mode is on:
 - Only read-only tools run (`read_file`, `list_files`, `search_files`, `git_status`, `git_diff`, ...). Every other tool — including `execute`, file writes, scripted/MCP tools, and `spawn_subagent` — returns a "blocked by plan mode" error to the model. These blocks are fed back as ordinary tool errors (not fatal) and are exempt from the circuit breakers.
 - The one way out is the `exit_plan` tool: the model calls it with the finished plan as markdown. The plan is saved to `<project>/.wizard/plan.md` and presented for a verdict.
 - Approval ends plan mode and the model executes the plan in the same turn. Rejection (with optional feedback) keeps plan mode on; the feedback is fed back so the model can revise and call `exit_plan` again.
+- Before finishing, the model can call the read-only `interview` tool to ask a short batch of clarifying questions (see below) when answers would change the plan.
+
+### Interview
+
+When the agent has explored enough to understand the shape of the task but still has genuine open questions whose answers would change the plan (scope, trade-offs, ambiguous intent), it calls the `interview` tool with a short batch of questions — each optionally offering suggested answers. In the TUI an interview modal opens: type a free-text answer, or press `1`–`9` to fill in a suggested option (then edit or accept it), `Enter` commits the current answer and advances, `Esc` dismisses the whole interview. The answers are fed back to the model, which folds them into the plan before calling `exit_plan`. Headless runs, the gateway, and the fleet have no interactive user, so the interview is declined automatically and the model proceeds on its best judgment. The tool is read-only, so it works mid-plan without tripping the gate.
+
+### Omakase (chef's choice)
+
+Omakase is the chef's-choice flavor of plan mode, going beyond a simple review gate: the agent still explores read-only, but then it **decides the approach itself and auto-approves its own plan** — no interview, no human review. It is for when you want the result, not the deliberation. The plan it commits to is written to `<project>/.wizard/plan.md` and surfaced (in the TUI as a "chef's choice" card; headless prints it) before execution begins, so the chosen approach is never a black box. Because the agent is told there is no review gate, its `exit_plan` plan is self-justifying: it states the approach picked, the alternatives weighed, and the assumptions made. The `interview` tool declines to ask in omakase — the chef decides.
+
+```
+/omakase       # toggle omakase mode (implies plan mode)
+```
 
 ### TUI (genie)
 
 ```
 /plan          # toggle plan mode (Shift+Tab does the same)
+/omakase       # toggle omakase (chef's-choice) mode
 ```
 
-The status bar shows `PLAN` while active. When the model presents a plan, a review modal opens: `y`/Enter approves, `n` opens a feedback line (type the reason, Enter sends the rejection, Esc goes back), ↑/↓ scroll the plan.
+The status bar shows `PLAN` while plan mode is active, or `OMAKASE` in omakase mode. When the model presents a plan for review (non-omakase), a review modal opens: `y`/Enter approves, `n` opens a feedback line (type the reason, Enter sends the rejection, Esc goes back), ↑/↓ scroll the plan.
 
 ### Headless (sovereign / continuous / gateway)
 
@@ -167,10 +181,12 @@ wizard --mode sovereign --plan -p "refactor the config loader"
 | Knob | Effect |
 |------|--------|
 | `--plan` (flag) | This run starts in plan mode |
+| `--omakase` (flag) | This run starts in omakase mode (implies `--plan`) |
 | `plan_first = true` (config) | Every session starts in plan mode |
+| `omakase = true` (config) | Every session starts in omakase mode (implies `plan_first`) |
 | `plan_each_cycle = true` (config) | Continuous mode re-enters plan mode at the top of every cycle |
 
-With no human in the loop, `exit_plan` is auto-approved: the plan is printed (or, on the gateway, included in the chat reply), approval is sent automatically, and the same turn proceeds to execute — a natural two-phase plan-then-execute turn. The gateway also accepts a `/plan` chat message to toggle plan mode for subsequent messages.
+With no human in the loop, `exit_plan` is auto-approved: the plan is printed (or, on the gateway, included in the chat reply), approval is sent automatically, and the same turn proceeds to execute — a natural two-phase plan-then-execute turn. (Omakase makes this explicit: the agent always decides for itself, with or without a human present.) The gateway also accepts `/plan` and `/omakase` chat messages to toggle these modes for subsequent messages.
 
 The last presented plan is always available at `<project>/.wizard/plan.md`.
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -73,6 +73,18 @@ impl PlanVerdict {
     }
 }
 
+/// One clarifying question asked via the `interview` tool (plan mode). The
+/// surface collects an answer for each; an empty option list means a
+/// free-text answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterviewQuestion {
+    /// The question text shown to the user.
+    pub question: String,
+    /// Suggested answers the user can pick from; empty for free-text only.
+    /// The user may always type their own answer instead of picking.
+    pub options: Vec<String>,
+}
+
 /// Events emitted by the agent loop. The TUI renders them; the headless
 /// runner logs them.
 #[derive(Debug)]
@@ -110,6 +122,26 @@ pub enum AgentEvent {
         /// The plan markdown (also persisted to `.wizard/plan.md`).
         plan: String,
         respond: tokio::sync::oneshot::Sender<PlanVerdict>,
+    },
+    /// Plan mode: the model asked clarifying questions via the `interview`
+    /// tool and the turn is paused awaiting answers. The consumer must send
+    /// exactly one response on `respond`: `Some(answers)` aligned with
+    /// `questions` (empty string = the user skipped that one), or `None` to
+    /// decline the interview entirely (no interactive user, or the user
+    /// dismissed it). Dropping the sender counts as `None`. Read-only, so it
+    /// is allowed mid-plan.
+    Interview {
+        /// The questions to put to the user, in order.
+        questions: Vec<InterviewQuestion>,
+        respond: tokio::sync::oneshot::Sender<Option<Vec<String>>>,
+    },
+    /// Omakase (chef's-choice) mode: the model finished planning and, because
+    /// there is no human review gate, is proceeding to execute. Informational
+    /// only — the plan markdown for the surface to display. The plan is also
+    /// persisted to `.wizard/plan.md`.
+    OmakaseProceeding {
+        /// The plan markdown the chef chose.
+        plan: String,
     },
     /// Token usage of one completed model call, when the backend reported
     /// counts. Surfaces accumulate these (status bar, headless summary).
@@ -287,6 +319,14 @@ pub struct Agent {
     /// Whether the plan-mode instruction block is currently baked into the
     /// system prompt; [`Agent::sync_plan_prompt`] refreshes on mismatch.
     plan_prompt_on: bool,
+    /// Omakase (chef's-choice) flag, shared with the `exit_plan` and
+    /// `interview` tools. While set, `exit_plan` auto-approves the plan and
+    /// `interview` declines to ask — the agent decides and proceeds.
+    /// Implies plan mode (the read-only exploration phase).
+    omakase: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the omakase instruction block is currently baked into the
+    /// system prompt; refreshed on mismatch alongside the plan block.
+    omakase_prompt_on: bool,
     /// Token counters fed from `ChatChunk` eval counts during streaming.
     usage: crate::usage::UsageTracker,
     /// Where per-turn usage records are appended
@@ -377,6 +417,9 @@ impl Agent {
         // Plan mode: one flag shared by the dispatcher (read-only gate) and
         // the always-registered exit_plan tool (cleared on approval).
         let plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        // Omakase: chef's-choice flavor of plan mode, shared with exit_plan
+        // (auto-approve) and interview (decline to ask).
+        let omakase = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let web = config.web.clone();
 
         // Checkpoints: per-file snapshots of everything this agent edits.
@@ -394,9 +437,13 @@ impl Agent {
         }
 
         let mut registry = registry;
-        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
-            &plan_mode,
-        ))));
+        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(
+            Arc::clone(&plan_mode),
+            Arc::clone(&omakase),
+        )));
+        registry.register(Arc::new(crate::tools::interview::InterviewTool::new(
+            Arc::clone(&omakase),
+        )));
 
         let mut agent = Self {
             client,
@@ -423,6 +470,8 @@ impl Agent {
             load_warning,
             plan_mode,
             plan_prompt_on: false,
+            omakase,
+            omakase_prompt_on: false,
             usage: crate::usage::UsageTracker::new(),
             usage_log: crate::usage::default_log_path(),
             checkpoints,
@@ -563,13 +612,17 @@ impl Agent {
     }
 
     /// Swap the tool registry (after `/reload` or `/evolve`). Re-registers
-    /// the always-present `exit_plan` tool (sharing this agent's plan-mode
-    /// flag) and refreshes the system prompt so the JSON tool protocol's
-    /// tool list stays current.
+    /// the always-present `exit_plan` and `interview` tools (sharing this
+    /// agent's plan-mode and omakase flags) and refreshes the system prompt so
+    /// the JSON tool protocol's tool list stays current.
     pub fn set_registry(&mut self, mut registry: ToolRegistry) {
-        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(Arc::clone(
-            &self.plan_mode,
-        ))));
+        registry.register(Arc::new(crate::tools::plan::ExitPlanTool::new(
+            Arc::clone(&self.plan_mode),
+            Arc::clone(&self.omakase),
+        )));
+        registry.register(Arc::new(crate::tools::interview::InterviewTool::new(
+            Arc::clone(&self.omakase),
+        )));
         self.dispatcher.set_registry(registry);
         self.refresh_system_prompt();
     }
@@ -607,16 +660,42 @@ impl Agent {
     pub fn set_plan_mode(&mut self, on: bool) {
         self.plan_mode
             .store(on, std::sync::atomic::Ordering::SeqCst);
+        // Leaving plan mode also leaves omakase (omakase is a flavor of plan
+        // mode; there is no omakase without the read-only exploration phase).
+        if !on {
+            self.omakase
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
         self.sync_plan_prompt();
     }
 
-    /// Re-compose the system prompt when the plan-mode flag changed since it
-    /// was last baked in. The flag can flip mid-turn (exit_plan approval
-    /// clears it), so the turn loop calls this before every completion.
+    /// Whether omakase (chef's-choice) mode is active.
+    pub fn omakase(&self) -> bool {
+        self.omakase.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Turn omakase mode on or off (`/omakase`, `--omakase`). Omakase implies
+    /// plan mode, so enabling it enables plan mode too; the agent explores
+    /// read-only, then auto-approves its own plan and proceeds.
+    pub fn set_omakase(&mut self, on: bool) {
+        self.omakase.store(on, std::sync::atomic::Ordering::SeqCst);
+        if on {
+            self.plan_mode
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        self.sync_plan_prompt();
+    }
+
+    /// Re-compose the system prompt when the plan-mode or omakase flag changed
+    /// since it was last baked in. Either flag can flip mid-turn (exit_plan
+    /// approval clears plan mode), so the turn loop calls this before every
+    /// completion.
     fn sync_plan_prompt(&mut self) {
-        let on = self.plan_mode();
-        if on != self.plan_prompt_on {
-            self.plan_prompt_on = on;
+        let plan = self.plan_mode();
+        let omakase = self.omakase();
+        if plan != self.plan_prompt_on || omakase != self.omakase_prompt_on {
+            self.plan_prompt_on = plan;
+            self.omakase_prompt_on = omakase;
             self.refresh_system_prompt();
         }
     }
@@ -664,6 +743,10 @@ impl Agent {
         if self.plan_mode() {
             prompt.push_str("\n\n");
             prompt.push_str(prompts::PLAN_MODE_PROMPT);
+            if self.omakase() {
+                prompt.push_str("\n\n");
+                prompt.push_str(prompts::OMAKASE_PROMPT);
+            }
         }
         prompt
     }

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -47,10 +47,35 @@ pub const PLAN_MODE_PROMPT: &str = "\
 You are in PLAN MODE. Investigate using read-only tools only (reading, \
 listing, and searching files; inspecting git state); every other tool is \
 blocked until your plan is approved. Do not attempt to make changes yet. \
+Once you have explored enough to understand the shape of the task but still \
+have genuine open questions whose answers would change the plan (scope, \
+trade-offs, ambiguous intent, where something should live), call the \
+`interview` tool to ask the user a short batch of clarifying questions \
+before you commit to an approach — prefer one well-aimed interview over \
+guessing. Skip it when the task is already unambiguous. \
 Once you understand the task, present your implementation plan by calling \
 the `exit_plan` tool with the complete plan as markdown. If the plan is \
 approved, plan mode ends and you carry it out; if it is rejected, refine \
 the plan using the feedback you receive and call `exit_plan` again.";
+
+/// Appended after [`PLAN_MODE_PROMPT`] when omakase mode is active: the agent
+/// has full authority over the approach. It still explores read-only first,
+/// but it does not interview the user and its plan is auto-approved — it
+/// decides and proceeds. Like plan mode, this block disappears once omakase
+/// is turned off (the prompt is recomposed on every flag flip).
+pub const OMAKASE_PROMPT: &str = "\
+## Omakase mode (chef's choice)
+
+Omakase is on: this is the chef's-choice flavor of plan mode — you have full \
+authority over the approach and the user has handed you the wheel. After \
+exploring read-only, do NOT call `interview`; resolve every open question \
+yourself by making the most reasonable assumption a senior engineer would, \
+and choose the approach you judge best. Your plan is auto-approved — there \
+is no human review gate — so when you call `exit_plan`, make the plan \
+self-justifying: state the approach you picked, the alternatives you \
+weighed, the assumptions you made, and why. Then execute it end to end, \
+verify your work, and deliver a polished result. Be decisive and tasteful; \
+surprise them with quality, not with questions.";
 
 /// Appended to the system prompt when the `todo` tool is registered: keep a
 /// working todo list for multi-step tasks so every surface can mirror

--- a/src/app.rs
+++ b/src/app.rs
@@ -4710,7 +4710,8 @@ impl CommandContext<'_> {
                  approach itself, and executes its own plan (/omakase to leave)",
             );
         } else {
-            self.app.notice("omakase off — back to plan mode (you review the plan)");
+            self.app
+                .notice("omakase off — back to plan mode (you review the plan)");
         }
     }
 
@@ -6629,7 +6630,10 @@ mod tests {
 
     #[test]
     fn omakase_parses_and_round_trips() {
-        assert_eq!(SlashCommand::parse("/omakase"), Some(Ok(SlashCommand::Omakase)));
+        assert_eq!(
+            SlashCommand::parse("/omakase"),
+            Some(Ok(SlashCommand::Omakase))
+        );
     }
 
     #[test]
@@ -6651,7 +6655,10 @@ mod tests {
             "postgres",
             "digit fills the matching option"
         );
-        assert!(app.input.is_empty(), "interview keys never hit the input line");
+        assert!(
+            app.input.is_empty(),
+            "interview keys never hit the input line"
+        );
         press(&mut app, KeyCode::Enter);
         assert_eq!(app.interview.as_ref().expect("still open").current, 1);
 
@@ -6659,7 +6666,10 @@ mod tests {
         type_str(&mut app, "yes, oauth");
         press(&mut app, KeyCode::Enter);
 
-        assert!(app.interview.is_none(), "interview closed after the last answer");
+        assert!(
+            app.interview.is_none(),
+            "interview closed after the last answer"
+        );
         assert_eq!(
             rx.try_recv(),
             Ok(Some(vec!["postgres".to_string(), "yes, oauth".to_string()]))
@@ -6693,10 +6703,12 @@ mod tests {
         });
         assert!(!app.plan_mode, "chef's choice leaves plan mode");
         assert!(!app.omakase, "omakase cleared once proceeding");
-        let shown = app.transcript.iter().any(|e| matches!(
-            e,
-            TranscriptEntry::ToolCard { output: Some(p), .. } if p == "# chef plan"
-        ));
+        let shown = app.transcript.iter().any(|e| {
+            matches!(
+                e,
+                TranscriptEntry::ToolCard { output: Some(p), .. } if p == "# chef plan"
+            )
+        });
         assert!(shown, "the chosen plan is surfaced in the transcript");
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,8 @@ use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::agent::{
-    Agent, AgentEvent, CompactOutcome, DoneReason, PlanVerdict, session::Session, subagent,
+    Agent, AgentEvent, CompactOutcome, DoneReason, InterviewQuestion, PlanVerdict,
+    session::Session, subagent,
 };
 use crate::cli::Cli;
 use crate::commands::CustomCommand;
@@ -134,6 +135,10 @@ pub enum SlashCommand {
     /// Toggle plan mode (also Shift+Tab): read-only investigation until a
     /// plan is approved via `exit_plan`.
     Plan,
+    /// Toggle omakase (chef's-choice) mode: plan mode where the agent decides
+    /// the approach itself and auto-approves its own plan — no interview, no
+    /// review gate.
+    Omakase,
     /// `/rewind [turn]` — restore file checkpoints and truncate history.
     /// `None` opens the turn picker; `Some` rewinds to before that turn.
     Rewind(Option<u64>),
@@ -427,6 +432,7 @@ impl SlashCommand {
             }
             "reload" => Ok(Self::Reload),
             "plan" => Ok(Self::Plan),
+            "omakase" => Ok(Self::Omakase),
             "rewind" => match args.first() {
                 None => Ok(Self::Rewind(None)),
                 Some(arg) => arg
@@ -520,6 +526,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "plan",
         args: "",
         description: "toggle plan mode: read-only until a plan is approved",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "omakase",
+        args: "",
+        description: "toggle omakase: chef's-choice plan mode, the agent decides",
         takes_args: false,
     },
     CommandSpec {
@@ -809,6 +821,33 @@ pub struct PlanReview {
     pub scroll: u16,
 }
 
+/// In-flight interview (plan mode): the model called `interview` and the turn
+/// is paused inside the tool until the user answers every question or
+/// dismisses the modal.
+#[derive(Debug)]
+pub struct Interview {
+    /// The questions, in order.
+    pub questions: Vec<InterviewQuestion>,
+    /// Answers collected so far, one per answered question (parallel to
+    /// `questions[..current]`).
+    pub answers: Vec<String>,
+    /// Index of the question currently being answered.
+    pub current: usize,
+    /// The answer being typed for the current question.
+    pub input: String,
+    /// Answer channel back into the paused `interview` call; taken exactly
+    /// once when the interview finishes (`Some(answers)`) or is dismissed
+    /// (`None`).
+    respond: Option<tokio::sync::oneshot::Sender<Option<Vec<String>>>>,
+}
+
+impl Interview {
+    /// The question now being answered, if any remain.
+    pub fn current_question(&self) -> Option<&InterviewQuestion> {
+        self.questions.get(self.current)
+    }
+}
+
 /// Status bar contents.
 #[derive(Debug, Default)]
 pub struct StatusLine {
@@ -948,6 +987,9 @@ pub struct App {
     /// Whether plan mode is active (mirrors the agent's flag for the status
     /// bar; toggled by `/plan` and Shift+Tab).
     pub plan_mode: bool,
+    /// Whether omakase (chef's-choice) mode is active (mirrors the agent's
+    /// flag; toggled by `/omakase`). Implies `plan_mode`.
+    pub omakase: bool,
     /// Whether the active client is a [`FusionProvider`](crate::llm::fusion)
     /// (`/fusion` toggled on). Drives the loud status-bar indicator and lets
     /// `/fusion` toggle back to the underlying single provider.
@@ -955,6 +997,9 @@ pub struct App {
     /// Open plan-review modal (the turn is paused inside `exit_plan` until
     /// it resolves), if any.
     pub plan_review: Option<PlanReview>,
+    /// Open interview modal (the turn is paused inside the `interview` tool
+    /// until the user answers or dismisses), if any.
+    pub interview: Option<Interview>,
     /// Previously submitted inputs, oldest first (↑/↓ recall).
     pub history: Vec<String>,
     /// Position while browsing `history`; `None` when composing fresh input.
@@ -1003,7 +1048,9 @@ pub struct App {
 impl App {
     pub fn new(config: Config) -> Self {
         let mode = config.mode;
-        let plan_mode = config.plan_first;
+        // Omakase implies plan mode (the read-only exploration phase).
+        let omakase = config.omakase;
+        let plan_mode = config.plan_first || omakase;
         let spinner_verb = config.ui.spinner_verb(0).to_string();
         let status = StatusLine {
             model: config.active().model,
@@ -1052,8 +1099,10 @@ impl App {
             prompt: None,
             web_key_backend: None,
             plan_mode,
+            omakase,
             fusion_active: false,
             plan_review: None,
+            interview: None,
             history: Vec::new(),
             history_pos: None,
             history_draft: String::new(),
@@ -1638,7 +1687,7 @@ impl App {
     /// Current state for this session's heartbeat: needs-input when paused on a
     /// plan review, working while a turn streams, otherwise idle.
     fn session_state(&self) -> SessionState {
-        if self.plan_review.is_some() {
+        if self.plan_review.is_some() || self.interview.is_some() {
             SessionState::NeedsInput
         } else if self.status.busy {
             SessionState::Working
@@ -1651,6 +1700,9 @@ impl App {
     fn session_activity(&self) -> String {
         if self.plan_review.is_some() {
             return "waiting for plan approval".to_string();
+        }
+        if self.interview.is_some() {
+            return "waiting for interview answers".to_string();
         }
         if !self.status.busy {
             return "idle".to_string();
@@ -2202,6 +2254,13 @@ impl App {
         // exit_plan until a verdict is sent.
         if self.plan_review.is_some() {
             self.handle_plan_review_key(key);
+            return Ok(None);
+        }
+
+        // An open interview captures all keys: the turn is paused inside the
+        // interview tool until the user answers or dismisses it.
+        if self.interview.is_some() {
+            self.handle_interview_key(key);
             return Ok(None);
         }
 
@@ -2787,6 +2846,81 @@ impl App {
         }
     }
 
+    /// Drive the interview modal: number keys pick a suggested option, typing
+    /// composes a free-text answer, Enter commits the current question and
+    /// advances (committing the last one sends every answer back), and Esc
+    /// dismisses the whole interview (the model proceeds on its own judgment).
+    fn handle_interview_key(&mut self, key: KeyEvent) {
+        let Some(interview) = self.interview.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                self.finish_interview(None);
+            }
+            KeyCode::Enter => {
+                // Commit the current answer (the typed text wins; empty means
+                // "skip this one") and advance.
+                let answer = interview.input.trim().to_string();
+                interview.answers.push(answer);
+                interview.input.clear();
+                interview.current += 1;
+                if interview.current >= interview.questions.len() {
+                    let answers = std::mem::take(&mut interview.answers);
+                    self.finish_interview(Some(answers));
+                }
+            }
+            KeyCode::Backspace => {
+                interview.input.pop();
+            }
+            // 1-9 fill the input with the matching suggested option, so the
+            // user can accept it with Enter or edit it first.
+            KeyCode::Char(c)
+                if c.is_ascii_digit()
+                    && c != '0'
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                let idx = (c as u8 - b'1') as usize;
+                if let Some(option) = interview
+                    .current_question()
+                    .and_then(|q| q.options.get(idx))
+                {
+                    interview.input = option.clone();
+                } else {
+                    interview.input.push(c);
+                }
+            }
+            KeyCode::Char(c)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                interview.input.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    /// Close the interview and send `answers` back into the paused
+    /// `interview` call: `Some(answers)` aligned with the questions, or `None`
+    /// when the user dismissed it (the model then uses its best judgment).
+    fn finish_interview(&mut self, answers: Option<Vec<String>>) {
+        let Some(mut interview) = self.interview.take() else {
+            return;
+        };
+        let answered = answers.is_some();
+        if let Some(respond) = interview.respond.take() {
+            let _ = respond.send(answers);
+        }
+        self.notice(if answered {
+            "answers sent — the agent is finishing its plan"
+        } else {
+            "interview dismissed — the agent will use its best judgment"
+        });
+    }
+
     /// Record a submitted input for ↑/↓ recall (skipping immediate repeats).
     fn push_history(&mut self, input: &str) {
         if self.history.last().map(String::as_str) != Some(input) {
@@ -2876,6 +3010,37 @@ impl App {
                     feedback: None,
                     scroll: 0,
                 });
+            }
+            AgentEvent::Interview { questions, respond } => {
+                self.flush_streaming();
+                // Defensive: an empty set would leave the modal with nothing
+                // to answer and the turn wedged — decline immediately.
+                if questions.is_empty() {
+                    let _ = respond.send(None);
+                } else {
+                    self.interview = Some(Interview {
+                        questions,
+                        answers: Vec::new(),
+                        current: 0,
+                        input: String::new(),
+                        respond: Some(respond),
+                    });
+                }
+            }
+            AgentEvent::OmakaseProceeding { plan } => {
+                self.flush_streaming();
+                // Chef's choice: no review gate. Mirror the agent clearing its
+                // flags and surface the plan it chose.
+                self.plan_mode = false;
+                self.omakase = false;
+                self.transcript.push(TranscriptEntry::ToolCard {
+                    name: "omakase plan (chef's choice)".to_string(),
+                    args: Value::Null,
+                    output: Some(plan),
+                    is_error: false,
+                    collapsed: false,
+                });
+                self.notice("omakase — chef's choice: proceeding with the agent's own plan");
             }
             AgentEvent::Usage {
                 prompt_tokens,
@@ -3340,6 +3505,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /mode [genie|sovereign]     pick or switch personality mode\n  \
 /genie · /sovereign         switch mode directly\n  \
 /plan                       toggle plan mode (read-only until a plan is approved)\n  \
+/omakase                    toggle omakase: chef's-choice plan mode, the agent decides\n  \
 /rewind [turn]              rewind files and conversation to before a turn\n  \
 /resume                     reopen and continue a past session\n  \
 /compact                    summarize older history into a progress note now\n  \
@@ -4116,6 +4282,7 @@ impl CommandContext<'_> {
             SlashCommand::Mode(None) => self.open_mode_picker(),
             SlashCommand::Mode(Some(mode)) => self.switch_mode(mode),
             SlashCommand::Plan => self.toggle_plan(),
+            SlashCommand::Omakase => self.toggle_omakase(),
             SlashCommand::Rewind(None) => self.open_rewind_picker(),
             SlashCommand::Rewind(Some(turn)) => self.rewind(turn),
             SlashCommand::Resume(None) => self.app.open_resume_picker(),
@@ -4299,7 +4466,13 @@ impl CommandContext<'_> {
         }
         text.push_str(&format!(
             "\nplan mode: {}",
-            if self.app.plan_mode { "on" } else { "off" }
+            if self.app.omakase {
+                "on (omakase — chef's choice)"
+            } else if self.app.plan_mode {
+                "on"
+            } else {
+                "off"
+            }
         ));
         self.app.notice(text);
     }
@@ -4503,12 +4676,42 @@ impl CommandContext<'_> {
             agent.set_plan_mode(on);
         }
         self.app.plan_mode = on;
+        // Plain plan mode and omakase are mutually exclusive flavors; turning
+        // plan mode off leaves omakase too (mirrors the agent).
+        if !on {
+            self.app.omakase = false;
+        }
         self.app.notice(if on {
             "plan mode on — the agent investigates read-only and presents a plan via \
              exit_plan for approval (/plan or Shift+Tab to leave)"
         } else {
             "plan mode off"
         });
+    }
+
+    /// `/omakase`: toggle chef's-choice mode on the live agent. Omakase is a
+    /// flavor of plan mode — the agent explores read-only, then decides the
+    /// approach itself and auto-approves its own plan (no interview, no review
+    /// gate). Enabling it enables plan mode; disabling it drops back to plain
+    /// plan mode.
+    fn toggle_omakase(&mut self) {
+        if self.agent_unavailable("toggle omakase") {
+            return;
+        }
+        let on = !self.app.omakase;
+        if let Some(agent) = self.agent_slot.as_mut() {
+            agent.set_omakase(on);
+        }
+        self.app.omakase = on;
+        if on {
+            self.app.plan_mode = true;
+            self.app.notice(
+                "omakase on — chef's choice: the agent explores read-only, decides the \
+                 approach itself, and executes its own plan (/omakase to leave)",
+            );
+        } else {
+            self.app.notice("omakase off — back to plan mode (you review the plan)");
+        }
     }
 
     /// `/rewind`: open the turn picker (newest first). Each row shows the
@@ -6405,6 +6608,96 @@ mod tests {
             app.plan_review.as_ref().expect("open").feedback.as_deref(),
             Some("")
         );
+    }
+
+    /// Open an interview via the agent event, returning the answers receiver.
+    fn open_interview(
+        app: &mut App,
+        questions: Vec<InterviewQuestion>,
+    ) -> tokio::sync::oneshot::Receiver<Option<Vec<String>>> {
+        let (respond, rx) = tokio::sync::oneshot::channel();
+        app.handle_agent_event(AgentEvent::Interview { questions, respond });
+        rx
+    }
+
+    fn question(q: &str, options: &[&str]) -> InterviewQuestion {
+        InterviewQuestion {
+            question: q.to_string(),
+            options: options.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn omakase_parses_and_round_trips() {
+        assert_eq!(SlashCommand::parse("/omakase"), Some(Ok(SlashCommand::Omakase)));
+    }
+
+    #[test]
+    fn interview_collects_answers_and_advances() {
+        let mut app = app();
+        let mut rx = open_interview(
+            &mut app,
+            vec![
+                question("which db?", &["sqlite", "postgres"]),
+                question("any auth?", &[]),
+            ],
+        );
+        assert!(app.interview.is_some(), "interview modal open");
+
+        // Pick option 2 for the first question, then accept it with Enter.
+        press(&mut app, KeyCode::Char('2'));
+        assert_eq!(
+            app.interview.as_ref().expect("open").input,
+            "postgres",
+            "digit fills the matching option"
+        );
+        assert!(app.input.is_empty(), "interview keys never hit the input line");
+        press(&mut app, KeyCode::Enter);
+        assert_eq!(app.interview.as_ref().expect("still open").current, 1);
+
+        // Free-text the second answer.
+        type_str(&mut app, "yes, oauth");
+        press(&mut app, KeyCode::Enter);
+
+        assert!(app.interview.is_none(), "interview closed after the last answer");
+        assert_eq!(
+            rx.try_recv(),
+            Ok(Some(vec!["postgres".to_string(), "yes, oauth".to_string()]))
+        );
+    }
+
+    #[test]
+    fn interview_esc_dismisses_with_no_answers() {
+        let mut app = app();
+        let mut rx = open_interview(&mut app, vec![question("which db?", &[])]);
+        press(&mut app, KeyCode::Esc);
+        assert!(app.interview.is_none(), "dismissed");
+        assert_eq!(rx.try_recv(), Ok(None), "decline sent to the tool");
+    }
+
+    #[test]
+    fn empty_interview_declines_immediately() {
+        let mut app = app();
+        let mut rx = open_interview(&mut app, vec![]);
+        assert!(app.interview.is_none(), "nothing to ask");
+        assert_eq!(rx.try_recv(), Ok(None));
+    }
+
+    #[test]
+    fn omakase_proceeding_clears_flags_and_shows_the_plan() {
+        let mut app = app();
+        app.plan_mode = true;
+        app.omakase = true;
+        app.handle_agent_event(AgentEvent::OmakaseProceeding {
+            plan: "# chef plan".to_string(),
+        });
+        assert!(!app.plan_mode, "chef's choice leaves plan mode");
+        assert!(!app.omakase, "omakase cleared once proceeding");
+        let shown = app.transcript.iter().any(|e| matches!(
+            e,
+            TranscriptEntry::ToolCard { output: Some(p), .. } if p == "# chef plan"
+        ));
+        assert!(shown, "the chosen plan is surfaced in the transcript");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,12 @@ pub struct Cli {
     #[arg(long)]
     pub plan: bool,
 
+    /// Start in omakase (chef's-choice) mode: plan mode where the agent
+    /// explores read-only, decides the approach itself, and auto-approves its
+    /// own plan — no interview, no review gate. Implies `--plan`.
+    #[arg(long)]
+    pub omakase: bool,
+
     /// Time limit in hours for a sovereign-mode run.
     #[arg(long)]
     pub max_hours: Option<f64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -454,6 +454,10 @@ pub struct Config {
     /// run): the agent investigates with read-only tools and presents a plan
     /// via `exit_plan` before executing. Headless runs auto-approve the plan.
     pub plan_first: bool,
+    /// Start every session in omakase (chef's-choice) mode (the `--omakase`
+    /// flag sets this for one run): plan mode where the agent decides the
+    /// approach itself and auto-approves its own plan. Implies `plan_first`.
+    pub omakase: bool,
     /// Continuous mode: re-enter plan mode at the top of every cycle, so each
     /// cycle plans read-only before acting.
     pub plan_each_cycle: bool,
@@ -521,6 +525,7 @@ impl Default for Config {
             max_steps: 25,
             continuous: false,
             plan_first: false,
+            omakase: false,
             plan_each_cycle: false,
             rollback_failed_cycles: false,
             retry_base_secs: 5,
@@ -846,6 +851,11 @@ impl Config {
         if cli.plan {
             self.plan_first = true;
         }
+        if cli.omakase {
+            // Omakase is a flavor of plan mode; it implies plan_first.
+            self.omakase = true;
+            self.plan_first = true;
+        }
         if self.mode == Mode::Sovereign && self.max_steps < Mode::Sovereign.default_max_steps() {
             self.max_steps = Mode::Sovereign.default_max_steps();
         }
@@ -935,6 +945,7 @@ mod tests {
             max_steps: 200,
             continuous: true,
             plan_first: true,
+            omakase: true,
             plan_each_cycle: true,
             rollback_failed_cycles: true,
             retry_base_secs: 10,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -199,6 +199,23 @@ async fn serve(mut gateway: Box<dyn Gateway>, config: Config, project_root: &Pat
                 continue;
             }
 
+            // "/omakase" toggles chef's-choice mode: the agent plans read-only
+            // then decides and executes its own plan (the gateway has no human
+            // reviewer anyway, so this mainly steers the agent's autonomy).
+            if message.text.trim() == "/omakase" {
+                let on = !agent.omakase();
+                agent.set_omakase(on);
+                let confirmation = if on {
+                    "omakase on — chef's choice: the agent plans, decides, and executes on its own"
+                } else {
+                    "omakase off"
+                };
+                if let Err(err) = gateway.send(message.chat_id, confirmation).await {
+                    eprintln!("failed to confirm /omakase to {}: {err:#}", message.chat_id);
+                }
+                continue;
+            }
+
             println!("← [{}] {}", message.chat_id, first_line(&message.text));
             let reply = run_one_turn(&mut agent, &message.text).await;
             for chunk in split_message(&reply, MAX_MESSAGE_CHARS) {

--- a/src/output.rs
+++ b/src/output.rs
@@ -137,6 +137,17 @@ impl EventSink for TextSink {
                 let _ = respond.send(PlanVerdict::approve());
                 self.spinner.show();
             }
+            AgentEvent::Interview { respond, .. } => {
+                // Headless: no interactive user — decline so the model
+                // proceeds with its best judgment.
+                let _ = respond.send(None);
+            }
+            AgentEvent::OmakaseProceeding { plan } => {
+                self.spinner.println(&format!(
+                    "\n=== plan (omakase — chef's choice) ===\n{plan}\n=== proceeding ==="
+                ));
+                self.spinner.show();
+            }
             AgentEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
@@ -252,6 +263,10 @@ impl<W: Write + Send> EventSink for JsonSink<W> {
                 // No human in the loop: approve so the turn executes.
                 let _ = respond.send(PlanVerdict::approve());
             }
+            AgentEvent::Interview { respond, .. } => {
+                // No interactive user: decline so the model uses its judgment.
+                let _ = respond.send(None);
+            }
             AgentEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
@@ -262,6 +277,7 @@ impl<W: Write + Send> EventSink for JsonSink<W> {
             AgentEvent::Done { .. } => self.turns += 1,
             AgentEvent::ThinkingDelta(_)
             | AgentEvent::HookFired { .. }
+            | AgentEvent::OmakaseProceeding { .. }
             | AgentEvent::TodoUpdated(_)
             | AgentEvent::TaskStarted { .. }
             | AgentEvent::TaskFinished { .. } => {}
@@ -365,6 +381,16 @@ impl<W: Write + Send> EventSink for StreamJsonSink<W> {
                 // No human in the loop: report the plan and approve it.
                 self.emit(json!({"type": "plan", "plan": plan, "approved": true}));
                 let _ = respond.send(PlanVerdict::approve());
+            }
+            AgentEvent::Interview { questions, respond } => {
+                // No interactive user: report the questions, then decline so
+                // the model proceeds with its best judgment.
+                let asked: Vec<&str> = questions.iter().map(|q| q.question.as_str()).collect();
+                self.emit(json!({"type": "interview", "questions": asked, "answered": false}));
+                let _ = respond.send(None);
+            }
+            AgentEvent::OmakaseProceeding { plan } => {
+                self.emit(json!({"type": "plan", "plan": plan, "omakase": true, "approved": true}));
             }
             AgentEvent::Usage {
                 prompt_tokens,

--- a/src/tools/interview.rs
+++ b/src/tools/interview.rs
@@ -188,12 +188,14 @@ impl Tool for InterviewTool {
                 let mut out = String::from("The user answered your questions:\n");
                 for (i, q) in questions.iter().enumerate() {
                     let answer = answers.get(i).map(String::as_str).unwrap_or("").trim();
-                    let answer = if answer.is_empty() { "(skipped)" } else { answer };
+                    let answer = if answer.is_empty() {
+                        "(skipped)"
+                    } else {
+                        answer
+                    };
                     let _ = write!(out, "\nQ: {}\nA: {answer}\n", q.question);
                 }
-                out.push_str(
-                    "\nIncorporate these answers into your plan, then call exit_plan.",
-                );
+                out.push_str("\nIncorporate these answers into your plan, then call exit_plan.");
                 Ok(ToolOutput::ok(out))
             }
             Ok(None) => Ok(unanswered(
@@ -234,10 +236,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let ctx = ToolContext::new("/tmp").with_events(tx);
         let out = tool
-            .execute(
-                json!({ "questions": [{ "question": "which db?" }] }),
-                &ctx,
-            )
+            .execute(json!({ "questions": [{ "question": "which db?" }] }), &ctx)
             .await
             .expect("executes");
         assert!(!out.is_error);

--- a/src/tools/interview.rs
+++ b/src/tools/interview.rs
@@ -1,0 +1,316 @@
+//! Plan mode's clarifying-questions hatch: the `interview` tool.
+//!
+//! After exploring the codebase read-only, the model can pause to ask the
+//! user a short batch of clarifying questions before committing to a plan —
+//! the same "interview" step Claude Code offers in plan mode. The tool is
+//! read-only (so the plan-mode gate lets it through), emits an
+//! [`AgentEvent::Interview`] carrying the questions, and blocks until the
+//! surface answers: the TUI renders an interactive Q&A modal; headless
+//! runners, the gateway, and the fleet have no interactive user and decline,
+//! which the tool reports back as "proceed with your best judgment" rather
+//! than an error. In omakase mode the chef decides for themselves, so the
+//! tool refuses to ask at all.
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::sync::oneshot;
+
+use crate::agent::{AgentEvent, InterviewQuestion};
+
+use super::{Tool, ToolAccess, ToolContext, ToolError, ToolOutput, parse_args};
+
+/// Advertised name of the tool.
+pub const INTERVIEW_TOOL_NAME: &str = "interview";
+
+/// Most questions a single interview may carry; keeps the model from dumping
+/// an unbounded questionnaire on the user.
+const MAX_QUESTIONS: usize = 6;
+
+/// `interview` — ask the user a batch of clarifying questions during plan
+/// mode and feed their answers back to the model. Always registered (so the
+/// model sees it documented); meaningful only while a surface with an
+/// interactive user is attached.
+pub struct InterviewTool {
+    /// Omakase flag, shared with the agent. When set, the chef makes its own
+    /// calls and the tool declines to interview.
+    omakase: Arc<AtomicBool>,
+}
+
+impl InterviewTool {
+    pub fn new(omakase: Arc<AtomicBool>) -> Self {
+        Self { omakase }
+    }
+}
+
+#[derive(Deserialize)]
+struct Args {
+    questions: Vec<QuestionArg>,
+}
+
+#[derive(Deserialize)]
+struct QuestionArg {
+    question: String,
+    #[serde(default)]
+    options: Vec<String>,
+}
+
+/// Render the questions the model asked, so it can proceed using its own
+/// judgment when no answers come back (no surface, or the user declined).
+fn unanswered(questions: &[InterviewQuestion], reason: &str) -> ToolOutput {
+    let mut out = format!("{reason} Proceed using your best judgment for:\n");
+    for (i, q) in questions.iter().enumerate() {
+        let _ = write!(out, "\n{}. {}", i + 1, q.question);
+    }
+    ToolOutput::ok(out)
+}
+
+#[async_trait]
+impl Tool for InterviewTool {
+    fn name(&self) -> &str {
+        INTERVIEW_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Ask the user a short batch of clarifying questions during plan mode, \
+         before you commit to a plan. Use it only when you have genuine open \
+         questions whose answers would change your approach (scope, \
+         trade-offs, ambiguous intent) — not for things you can determine by \
+         reading the code. Each question may offer suggested options; the user \
+         can pick one or write their own. Their answers come back as the tool \
+         result. Read-only, so it works mid-plan."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "description": "The clarifying questions to ask, in order \
+                                    (at most 6).",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question": {
+                                "type": "string",
+                                "description": "The question to put to the user."
+                            },
+                            "options": {
+                                "type": "array",
+                                "description": "Optional suggested answers the \
+                                                user can pick from; omit for a \
+                                                free-text question.",
+                                "items": { "type": "string" }
+                            }
+                        },
+                        "required": ["question"]
+                    }
+                }
+            },
+            "required": ["questions"]
+        })
+    }
+
+    fn access(&self) -> ToolAccess {
+        // Read-only: it gathers information and makes no changes, so the
+        // plan-mode gate lets it through.
+        ToolAccess::ReadOnly
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        let Args { questions } = parse_args(INTERVIEW_TOOL_NAME, args)?;
+
+        let questions: Vec<InterviewQuestion> = questions
+            .into_iter()
+            .map(|q| InterviewQuestion {
+                question: q.question.trim().to_string(),
+                options: q
+                    .options
+                    .into_iter()
+                    .map(|o| o.trim().to_string())
+                    .filter(|o| !o.is_empty())
+                    .collect(),
+            })
+            .filter(|q| !q.question.is_empty())
+            .collect();
+
+        if questions.is_empty() {
+            return Ok(ToolOutput::error(
+                "no questions provided — call interview with at least one question",
+            ));
+        }
+        if questions.len() > MAX_QUESTIONS {
+            return Ok(ToolOutput::error(format!(
+                "too many questions ({}) — ask at most {MAX_QUESTIONS} at a time",
+                questions.len()
+            )));
+        }
+
+        // Omakase: the chef decides. Don't put questions to the user.
+        if self.omakase.load(Ordering::SeqCst) {
+            return Ok(unanswered(
+                &questions,
+                "Omakase mode is on — you have full authority and should not \
+                 interview the user.",
+            ));
+        }
+
+        let Some(events) = ctx.events.clone() else {
+            // No surface (subagent / direct execution): nobody to answer.
+            return Ok(unanswered(
+                &questions,
+                "No interactive user is available to answer.",
+            ));
+        };
+
+        let (respond, answers) = oneshot::channel();
+        if events
+            .send(AgentEvent::Interview {
+                questions: questions.clone(),
+                respond,
+            })
+            .await
+            .is_err()
+        {
+            return Ok(unanswered(
+                &questions,
+                "The interview could not be presented (no surface).",
+            ));
+        }
+
+        match answers.await {
+            Ok(Some(answers)) => {
+                let mut out = String::from("The user answered your questions:\n");
+                for (i, q) in questions.iter().enumerate() {
+                    let answer = answers.get(i).map(String::as_str).unwrap_or("").trim();
+                    let answer = if answer.is_empty() { "(skipped)" } else { answer };
+                    let _ = write!(out, "\nQ: {}\nA: {answer}\n", q.question);
+                }
+                out.push_str(
+                    "\nIncorporate these answers into your plan, then call exit_plan.",
+                );
+                Ok(ToolOutput::ok(out))
+            }
+            Ok(None) => Ok(unanswered(
+                &questions,
+                "The user dismissed the interview without answering.",
+            )),
+            Err(_) => Ok(unanswered(
+                &questions,
+                "The interview ended without answers.",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn flag(on: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(on))
+    }
+
+    #[tokio::test]
+    async fn rejects_an_empty_question_set() {
+        let tool = InterviewTool::new(flag(false));
+        let out = tool
+            .execute(json!({ "questions": [] }), &ToolContext::new("/tmp"))
+            .await
+            .expect("executes");
+        assert!(out.is_error, "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn omakase_declines_to_ask() {
+        let tool = InterviewTool::new(flag(true));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new("/tmp").with_events(tx);
+        let out = tool
+            .execute(
+                json!({ "questions": [{ "question": "which db?" }] }),
+                &ctx,
+            )
+            .await
+            .expect("executes");
+        assert!(!out.is_error);
+        assert!(out.content.contains("Omakase"), "{}", out.content);
+        assert!(out.content.contains("which db?"), "{}", out.content);
+        // No event was emitted: the chef does not interview.
+        assert!(rx.try_recv().is_err(), "no interview event in omakase");
+    }
+
+    #[tokio::test]
+    async fn no_surface_falls_back_to_best_judgment() {
+        let tool = InterviewTool::new(flag(false));
+        let out = tool
+            .execute(
+                json!({ "questions": [{ "question": "which db?" }] }),
+                &ToolContext::new("/tmp"),
+            )
+            .await
+            .expect("executes");
+        assert!(!out.is_error);
+        assert!(out.content.contains("best judgment"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn answers_are_paired_with_questions() {
+        let tool = InterviewTool::new(flag(false));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new("/tmp").with_events(tx);
+
+        let responder = async {
+            let Some(AgentEvent::Interview { questions, respond }) = rx.recv().await else {
+                panic!("expected Interview event");
+            };
+            assert_eq!(questions.len(), 2);
+            assert_eq!(questions[0].options, vec!["sqlite", "postgres"]);
+            respond
+                .send(Some(vec!["postgres".to_string(), String::new()]))
+                .expect("answers sent");
+        };
+        let (out, ()) = tokio::join!(
+            tool.execute(
+                json!({ "questions": [
+                    { "question": "which db?", "options": ["sqlite", "postgres"] },
+                    { "question": "any auth?" }
+                ] }),
+                &ctx
+            ),
+            responder
+        );
+        let out = out.expect("executes");
+        assert!(!out.is_error, "{}", out.content);
+        assert!(out.content.contains("A: postgres"), "{}", out.content);
+        // The skipped second answer renders explicitly.
+        assert!(out.content.contains("A: (skipped)"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn dismissed_interview_falls_back() {
+        let tool = InterviewTool::new(flag(false));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new("/tmp").with_events(tx);
+        let responder = async {
+            let Some(AgentEvent::Interview { respond, .. }) = rx.recv().await else {
+                panic!("expected Interview event");
+            };
+            respond.send(None).expect("decline sent");
+        };
+        let (out, ()) = tokio::join!(
+            tool.execute(json!({ "questions": [{ "question": "x?" }] }), &ctx),
+            responder
+        );
+        let out = out.expect("executes");
+        assert!(!out.is_error);
+        assert!(out.content.contains("best judgment"), "{}", out.content);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -6,6 +6,7 @@
 pub mod evolve;
 pub mod file;
 pub mod git;
+pub mod interview;
 pub mod memory;
 pub mod plan;
 pub mod publish;

--- a/src/tools/plan.rs
+++ b/src/tools/plan.rs
@@ -108,9 +108,7 @@ impl Tool for ExitPlanTool {
             self.plan_mode.store(false, Ordering::SeqCst);
             self.omakase.store(false, Ordering::SeqCst);
             if let Some(events) = ctx.events.clone() {
-                let _ = events
-                    .send(AgentEvent::OmakaseProceeding { plan })
-                    .await;
+                let _ = events.send(AgentEvent::OmakaseProceeding { plan }).await;
             }
             return Ok(ToolOutput::ok(
                 "Omakase — plan auto-approved (chef's choice). Plan mode is off; \
@@ -315,8 +313,10 @@ mod tests {
                 other => panic!("expected OmakaseProceeding, got {other:?}"),
             }
         };
-        let (out, announced) =
-            tokio::join!(tool.execute(json!({ "plan": "# chef plan" }), &ctx), observer);
+        let (out, announced) = tokio::join!(
+            tool.execute(json!({ "plan": "# chef plan" }), &ctx),
+            observer
+        );
         let out = out.expect("executes");
 
         assert!(!out.is_error, "{}", out.content);

--- a/src/tools/plan.rs
+++ b/src/tools/plan.rs
@@ -34,11 +34,27 @@ pub struct ExitPlanTool {
     /// Plan-mode flag shared with the agent and its dispatcher; approval
     /// clears it.
     plan_mode: Arc<AtomicBool>,
+    /// Omakase (chef's-choice) flag shared with the agent. When set, the plan
+    /// is auto-approved with no review round-trip: the chef decides and
+    /// proceeds. Cleared alongside plan mode on approval.
+    omakase: Arc<AtomicBool>,
 }
 
 impl ExitPlanTool {
-    pub fn new(plan_mode: Arc<AtomicBool>) -> Self {
-        Self { plan_mode }
+    pub fn new(plan_mode: Arc<AtomicBool>, omakase: Arc<AtomicBool>) -> Self {
+        Self { plan_mode, omakase }
+    }
+
+    /// Persist the plan markdown to `<project>/.wizard/plan.md`.
+    fn persist(&self, ctx: &ToolContext, plan: &str) -> Result<(), ToolError> {
+        let path = ctx.cwd.join(PLAN_FILE);
+        path.parent()
+            .map_or(Ok(()), std::fs::create_dir_all)
+            .and_then(|()| std::fs::write(&path, plan))
+            .map_err(|err| ToolError::Execution {
+                tool: EXIT_PLAN_TOOL_NAME.to_string(),
+                source: anyhow::anyhow!("writing {}: {err}", path.display()),
+            })
     }
 }
 
@@ -81,6 +97,27 @@ impl Tool for ExitPlanTool {
                 "not in plan mode — exit_plan only applies while plan mode is active",
             ));
         }
+
+        // Omakase: chef's choice. There is no review gate — persist the plan,
+        // clear the flags, tell the surface the chef is proceeding (best
+        // effort; this is informational), and let the agent execute. This
+        // path also covers contexts with no surface (subagents), where a
+        // review round-trip would otherwise be impossible.
+        if self.omakase.load(Ordering::SeqCst) {
+            self.persist(ctx, &plan)?;
+            self.plan_mode.store(false, Ordering::SeqCst);
+            self.omakase.store(false, Ordering::SeqCst);
+            if let Some(events) = ctx.events.clone() {
+                let _ = events
+                    .send(AgentEvent::OmakaseProceeding { plan })
+                    .await;
+            }
+            return Ok(ToolOutput::ok(
+                "Omakase — plan auto-approved (chef's choice). Plan mode is off; \
+                 execute the plan end to end now.",
+            ));
+        }
+
         let Some(events) = ctx.events.clone() else {
             // Outside the dispatch pipeline there is no surface to review the
             // plan (e.g. a subagent context); refuse rather than silently
@@ -92,17 +129,7 @@ impl Tool for ExitPlanTool {
 
         // Persist the plan before asking for a verdict, so it survives a
         // rejected or interrupted review.
-        let path = ctx.cwd.join(PLAN_FILE);
-        let write = path
-            .parent()
-            .map_or(Ok(()), std::fs::create_dir_all)
-            .and_then(|()| std::fs::write(&path, &plan));
-        if let Err(err) = write {
-            return Err(ToolError::Execution {
-                tool: EXIT_PLAN_TOOL_NAME.to_string(),
-                source: anyhow::anyhow!("writing {}: {err}", path.display()),
-            });
-        }
+        self.persist(ctx, &plan)?;
 
         let (respond, verdict) = oneshot::channel();
         if events
@@ -173,7 +200,7 @@ mod tests {
     #[tokio::test]
     async fn errors_outside_plan_mode() {
         let tmp = TempDir::new();
-        let tool = ExitPlanTool::new(flag(false));
+        let tool = ExitPlanTool::new(flag(false), flag(false));
         let out = tool
             .execute(json!({ "plan": "# p" }), &ToolContext::new(&tmp.0))
             .await
@@ -186,7 +213,7 @@ mod tests {
     #[tokio::test]
     async fn errors_without_an_event_channel() {
         let tmp = TempDir::new();
-        let tool = ExitPlanTool::new(flag(true));
+        let tool = ExitPlanTool::new(flag(true), flag(false));
         let out = tool
             .execute(json!({ "plan": "# p" }), &ToolContext::new(&tmp.0))
             .await
@@ -199,7 +226,7 @@ mod tests {
     async fn approval_writes_plan_and_clears_the_flag() {
         let tmp = TempDir::new();
         let plan_mode = flag(true);
-        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode), flag(false));
         let (tx, mut rx) = mpsc::channel(8);
         let ctx = ToolContext::new(&tmp.0).with_events(tx);
 
@@ -227,7 +254,7 @@ mod tests {
     async fn rejection_keeps_plan_mode_and_returns_feedback() {
         let tmp = TempDir::new();
         let plan_mode = flag(true);
-        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode), flag(false));
         let (tx, mut rx) = mpsc::channel(8);
         let ctx = ToolContext::new(&tmp.0).with_events(tx);
 
@@ -255,7 +282,7 @@ mod tests {
     async fn dropped_verdict_keeps_plan_mode() {
         let tmp = TempDir::new();
         let plan_mode = flag(true);
-        let tool = ExitPlanTool::new(Arc::clone(&plan_mode));
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode), flag(false));
         let (tx, mut rx) = mpsc::channel(8);
         let ctx = ToolContext::new(&tmp.0).with_events(tx);
 
@@ -269,5 +296,51 @@ mod tests {
         let out = out.expect("executes");
         assert!(out.is_error);
         assert!(plan_mode.load(Ordering::SeqCst), "plan mode stays on");
+    }
+
+    #[tokio::test]
+    async fn omakase_auto_approves_without_a_review_round_trip() {
+        let tmp = TempDir::new();
+        let plan_mode = flag(true);
+        let omakase = flag(true);
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode), Arc::clone(&omakase));
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolContext::new(&tmp.0).with_events(tx);
+
+        // The surface only observes an informational OmakaseProceeding event;
+        // it never sends a verdict.
+        let observer = async {
+            match rx.recv().await {
+                Some(AgentEvent::OmakaseProceeding { plan }) => plan,
+                other => panic!("expected OmakaseProceeding, got {other:?}"),
+            }
+        };
+        let (out, announced) =
+            tokio::join!(tool.execute(json!({ "plan": "# chef plan" }), &ctx), observer);
+        let out = out.expect("executes");
+
+        assert!(!out.is_error, "{}", out.content);
+        assert!(out.content.contains("Omakase"), "{}", out.content);
+        assert_eq!(announced, "# chef plan");
+        assert!(!plan_mode.load(Ordering::SeqCst), "plan mode cleared");
+        assert!(!omakase.load(Ordering::SeqCst), "omakase cleared");
+        let saved = std::fs::read_to_string(tmp.0.join(PLAN_FILE)).expect("plan persisted");
+        assert_eq!(saved, "# chef plan");
+    }
+
+    #[tokio::test]
+    async fn omakase_proceeds_even_without_a_surface() {
+        // Subagent context (no event channel): omakase still auto-approves
+        // rather than refusing, because the chef needs no human gate.
+        let tmp = TempDir::new();
+        let plan_mode = flag(true);
+        let omakase = flag(true);
+        let tool = ExitPlanTool::new(Arc::clone(&plan_mode), Arc::clone(&omakase));
+        let out = tool
+            .execute(json!({ "plan": "# p" }), &ToolContext::new(&tmp.0))
+            .await
+            .expect("executes");
+        assert!(!out.is_error, "{}", out.content);
+        assert!(!plan_mode.load(Ordering::SeqCst), "plan mode cleared");
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,6 +97,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     // Floating layers, back to front.
     if app.picker.is_none()
         && app.plan_review.is_none()
+        && app.interview.is_none()
         && !app.show_dashboard
         && !app.show_subagents
     {
@@ -107,6 +108,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
     if app.plan_review.is_some() {
         draw_plan_review(frame, app);
+    }
+    if app.interview.is_some() {
+        draw_interview(frame, app);
     }
     // The dashboard and subagent monitor are modal and full-screen, so they
     // paint last (on top). Only one is ever open at a time.
@@ -197,6 +201,7 @@ fn draw_transcript(frame: &mut Frame, app: &App, area: Rect) {
         // Drop the card while any overlay is open so there's no text overlay.
         let overlay_open = app.picker.is_some()
             || app.plan_review.is_some()
+            || app.interview.is_some()
             || app.show_dashboard
             || app.show_subagents;
         if !overlay_open {
@@ -696,7 +701,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(" · ", dim()),
         mode_span(app.status.mode),
     ];
-    if app.plan_mode {
+    if app.omakase {
+        spans.push(Span::styled(" · ", dim()));
+        spans.push(Span::styled("OMAKASE", accent().bold()));
+    } else if app.plan_mode {
         spans.push(Span::styled(" · ", dim()));
         spans.push(Span::styled("PLAN", accent().bold()));
     }
@@ -759,6 +767,8 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             "y/Enter approve · n reject · ↑↓ scroll"
         }
+    } else if app.interview.is_some() {
+        "1-9 pick · type answer · Enter next · Esc skip"
     } else if app.picker.is_some() {
         "↑↓ move · Enter select · Esc cancel"
     } else if !app.suggestions.is_empty() {
@@ -862,7 +872,7 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
         area,
     );
 
-    if app.picker.is_none() && app.plan_review.is_none() {
+    if app.picker.is_none() && app.plan_review.is_none() && app.interview.is_none() {
         frame.set_cursor_position(Position::new(cursor_x, area.y + 1));
     }
 }
@@ -1474,6 +1484,127 @@ fn draw_plan_review(frame: &mut Frame, app: &App) {
             feedback_area,
         );
     }
+}
+
+/// Centered modal for the plan-mode interview: the agent's clarifying
+/// questions with their answer-so-far status, and a free-text input for the
+/// current question. The turn is paused inside the `interview` tool until the
+/// user answers every question or dismisses the modal.
+fn draw_interview(frame: &mut Frame, app: &App) {
+    let Some(interview) = &app.interview else {
+        return;
+    };
+
+    let frame_area = frame.area();
+    let width = frame_area.width.saturating_sub(6).clamp(24, 92);
+    let height = frame_area.height.saturating_sub(2).max(5);
+    let area = Rect {
+        x: frame_area.x + (frame_area.width.saturating_sub(width)) / 2,
+        y: frame_area.y + (frame_area.height.saturating_sub(height)) / 2,
+        width,
+        height,
+    }
+    .intersection(frame_area);
+    if area.height < 5 || area.width < 10 {
+        return;
+    }
+    frame.render_widget(Clear, area);
+
+    let total = interview.questions.len();
+    let title = format!(" question {} of {total} ", (interview.current + 1).min(total));
+    let block = Block::bordered()
+        .border_type(BorderType::Rounded)
+        .border_style(dim())
+        .title(Line::from(vec![
+            Span::styled(" ✦", accent()),
+            Span::styled(" interview ", Style::default().fg(TEXT_DIM)),
+            Span::styled(title, dim()),
+        ]))
+        .title_bottom(
+            Line::from(Span::styled(
+                " 1-9 pick · type answer · Enter next · Esc skip ",
+                dim(),
+            ))
+            .centered(),
+        );
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.height < 2 {
+        return;
+    }
+
+    // Body: every question with its status; the current one gets its options
+    // and the live answer input. The input occupies the bottom line.
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (i, q) in interview.questions.iter().enumerate() {
+        if i < interview.current {
+            // Answered: show the question dimmed with its answer.
+            let answer = interview.answers.get(i).map(String::as_str).unwrap_or("");
+            let answer = if answer.trim().is_empty() {
+                "(skipped)".to_string()
+            } else {
+                answer.to_string()
+            };
+            lines.push(Line::from(vec![
+                Span::styled("✓ ", Style::default().fg(Color::Green)),
+                Span::styled(q.question.clone(), dim()),
+            ]));
+            lines.push(Line::from(Span::styled(format!("    {answer}"), dim().italic())));
+        } else if i == interview.current {
+            lines.push(Line::from(vec![
+                Span::styled("▶ ", accent().bold()),
+                Span::styled(q.question.clone(), Style::default().fg(Color::White).bold()),
+            ]));
+            for (n, option) in q.options.iter().enumerate() {
+                lines.push(Line::from(vec![
+                    Span::styled(format!("    {}) ", n + 1), accent()),
+                    Span::raw(option.clone()),
+                ]));
+            }
+        } else {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", q.question),
+                dim(),
+            )));
+        }
+    }
+
+    let body_area = Rect {
+        height: inner.height.saturating_sub(2),
+        ..inner
+    };
+    if body_area.height > 0 {
+        let wrapped = wrap_lines(Text::from(lines), body_area.width as usize);
+        let skip = wrapped.len().saturating_sub(body_area.height as usize);
+        let visible: Vec<Line<'static>> = wrapped.into_iter().skip(skip).collect();
+        frame.render_widget(Paragraph::new(Text::from(visible)), body_area);
+    }
+
+    // Answer input on the bottom line, scrolled to keep the tail visible.
+    let input_area = Rect {
+        y: inner.bottom().saturating_sub(1),
+        height: 1,
+        ..inner
+    };
+    let prompt = "answer ❯ ";
+    let budget = (input_area.width as usize).saturating_sub(prompt.width() + 1);
+    let shown: String = interview
+        .input
+        .chars()
+        .rev()
+        .take(budget)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(prompt, accent().bold()),
+            Span::raw(shown),
+            Span::styled("▍", dim()),
+        ])),
+        input_area,
+    );
 }
 
 /// Wrap styled lines at `width` display columns (wide CJK/emoji glyphs

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1511,7 +1511,10 @@ fn draw_interview(frame: &mut Frame, app: &App) {
     frame.render_widget(Clear, area);
 
     let total = interview.questions.len();
-    let title = format!(" question {} of {total} ", (interview.current + 1).min(total));
+    let title = format!(
+        " question {} of {total} ",
+        (interview.current + 1).min(total)
+    );
     let block = Block::bordered()
         .border_type(BorderType::Rounded)
         .border_style(dim())
@@ -1549,7 +1552,10 @@ fn draw_interview(frame: &mut Frame, app: &App) {
                 Span::styled("✓ ", Style::default().fg(Color::Green)),
                 Span::styled(q.question.clone(), dim()),
             ]));
-            lines.push(Line::from(Span::styled(format!("    {answer}"), dim().italic())));
+            lines.push(Line::from(Span::styled(
+                format!("    {answer}"),
+                dim().italic(),
+            )));
         } else if i == interview.current {
             lines.push(Line::from(vec![
                 Span::styled("▶ ", accent().bold()),
@@ -1562,10 +1568,7 @@ fn draw_interview(frame: &mut Frame, app: &App) {
                 ]));
             }
         } else {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", q.question),
-                dim(),
-            )));
+            lines.push(Line::from(Span::styled(format!("  {}", q.question), dim())));
         }
     }
 


### PR DESCRIPTION
## What

Two additions to plan mode:

### Interview (Claude Code parity)
After exploring the codebase read-only, the agent can call the new **`interview`** tool to ask the user a short batch of clarifying questions before committing to a plan — for genuine open questions whose answers change the approach (scope, trade-offs, ambiguous intent).

- TUI renders an interactive Q&A modal: `1`–`9` fill a suggested option, type a free-text answer, `Enter` commits + advances, `Esc` dismisses.
- Read-only, so it passes the plan-mode gate.
- Headless / gateway / fleet have no interactive user → auto-decline; the model proceeds on its best judgment (never wedges the turn).

### Omakase — chef's choice (beyond parity)
The autonomous flavor of plan mode: the agent explores read-only, then **decides the approach itself and auto-approves its own plan** — no interview, no review gate. The chosen plan is still persisted to `.wizard/plan.md` and surfaced before execution (a "chef's choice" card in the TUI), so the approach is never a black box. The omakase system prompt tells the model to make its plan self-justifying (approach picked, alternatives weighed, assumptions made).

Toggle via `/omakase`, `--omakase`, or `omakase = true` in config; the gateway accepts a `/omakase` chat message too. Status bar shows `OMAKASE`.

## How
Both are shared `Arc<AtomicBool>` flags threaded through the agent, `exit_plan`, and the `interview` tool. Two new `AgentEvent` variants (`Interview`, `OmakaseProceeding`) carry the round-trip/display to every surface. System prompt gains `interview` guidance in the plan block and a dedicated omakase block.

## Tests
- `src/tools/interview.rs`: empty set rejected, omakase declines, no-surface fallback, answer pairing, dismissal.
- `src/tools/plan.rs`: omakase auto-approve (with and without a surface).
- `src/app.rs`: `/omakase` parse, interview modal collect/advance/dismiss, empty-interview decline, omakase-proceeding clears flags + shows plan.

`cargo build`, `cargo clippy`, and all 586 unit tests pass.