### PR TITLE
feat(tui): vim modal editing + Shift+Enter multi-line composer

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,8 @@ Type a task in natural language:
 
 Wizard reads files, applies changes, runs tests, and shows git diffs.
 
+**Enter** sends the message; **Shift+Enter** inserts a newline for multi-line prompts (the composer grows to fit, then scrolls). Shift+Enter needs a terminal that supports the keyboard-enhancement protocol — Wizard enables it on launch when available; where it isn't, **Alt+Enter** does the same thing.
+
 ## Configuration
 
 `~/.wizard/config.toml` as written by onboarding's Local pick (or a `WIZARD_LOCAL=1` install):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,6 +150,23 @@ spinner_verbs = ["Pondering", "Musing", "Noodling"]
 
 A non-empty list fully replaces the defaults; omitting the section or setting `spinner_verbs = []` keeps the built-in wizard verbs. The status bar (`step x/y · Ns`) and tool spinners are unaffected.
 
+### Vim mode (`[ui]`)
+
+Modal (vim-style) editing for the input line, like Claude Code's. Toggle it live with `/vim` (or `/settings → Vim mode`), or set it as the default:
+
+```toml
+[ui]
+vim = true
+```
+
+The composer starts in **INSERT** (ordinary typing); **Esc** drops to **NORMAL**, where keys are motions and operators instead of text. The status bar shows the active mode and a block cursor marks NORMAL. Single-line vim:
+
+- **Motions:** `h`/`l` left/right, `0`/`^`/`$` line ends, `w`/`b`/`e` by word, `j`/`k` recall input history. A count prefix repeats them (`3w`, `2x`).
+- **Insert:** `i`/`a` before/after the cursor, `I`/`A` line start/end, `o`/`O` end/start (single-line analogs).
+- **Edits:** `x`/`X` delete a char, `r` replace one, `d`/`c`/`y` operators with a motion (`dw`, `c$`, `ye`) or doubled for the whole line (`dd`/`cc`/`yy`), `D`/`C`/`s`/`S`, `p`/`P` paste, `u` undo.
+
+The Ctrl readline chords (`Ctrl-A/E/U/W/K`, history, etc.) keep working in both modes, and **Enter** submits from either.
+
 ## Migrating from Ollama
 
 The local default is llama.cpp; Ollama stays fully supported but is opt-in:

--- a/src/app.rs
+++ b/src/app.rs
@@ -1984,6 +1984,12 @@ impl App {
         self.cursor += 1;
     }
 
+    /// Insert a hard line break at the cursor (Shift/Alt+Enter). The composer
+    /// grows to a multi-line box; Enter alone still submits.
+    fn insert_newline(&mut self) {
+        self.insert_char('\n');
+    }
+
     fn insert_str(&mut self, text: &str) {
         let index = self.byte_index();
         self.input.insert_str(index, text);
@@ -2376,6 +2382,14 @@ impl App {
                 }
 
                 // --- still-useful editing keys in Normal mode ---
+                KeyCode::Enter
+                    if key
+                        .modifiers
+                        .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT) =>
+                {
+                    self.vim.count = None;
+                    self.insert_newline();
+                }
                 KeyCode::Enter => {
                     self.vim.count = None;
                     action = self.submit();
@@ -2954,6 +2968,16 @@ impl App {
 
         let suggesting = !self.suggestions.is_empty();
         let action = match key.code {
+            // Shift+Enter (terminals with keyboard enhancement) or Alt+Enter
+            // (the fallback elsewhere) inserts a newline instead of submitting.
+            KeyCode::Enter
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT) =>
+            {
+                self.insert_newline();
+                None
+            }
             KeyCode::Enter => self.submit(),
             KeyCode::Backspace => {
                 self.delete_back();
@@ -3578,6 +3602,18 @@ fn setup_terminal() -> Result<Tui> {
         crossterm::event::EnableMouseCapture,
     )
     .context("entering alternate screen")?;
+    // Kitty keyboard protocol (best-effort): with disambiguation on, terminals
+    // report Shift+Enter as Enter+SHIFT instead of a bare Enter, which lets the
+    // composer bind it to a newline. Terminals that don't support it are left
+    // untouched (Alt+Enter is the fallback there). Popped in `restore_terminal`.
+    if crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false) {
+        let _ = crossterm::execute!(
+            stdout,
+            crossterm::event::PushKeyboardEnhancementFlags(
+                crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+            ),
+        );
+    }
     Terminal::new(CrosstermBackend::new(stdout)).context("creating terminal")
 }
 
@@ -3662,6 +3698,14 @@ fn copy_to_clipboard(text: &str) -> Result<()> {
 }
 
 fn restore_terminal() -> Result<()> {
+    // Pop the keyboard-enhancement flags pushed in `setup_terminal`. Done
+    // unconditionally (and ignoring errors): popping an empty/absent stack is a
+    // no-op on supporting terminals and an ignored escape elsewhere, which is
+    // safer than re-querying support from a panic/teardown path.
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::PopKeyboardEnhancementFlags,
+    );
     crossterm::execute!(
         std::io::stdout(),
         crossterm::event::DisableMouseCapture,
@@ -6063,6 +6107,11 @@ mod tests {
             .expect("key handled")
     }
 
+    fn press_mod(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<AppAction> {
+        app.handle_key(KeyEvent::new(code, mods))
+            .expect("key handled")
+    }
+
     fn type_str(app: &mut App, text: &str) {
         for c in text.chars() {
             press(app, KeyCode::Char(c));
@@ -7437,5 +7486,57 @@ mod tests {
         type_str(&mut app, "hjkl");
         press(&mut app, KeyCode::Esc); // plain clear, not a mode switch
         assert_eq!(app.input, "");
+    }
+
+    // --- Shift/Alt+Enter newline ---
+
+    #[test]
+    fn shift_enter_inserts_newline_without_submitting() {
+        let mut app = app();
+        type_str(&mut app, "line one");
+        let action = press_mod(&mut app, KeyCode::Enter, KeyModifiers::SHIFT);
+        assert!(action.is_none());
+        type_str(&mut app, "line two");
+        assert_eq!(app.input, "line one\nline two");
+        // Nothing was submitted.
+        assert!(!app.has_conversation());
+    }
+
+    #[test]
+    fn alt_enter_also_inserts_newline() {
+        let mut app = app();
+        type_str(&mut app, "a");
+        press_mod(&mut app, KeyCode::Enter, KeyModifiers::ALT);
+        type_str(&mut app, "b");
+        assert_eq!(app.input, "a\nb");
+    }
+
+    #[test]
+    fn plain_enter_submits_multiline_input() {
+        let mut app = app();
+        type_str(&mut app, "first");
+        press_mod(&mut app, KeyCode::Enter, KeyModifiers::SHIFT);
+        type_str(&mut app, "second");
+        let action = press(&mut app, KeyCode::Enter);
+        match action {
+            Some(AppAction::Submit(text)) => {
+                assert!(text.contains("first") && text.contains('\n') && text.contains("second"));
+            }
+            other => panic!("expected a submit action, got {other:?}"),
+        }
+        assert_eq!(app.input, "");
+    }
+
+    #[test]
+    fn shift_enter_inserts_newline_in_vim_normal_mode() {
+        let mut app = vim_app();
+        type_str(&mut app, "xy");
+        press(&mut app, KeyCode::Esc); // NORMAL, cursor on the last char
+        let action = press_mod(&mut app, KeyCode::Enter, KeyModifiers::SHIFT);
+        // A break is inserted (never submits); the cursor sits on a char, so it
+        // lands before it rather than at the very end.
+        assert!(action.is_none());
+        assert!(app.input.contains('\n'));
+        assert_eq!(app.input.chars().filter(|c| !c.is_whitespace()).count(), 2);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ use crate::session_registry::{self, SessionRecord, SessionState};
 use crate::skills::Skill;
 use crate::tools::registry::ToolRegistry;
 use crate::tools::todo::TodoItem;
+use crate::vim::{self, Pending, VimMode, VimOp, VimState};
 
 /// One rendered entry in the chat transcript.
 #[derive(Debug)]
@@ -201,6 +202,8 @@ pub enum SlashCommand {
     Login(String),
     /// `/settings` — open the in-app settings menu (a reusable picker).
     Settings,
+    /// `/vim` — toggle modal (vim-style) editing of the input composer.
+    Vim,
     /// Import the selected artifacts from Claude Code (`~/.claude/`). Not a
     /// typed command; dispatched from the `/settings` import picker, which is
     /// why it carries the [`ImportSelection`].
@@ -476,6 +479,7 @@ impl SlashCommand {
                 None => Err("usage: /login xai".to_string()),
             },
             "settings" => Ok(Self::Settings),
+            "vim" => Ok(Self::Vim),
             "quit" | "q" | "exit" => Ok(Self::Quit),
             other => Err(format!("unknown command '/{other}' — try /help")),
         };
@@ -646,6 +650,12 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "settings",
         args: "",
         description: "open the settings menu (change config anytime)",
+        takes_args: false,
+    },
+    CommandSpec {
+        name: "vim",
+        args: "",
+        description: "toggle vim-style modal editing of the input line",
         takes_args: false,
     },
     CommandSpec {
@@ -909,6 +919,9 @@ pub struct App {
     /// Cursor position in `input`, in characters.
     pub cursor: usize,
     pub input_mode: InputMode,
+    /// Modal (vim-style) editing state for the composer. Inert (always
+    /// insert-like) unless `vim.enabled`.
+    pub vim: VimState,
     pub transcript: Vec<TranscriptEntry>,
     /// Partial assistant text of the in-flight turn (moved into the
     /// transcript when the turn ends).
@@ -1052,6 +1065,12 @@ impl App {
         let omakase = config.omakase;
         let plan_mode = config.plan_first || omakase;
         let spinner_verb = config.ui.spinner_verb(0).to_string();
+        // Vim mode starts in Insert so typing works immediately; `Esc` drops
+        // to Normal.
+        let vim = VimState {
+            enabled: config.ui.vim,
+            ..VimState::default()
+        };
         let status = StatusLine {
             model: config.active().model,
             mode,
@@ -1067,6 +1086,7 @@ impl App {
             input: String::new(),
             cursor: 0,
             input_mode: InputMode::default(),
+            vim,
             transcript: Vec::new(),
             streaming: String::new(),
             streaming_thinking: String::new(),
@@ -1186,6 +1206,11 @@ impl App {
                 on(self.config.rollback_failed_cycles),
             ),
             (
+                "vim",
+                "Vim mode (modal input)".to_string(),
+                on(self.config.ui.vim),
+            ),
+            (
                 "web_backend",
                 "Web search backend".to_string(),
                 self.config.web.search_backend.clone(),
@@ -1256,6 +1281,16 @@ impl App {
                 // Handled by the main loop, which owns the terminal.
                 self.pending_edit_config = true;
                 return None;
+            }
+            "vim" => {
+                let on = !self.config.ui.vim;
+                self.config.ui.vim = on;
+                // Keep the live composer state in step with the persisted flag.
+                self.vim = VimState {
+                    enabled: on,
+                    mode: VimMode::Insert,
+                    ..VimState::default()
+                };
             }
             "plan_first" => self.config.plan_first = !self.config.plan_first,
             "continuous" => self.config.continuous = !self.config.continuous,
@@ -1917,9 +1952,15 @@ impl App {
 
     /// Byte offset of the cursor in `input`.
     fn byte_index(&self) -> usize {
+        self.char_byte(self.cursor)
+    }
+
+    /// Byte offset of character index `n` in `input` (its end when out of
+    /// range).
+    fn char_byte(&self, n: usize) -> usize {
         self.input
             .char_indices()
-            .nth(self.cursor)
+            .nth(n)
             .map(|(index, _)| index)
             .unwrap_or(self.input.len())
     }
@@ -1979,6 +2020,388 @@ impl App {
         while self.cursor > end {
             self.delete_back();
         }
+    }
+
+    // --- vim modal editing ---
+
+    /// `/vim`: toggle modal editing, persist the choice to `[ui] vim`, and
+    /// reset to Insert so typing works immediately when enabling.
+    pub fn toggle_vim(&mut self) {
+        let on = !self.vim.enabled;
+        self.vim = VimState {
+            enabled: on,
+            mode: VimMode::Insert,
+            ..VimState::default()
+        };
+        self.config.ui.vim = on;
+        if let Err(err) = self.config.save() {
+            self.notice(format!("could not save config: {err:#}"));
+        }
+        self.notice(if on {
+            "vim mode on — Esc for NORMAL (hjkl/w/b/e move · i/a/I/A insert · \
+             x/dd/dw/cw edit · u undo), i to type. /vim to leave"
+        } else {
+            "vim mode off"
+        });
+    }
+
+    /// Enter Insert mode (text entry resumes).
+    fn enter_insert(&mut self) {
+        self.vim.mode = VimMode::Insert;
+        self.vim.clear_pending();
+    }
+
+    /// Leave Insert for Normal mode. Vim nudges the cursor one cell left so it
+    /// sits on the last typed character rather than past it.
+    fn enter_normal_mode(&mut self) {
+        self.vim.mode = VimMode::Normal;
+        self.vim.clear_pending();
+        self.cursor = self.cursor.saturating_sub(1);
+        self.clamp_normal_cursor();
+    }
+
+    /// In Normal mode the cursor sits *on* a character, never past the last
+    /// one (an empty line keeps it at 0).
+    fn clamp_normal_cursor(&mut self) {
+        if self.vim.mode != VimMode::Normal {
+            return;
+        }
+        let len = self.input.chars().count();
+        self.cursor = if len == 0 {
+            0
+        } else {
+            self.cursor.min(len - 1)
+        };
+    }
+
+    /// Snapshot the line for `u` before a Normal-mode edit.
+    fn vim_snapshot(&mut self) {
+        let cursor = self.cursor;
+        self.vim.push_undo(&self.input, cursor);
+    }
+
+    /// Drop the most recent undo snapshot back into the line (`u`).
+    fn vim_undo(&mut self) {
+        if let Some((input, cursor)) = self.vim.undo.pop() {
+            self.input = input;
+            self.cursor = cursor;
+            self.clamp_normal_cursor();
+        }
+    }
+
+    /// Remove characters `[start, end)` and return them; leaves the cursor at
+    /// `start`. Used by `x`/`D` and the `d`/`c` operators.
+    fn vim_delete_range(&mut self, start: usize, end: usize) -> String {
+        let len = self.input.chars().count();
+        let start = start.min(len);
+        let end = end.min(len);
+        if start >= end {
+            return String::new();
+        }
+        let bstart = self.char_byte(start);
+        let bend = self.char_byte(end);
+        let removed = self.input[bstart..bend].to_string();
+        self.input.replace_range(bstart..bend, "");
+        self.cursor = start;
+        removed
+    }
+
+    /// Replace the character under the cursor with `c` (`r`).
+    fn vim_replace_char(&mut self, c: char) {
+        let len = self.input.chars().count();
+        if self.cursor >= len {
+            return;
+        }
+        self.vim_snapshot();
+        let idx = self.byte_index();
+        self.input.remove(idx);
+        self.input.insert(idx, c);
+    }
+
+    /// Apply an operator over the character range `[start, end)` (`dw`, `c$`,
+    /// `ye`, …). Delete/Change stash the text in the register; Change then
+    /// enters Insert. Yank only copies.
+    fn vim_apply_op(&mut self, op: VimOp, start: usize, end: usize) {
+        let (start, end) = (start.min(end), start.max(end));
+        if start >= end {
+            return;
+        }
+        match op {
+            VimOp::Yank => {
+                let bstart = self.char_byte(start);
+                let bend = self.char_byte(end);
+                self.vim.register = self.input[bstart..bend].to_string();
+            }
+            VimOp::Delete => {
+                self.vim_snapshot();
+                self.vim.register = self.vim_delete_range(start, end);
+                self.clamp_normal_cursor();
+            }
+            VimOp::Change => {
+                self.vim_snapshot();
+                self.vim.register = self.vim_delete_range(start, end);
+                self.enter_insert();
+            }
+        }
+    }
+
+    /// Linewise operator (`dd`/`cc`/`yy`): the whole single-line buffer.
+    fn vim_apply_linewise(&mut self, op: VimOp) {
+        match op {
+            VimOp::Yank => self.vim.register = self.input.clone(),
+            VimOp::Delete => {
+                self.vim_snapshot();
+                self.vim.register = std::mem::take(&mut self.input);
+                self.cursor = 0;
+            }
+            VimOp::Change => {
+                self.vim_snapshot();
+                self.vim.register = std::mem::take(&mut self.input);
+                self.cursor = 0;
+                self.enter_insert();
+            }
+        }
+    }
+
+    /// Paste the register `n` times, after the cursor (`p`) or before it
+    /// (`P`); the cursor lands on the last pasted character.
+    fn vim_paste(&mut self, after: bool, n: usize) {
+        if self.vim.register.is_empty() {
+            return;
+        }
+        self.vim_snapshot();
+        let text = self.vim.register.repeat(n.max(1));
+        let len = self.input.chars().count();
+        let at = if after && len > 0 {
+            (self.cursor + 1).min(len)
+        } else {
+            self.cursor
+        };
+        let byte = self.char_byte(at);
+        self.input.insert_str(byte, &text);
+        self.cursor = at + text.chars().count().saturating_sub(1);
+        self.clamp_normal_cursor();
+    }
+
+    /// Handle one key in Normal mode. Returns an [`AppAction`] only for keys
+    /// that submit (Enter); everything else mutates composer state in place.
+    fn handle_vim_normal(&mut self, key: KeyEvent) -> Result<Option<AppAction>> {
+        let mut action = None;
+        let printable = !key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT);
+        'dispatch: {
+            // `r` armed: the next printable key replaces the char under cursor.
+            if self.vim.pending == Some(Pending::Replace) {
+                self.vim.pending = None;
+                if let (KeyCode::Char(c), true) = (key.code, printable) {
+                    self.vim_replace_char(c);
+                }
+                break 'dispatch;
+            }
+
+            // Count prefix: digits accumulate (a leading `0` is the motion, not
+            // a count).
+            if let KeyCode::Char(c @ '0'..='9') = key.code
+                && printable
+                && !(c == '0' && self.vim.count.is_none())
+            {
+                let digit = c as usize - '0' as usize;
+                let next = self.vim.count.unwrap_or(0).saturating_mul(10) + digit;
+                self.vim.count = Some(next.min(100_000));
+                break 'dispatch;
+            }
+
+            // An operator is pending: read this key as its motion, or as the
+            // linewise form when the operator key repeats (`dd`/`cc`/`yy`).
+            if let Some(Pending::Operator(op)) = self.vim.pending {
+                self.vim.pending = None;
+                let n = self.vim.count.take().unwrap_or(1);
+                let repeated = matches!(
+                    (op, key.code),
+                    (VimOp::Delete, KeyCode::Char('d'))
+                        | (VimOp::Change, KeyCode::Char('c'))
+                        | (VimOp::Yank, KeyCode::Char('y'))
+                );
+                if repeated {
+                    self.vim_apply_linewise(op);
+                } else if let KeyCode::Char(motion) = key.code {
+                    let chars: Vec<char> = self.input.chars().collect();
+                    if let Some(m) = vim::resolve_motion(motion, n, &chars, self.cursor) {
+                        self.vim_apply_op(op, m.start, m.end);
+                    }
+                }
+                break 'dispatch;
+            }
+
+            let len = self.input.chars().count();
+            match key.code {
+                // --- motions ---
+                KeyCode::Char('h') | KeyCode::Left => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.cursor = self.cursor.saturating_sub(n);
+                }
+                KeyCode::Char('l') | KeyCode::Right | KeyCode::Char(' ') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.cursor = (self.cursor + n).min(len);
+                    self.clamp_normal_cursor();
+                }
+                KeyCode::Char('0') => {
+                    self.vim.count = None;
+                    self.cursor = 0;
+                }
+                KeyCode::Char('^') => {
+                    self.vim.count = None;
+                    let chars: Vec<char> = self.input.chars().collect();
+                    self.cursor = vim::first_non_blank(&chars);
+                }
+                KeyCode::Char('$') => {
+                    self.vim.count = None;
+                    self.cursor = len;
+                    self.clamp_normal_cursor();
+                }
+                KeyCode::Char('w') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    let chars: Vec<char> = self.input.chars().collect();
+                    for _ in 0..n {
+                        self.cursor = vim::word_forward(&chars, self.cursor);
+                    }
+                    self.clamp_normal_cursor();
+                }
+                KeyCode::Char('b') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    let chars: Vec<char> = self.input.chars().collect();
+                    for _ in 0..n {
+                        self.cursor = vim::word_back(&chars, self.cursor);
+                    }
+                }
+                KeyCode::Char('e') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    let chars: Vec<char> = self.input.chars().collect();
+                    for _ in 0..n {
+                        self.cursor = vim::word_end(&chars, self.cursor);
+                    }
+                    self.clamp_normal_cursor();
+                }
+                // Single-line analog of j/k: walk the input history.
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.vim.count = None;
+                    self.history_prev();
+                }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.vim.count = None;
+                    self.history_next();
+                }
+
+                // --- insert transitions ---
+                KeyCode::Char('i') => self.enter_insert(),
+                KeyCode::Char('I') => {
+                    let chars: Vec<char> = self.input.chars().collect();
+                    self.cursor = vim::first_non_blank(&chars);
+                    self.enter_insert();
+                }
+                KeyCode::Char('a') => {
+                    self.cursor = (self.cursor + 1).min(len);
+                    self.enter_insert();
+                }
+                KeyCode::Char('A') => {
+                    self.cursor = len;
+                    self.enter_insert();
+                }
+                // Single-line: `o`/`O` have no new line to open, so they map to
+                // append-at-end / insert-at-start.
+                KeyCode::Char('o') => {
+                    self.cursor = len;
+                    self.enter_insert();
+                }
+                KeyCode::Char('O') => {
+                    self.cursor = 0;
+                    self.enter_insert();
+                }
+
+                // --- edits ---
+                KeyCode::Char('x') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.vim_snapshot();
+                    self.vim.register = self.vim_delete_range(self.cursor, self.cursor + n);
+                    self.clamp_normal_cursor();
+                }
+                KeyCode::Char('X') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    let start = self.cursor.saturating_sub(n);
+                    self.vim_snapshot();
+                    self.vim.register = self.vim_delete_range(start, self.cursor);
+                }
+                KeyCode::Char('D') => {
+                    self.vim.count = None;
+                    self.vim_snapshot();
+                    self.vim.register = self.vim_delete_range(self.cursor, len);
+                    self.clamp_normal_cursor();
+                }
+                KeyCode::Char('C') => {
+                    self.vim.count = None;
+                    self.vim_snapshot();
+                    self.vim.register = self.vim_delete_range(self.cursor, len);
+                    self.enter_insert();
+                }
+                KeyCode::Char('s') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.vim_snapshot();
+                    self.vim.register = self.vim_delete_range(self.cursor, self.cursor + n);
+                    self.enter_insert();
+                }
+                KeyCode::Char('S') => {
+                    self.vim.count = None;
+                    self.vim_apply_linewise(VimOp::Change);
+                }
+                KeyCode::Char('r') => self.vim.pending = Some(Pending::Replace),
+
+                // --- operators (await a motion) ---
+                KeyCode::Char('d') => self.vim.pending = Some(Pending::Operator(VimOp::Delete)),
+                KeyCode::Char('c') => self.vim.pending = Some(Pending::Operator(VimOp::Change)),
+                KeyCode::Char('y') => self.vim.pending = Some(Pending::Operator(VimOp::Yank)),
+
+                // --- paste / undo ---
+                KeyCode::Char('p') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.vim_paste(true, n);
+                }
+                KeyCode::Char('P') => {
+                    let n = self.vim.count.take().unwrap_or(1);
+                    self.vim_paste(false, n);
+                }
+                KeyCode::Char('u') => {
+                    self.vim.count = None;
+                    self.vim_undo();
+                }
+
+                // --- still-useful editing keys in Normal mode ---
+                KeyCode::Enter => {
+                    self.vim.count = None;
+                    action = self.submit();
+                }
+                KeyCode::Backspace => {
+                    self.vim.count = None;
+                    self.cursor = self.cursor.saturating_sub(1);
+                }
+                // Esc keeps wizard's escape hatches (close diff, reset scroll)
+                // since Normal-mode Esc would otherwise be a no-op.
+                KeyCode::Esc => {
+                    self.vim.clear_pending();
+                    if self.show_diff {
+                        self.show_diff = false;
+                        self.diff_scroll = 0;
+                    } else if self.scroll > 0 {
+                        self.scroll = 0;
+                    }
+                }
+                KeyCode::PageUp => self.scroll = self.scroll.saturating_add(10),
+                KeyCode::PageDown => self.scroll = self.scroll.saturating_sub(10),
+                _ => self.vim.count = None,
+            }
+        }
+        self.sync_input_mode();
+        Ok(action)
     }
 
     // --- input history (↑/↓ recall, shell-style) ---
@@ -2508,6 +2931,25 @@ impl App {
         if (self.prompt.is_some() || self.web_key_backend.is_some()) && key.code == KeyCode::Esc {
             self.cancel_prompt();
             return Ok(None);
+        }
+
+        // Modal (vim) editing. In Normal mode keys are motions/operators, not
+        // text; in Insert mode the only extra binding is Esc → Normal, and
+        // everything else falls through to ordinary line editing below.
+        if self.vim.enabled {
+            match self.vim.mode {
+                VimMode::Normal => return self.handle_vim_normal(key),
+                VimMode::Insert => {
+                    if key.code == KeyCode::Esc
+                        && !key
+                            .modifiers
+                            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    {
+                        self.enter_normal_mode();
+                        return Ok(None);
+                    }
+                }
+            }
         }
 
         let suggesting = !self.suggestions.is_empty();
@@ -3526,6 +3968,7 @@ const HELP_TEXT: &str = "available commands:\n  \
 /status                     show session status (model, usage, todos, tasks)\n  \
 /goal [text]                show or set the standing mission goal\n  \
 /settings                   open the settings menu (change config anytime)\n  \
+/vim                        toggle vim-style modal editing of the input line\n  \
 /doctor                     diagnose config, providers, MCP, hooks, state dirs\n  \
 /quit                       exit\n\
 keys:\n  \
@@ -4308,6 +4751,7 @@ impl CommandContext<'_> {
             SlashCommand::Server(action) => self.server(action).await,
             SlashCommand::Login(provider) => self.login(provider),
             SlashCommand::Settings => self.app.open_settings_picker(),
+            SlashCommand::Vim => self.app.toggle_vim(),
             SlashCommand::ImportClaude(selection) => self.import_claude(selection).await,
         }
     }
@@ -5783,6 +6227,7 @@ mod tests {
                     "Musing".to_string(),
                     "Noodling".to_string(),
                 ],
+                vim: false,
             },
             ..Config::default()
         };
@@ -6876,5 +7321,121 @@ mod tests {
             .expect("key handled");
         assert!(action.is_none());
         assert!(app.picker.is_none());
+    }
+
+    // --- vim modal editing ---
+
+    fn vim_app() -> App {
+        let mut app = app();
+        app.toggle_vim();
+        assert!(app.vim.enabled);
+        assert_eq!(app.vim.mode, VimMode::Insert);
+        app
+    }
+
+    #[test]
+    fn esc_enters_normal_x_deletes_and_i_returns_to_insert() {
+        let mut app = vim_app();
+        type_str(&mut app, "hello");
+        assert_eq!(app.vim.mode, VimMode::Insert);
+        press(&mut app, KeyCode::Esc);
+        assert_eq!(app.vim.mode, VimMode::Normal);
+        // Leaving insert nudges the cursor left onto the last char ('o').
+        assert_eq!(app.cursor, 4);
+        // In normal mode 'x' deletes the char under the cursor, not insert 'x'.
+        press(&mut app, KeyCode::Char('x'));
+        assert_eq!(app.input, "hell");
+        press(&mut app, KeyCode::Char('i'));
+        assert_eq!(app.vim.mode, VimMode::Insert);
+    }
+
+    #[test]
+    fn word_motions_and_dw_in_normal_mode() {
+        let mut app = vim_app();
+        type_str(&mut app, "foo bar baz");
+        press(&mut app, KeyCode::Esc); // normal, cursor on last 'z'
+        press(&mut app, KeyCode::Char('0')); // start of line
+        assert_eq!(app.cursor, 0);
+        press(&mut app, KeyCode::Char('w')); // -> "bar"
+        assert_eq!(app.cursor, 4);
+        // dw deletes the word + trailing space.
+        press(&mut app, KeyCode::Char('d'));
+        press(&mut app, KeyCode::Char('w'));
+        assert_eq!(app.input, "foo baz");
+    }
+
+    #[test]
+    fn insert_transitions_append() {
+        let mut app = vim_app();
+        type_str(&mut app, "ab");
+        press(&mut app, KeyCode::Esc); // normal, cursor on 'b' (index 1)
+        press(&mut app, KeyCode::Char('0')); // index 0 ('a')
+        press(&mut app, KeyCode::Char('a')); // insert after 'a'
+        assert_eq!(app.vim.mode, VimMode::Insert);
+        press(&mut app, KeyCode::Char('X'));
+        assert_eq!(app.input, "aXb");
+        press(&mut app, KeyCode::Esc);
+        press(&mut app, KeyCode::Char('A')); // append at end
+        type_str(&mut app, "Z");
+        assert_eq!(app.input, "aXbZ");
+    }
+
+    #[test]
+    fn dd_clears_line_and_u_undoes() {
+        let mut app = vim_app();
+        type_str(&mut app, "scratch");
+        press(&mut app, KeyCode::Esc);
+        press(&mut app, KeyCode::Char('d'));
+        press(&mut app, KeyCode::Char('d'));
+        assert_eq!(app.input, "");
+        press(&mut app, KeyCode::Char('u'));
+        assert_eq!(app.input, "scratch");
+    }
+
+    #[test]
+    fn count_prefix_repeats_motion() {
+        let mut app = vim_app();
+        type_str(&mut app, "abcdef");
+        press(&mut app, KeyCode::Esc);
+        press(&mut app, KeyCode::Char('0'));
+        press(&mut app, KeyCode::Char('3'));
+        press(&mut app, KeyCode::Char('l')); // 3 right -> index 3
+        assert_eq!(app.cursor, 3);
+        press(&mut app, KeyCode::Char('2'));
+        press(&mut app, KeyCode::Char('x')); // delete 2 chars
+        assert_eq!(app.input, "abcf");
+    }
+
+    #[test]
+    fn delete_then_paste_register() {
+        let mut app = vim_app();
+        type_str(&mut app, "ab");
+        press(&mut app, KeyCode::Esc); // cursor on 'b' (index 1)
+        press(&mut app, KeyCode::Char('0')); // index 0
+        press(&mut app, KeyCode::Char('x')); // delete 'a' -> register "a", input "b"
+        assert_eq!(app.input, "b");
+        press(&mut app, KeyCode::Char('p')); // paste after 'b'
+        assert_eq!(app.input, "ba");
+    }
+
+    #[test]
+    fn enter_submits_in_normal_mode() {
+        let mut app = vim_app();
+        type_str(&mut app, "/help");
+        press(&mut app, KeyCode::Esc);
+        let action = press(&mut app, KeyCode::Enter);
+        assert!(matches!(
+            action,
+            Some(AppAction::Command(SlashCommand::Help))
+        ));
+        assert_eq!(app.input, "");
+    }
+
+    #[test]
+    fn disabled_vim_inserts_hjkl_literally() {
+        let mut app = app(); // vim off
+        type_str(&mut app, "hjkl");
+        press(&mut app, KeyCode::Esc); // plain clear, not a mode switch
+        assert_eq!(app.input, "");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,6 +157,17 @@ pub struct UiConfig {
     /// or empty keeps the defaults.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub spinner_verbs: Vec<String>,
+    /// Modal (vim-style) editing for the input composer: NORMAL/INSERT modes,
+    /// `hjkl`/word motions, `d`/`c`/`y` operators, `x`/`r`/`p`. Off by
+    /// default; toggle live with `/vim`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub vim: bool,
+}
+
+/// serde `skip_serializing_if` helper: keep `false` flags out of the written
+/// config so the file stays minimal.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl UiConfig {
@@ -970,6 +981,7 @@ mod tests {
             },
             ui: UiConfig {
                 spinner_verbs: vec!["Pondering".to_string(), "Musing".to_string()],
+                vim: true,
             },
             web: WebConfig {
                 fetch_max_bytes: 250_000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod skills;
 pub mod tools;
 pub mod ui;
 pub mod usage;
+pub mod vim;
 
 use std::io::IsTerminal;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,6 +36,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::app::{App, InputMode, Selection, TranscriptEntry};
 use crate::config::Mode;
 use crate::session_registry::SessionState;
+use crate::vim::VimMode;
 
 const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -701,6 +702,16 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(" · ", dim()),
         mode_span(app.status.mode),
     ];
+    // Vim mode indicator: NORMAL stands out (bold accent), INSERT stays quiet.
+    if let Some(label) = app.vim.label() {
+        spans.push(Span::styled(" · ", dim()));
+        let style = if app.vim.mode == VimMode::Normal {
+            accent().bold()
+        } else {
+            dim()
+        };
+        spans.push(Span::styled(label, style));
+    }
     if app.omakase {
         spans.push(Span::styled(" · ", dim()));
         spans.push(Span::styled("OMAKASE", accent().bold()));
@@ -837,16 +848,33 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
     let visible: String = chars[start..end].iter().collect();
     let cursor_x = area.x + (pad + prompt_width) as u16 + cursor_cols as u16;
 
-    let mut spans = vec![
-        Span::raw(" "),
-        Span::styled("❯ ", accent().bold()),
-        Span::raw(visible),
-    ];
+    // Vim Normal mode draws its own block cursor (reversed cell) instead of the
+    // terminal's thin bar, so the user can tell the modes apart at a glance.
+    let normal = app.vim.is_normal();
+    let mut spans = vec![Span::raw(" "), Span::styled("❯ ", accent().bold())];
+    if normal {
+        let vis: Vec<char> = chars[start..end].to_vec();
+        let rel = cursor.saturating_sub(start).min(vis.len());
+        let before: String = vis[..rel].iter().collect();
+        spans.push(Span::raw(before));
+        let block = Style::default().add_modifier(Modifier::REVERSED);
+        if rel < vis.len() {
+            spans.push(Span::styled(vis[rel].to_string(), block));
+            let after: String = vis[rel + 1..].iter().collect();
+            spans.push(Span::raw(after));
+        } else {
+            // Cursor past the last visible char (empty line): a reversed space.
+            spans.push(Span::styled(" ", block));
+        }
+    } else {
+        spans.push(Span::raw(visible));
+    }
 
     // Ghost text: the untyped remainder of the highlighted suggestion plus
     // its argument hint, dimmed (only when the whole input is visible and
     // the cursor sits at the end, where → can actually accept it).
-    if start == 0
+    if !normal
+        && start == 0
         && cursor == chars.len()
         && app.picker.is_none()
         && app.input_mode == InputMode::Command
@@ -872,7 +900,9 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
         area,
     );
 
-    if app.picker.is_none() && app.plan_review.is_none() && app.interview.is_none() {
+    // In Normal mode the block cursor above is the only cursor; leave the
+    // terminal's hardware cursor hidden.
+    if !normal && app.picker.is_none() && app.plan_review.is_none() && app.interview.is_none() {
         frame.set_cursor_position(Position::new(cursor_x, area.y + 1));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -40,6 +40,9 @@ use crate::vim::VimMode;
 
 const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
+/// Tallest the multi-line composer grows before it scrolls internally.
+const MAX_INPUT_ROWS: u16 = 10;
+
 /// The single accent color used for chrome (prompt, gutters, names,
 /// attention borders).
 const ACCENT: Color = Color::White;
@@ -62,9 +65,12 @@ fn accent() -> Style {
 /// Render one frame. The only entry point the main loop calls; everything
 /// else in this module is a helper.
 pub fn draw(frame: &mut Frame, app: &App) {
+    // The composer grows with its content (one row per hard line break) up to
+    // MAX_INPUT_ROWS, then scrolls internally. +2 for the rules above/below.
+    let input_rows = (app.input.split('\n').count() as u16).clamp(1, MAX_INPUT_ROWS);
     let [main_area, input_area, status_area] = Layout::vertical([
         Constraint::Min(1),
-        Constraint::Length(3),
+        Constraint::Length(input_rows + 2),
         Constraint::Length(1),
     ])
     .areas(frame.area());
@@ -828,82 +834,142 @@ fn draw_input(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         app.input.chars().collect()
     };
-    let widths: Vec<usize> = chars.iter().map(|c| c.width().unwrap_or(0)).collect();
     let cursor = app.cursor.min(chars.len());
-    // Keep the cursor visible: scroll the window (in display columns, so
-    // wide CJK/emoji glyphs count properly) until the cursor column fits,
-    // truncating the tail if needed.
-    let mut start = 0usize;
-    let mut cursor_cols: usize = widths[..cursor].iter().sum();
-    while start < cursor && cursor_cols > budget - 1 {
-        cursor_cols -= widths[start];
-        start += 1;
-    }
-    let mut end = start;
-    let mut used_cols = 0usize;
-    while end < chars.len() && used_cols + widths[end] <= budget {
-        used_cols += widths[end];
-        end += 1;
-    }
-    let visible: String = chars[start..end].iter().collect();
-    let cursor_x = area.x + (pad + prompt_width) as u16 + cursor_cols as u16;
-
-    // Vim Normal mode draws its own block cursor (reversed cell) instead of the
-    // terminal's thin bar, so the user can tell the modes apart at a glance.
     let normal = app.vim.is_normal();
-    let mut spans = vec![Span::raw(" "), Span::styled("❯ ", accent().bold())];
-    if normal {
-        let vis: Vec<char> = chars[start..end].to_vec();
-        let rel = cursor.saturating_sub(start).min(vis.len());
-        let before: String = vis[..rel].iter().collect();
-        spans.push(Span::raw(before));
-        let block = Style::default().add_modifier(Modifier::REVERSED);
-        if rel < vis.len() {
-            spans.push(Span::styled(vis[rel].to_string(), block));
-            let after: String = vis[rel + 1..].iter().collect();
-            spans.push(Span::raw(after));
-        } else {
-            // Cursor past the last visible char (empty line): a reversed space.
-            spans.push(Span::styled(" ", block));
+
+    // Split the buffer into logical rows on hard line breaks; each row is the
+    // half-open char range `[rs, re)` (the '\n' itself is not part of a row).
+    let mut rows: Vec<(usize, usize)> = Vec::new();
+    let mut start_char = 0usize;
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '\n' {
+            rows.push((start_char, i));
+            start_char = i + 1;
         }
+    }
+    rows.push((start_char, chars.len()));
+
+    // Locate the cursor (row, column-in-chars). `cursor <= re` puts an
+    // end-of-row cursor (just before the break) on that row, not the next.
+    let (mut crow, mut ccol) = (0usize, 0usize);
+    for (ri, &(rs, re)) in rows.iter().enumerate() {
+        if cursor <= re {
+            crow = ri;
+            ccol = cursor - rs;
+            break;
+        }
+    }
+
+    // Vertical window: show a block of rows that keeps the cursor row in view.
+    let content_h = (area.height as usize).saturating_sub(2).max(1);
+    let voff = if crow < content_h {
+        0
     } else {
-        spans.push(Span::raw(visible));
-    }
+        crow - content_h + 1
+    };
+    let last = (voff + content_h).min(rows.len());
 
-    // Ghost text: the untyped remainder of the highlighted suggestion plus
-    // its argument hint, dimmed (only when the whole input is visible and
-    // the cursor sits at the end, where → can actually accept it).
-    if !normal
-        && start == 0
-        && cursor == chars.len()
-        && app.picker.is_none()
-        && app.input_mode == InputMode::Command
-        && let Some(spec) = app.suggestions.get(app.suggestion_index)
-    {
-        let typed = app.input.trim_start().strip_prefix('/').unwrap_or_default();
-        if let Some(remainder) = spec.name.strip_prefix(typed) {
-            let mut ghost = remainder.to_string();
-            if !spec.args.is_empty() {
-                ghost.push(' ');
-                ghost.push_str(&spec.args);
-            }
-            let room = budget.saturating_sub(used_cols);
-            if !ghost.is_empty() && room > 0 {
-                let ghost: String = ghost.chars().take(room).collect();
-                spans.push(Span::styled(ghost, dim().italic()));
+    let block = Style::default().add_modifier(Modifier::REVERSED);
+    let mut lines: Vec<Line> = vec![rule.clone()];
+    let mut cursor_xy: Option<(u16, u16)> = None;
+
+    for ri in voff..last {
+        let (rs, re) = rows[ri];
+        let row: &[char] = &chars[rs..re];
+        let widths: Vec<usize> = row.iter().map(|c| c.width().unwrap_or(0)).collect();
+        let is_cursor_row = ri == crow;
+
+        // Only the cursor's row scrolls horizontally to keep the caret visible;
+        // other rows render from their start and truncate at the budget.
+        let mut hstart = 0usize;
+        if is_cursor_row {
+            let mut cols: usize = widths[..ccol.min(widths.len())].iter().sum();
+            while hstart < ccol && cols > budget - 1 {
+                cols -= widths[hstart];
+                hstart += 1;
             }
         }
+        let mut hend = hstart;
+        let mut used = 0usize;
+        while hend < row.len() && used + widths[hend] <= budget {
+            used += widths[hend];
+            hend += 1;
+        }
+
+        // First row carries the prompt glyph; continuation rows indent to match.
+        let leading = if ri == 0 {
+            Span::styled("❯ ", accent().bold())
+        } else {
+            Span::raw("  ")
+        };
+        let mut spans = vec![Span::raw(" "), leading];
+
+        if normal && is_cursor_row {
+            // Vim Normal mode paints its own block cursor (reversed cell) so the
+            // mode is legible without a hardware caret.
+            let rel = ccol.saturating_sub(hstart).min(hend - hstart);
+            spans.push(Span::raw(
+                row[hstart..hstart + rel].iter().collect::<String>(),
+            ));
+            if hstart + rel < hend {
+                spans.push(Span::styled(row[hstart + rel].to_string(), block));
+                spans.push(Span::raw(
+                    row[hstart + rel + 1..hend].iter().collect::<String>(),
+                ));
+            } else {
+                spans.push(Span::styled(" ", block));
+            }
+        } else {
+            spans.push(Span::raw(row[hstart..hend].iter().collect::<String>()));
+
+            // Ghost text (command completion) only makes sense on a single-row
+            // line with the cursor at the very end, where → can accept it.
+            if is_cursor_row
+                && !normal
+                && rows.len() == 1
+                && hstart == 0
+                && cursor == chars.len()
+                && app.picker.is_none()
+                && app.input_mode == InputMode::Command
+                && let Some(spec) = app.suggestions.get(app.suggestion_index)
+            {
+                let typed = app.input.trim_start().strip_prefix('/').unwrap_or_default();
+                if let Some(remainder) = spec.name.strip_prefix(typed) {
+                    let mut ghost = remainder.to_string();
+                    if !spec.args.is_empty() {
+                        ghost.push(' ');
+                        ghost.push_str(&spec.args);
+                    }
+                    let room = budget.saturating_sub(used);
+                    if !ghost.is_empty() && room > 0 {
+                        let ghost: String = ghost.chars().take(room).collect();
+                        spans.push(Span::styled(ghost, dim().italic()));
+                    }
+                }
+            }
+
+            if is_cursor_row && !normal {
+                let cols: usize = widths[hstart..ccol.min(widths.len())].iter().sum();
+                let x = area.x + (pad + prompt_width) as u16 + cols as u16;
+                let y = area.y + 1 + (ri - voff) as u16;
+                cursor_xy = Some((x, y));
+            }
+        }
+        lines.push(Line::from(spans));
     }
+    lines.push(rule);
 
-    frame.render_widget(
-        Paragraph::new(Text::from(vec![rule.clone(), Line::from(spans), rule])),
-        area,
-    );
+    frame.render_widget(Paragraph::new(Text::from(lines)), area);
 
-    // In Normal mode the block cursor above is the only cursor; leave the
-    // terminal's hardware cursor hidden.
-    if !normal && app.picker.is_none() && app.plan_review.is_none() && app.interview.is_none() {
-        frame.set_cursor_position(Position::new(cursor_x, area.y + 1));
+    // In Normal mode the block cursor above is the only cursor; otherwise place
+    // the terminal's caret on the cursor row.
+    if !normal
+        && app.picker.is_none()
+        && app.plan_review.is_none()
+        && app.interview.is_none()
+        && let Some((x, y)) = cursor_xy
+    {
+        frame.set_cursor_position(Position::new(x, y));
     }
 }
 

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,0 +1,323 @@
+//! Modal (vim-style) editing for the input composer.
+//!
+//! The composer is a single logical line (a `String` with a char-index
+//! cursor), so this is single-line vim: `hjkl`/`w`/`b`/`e`/`0`/`^`/`$`
+//! motions, the `d`/`c`/`y` operators with motions, `x`/`r`/`p` and the
+//! `i`/`a`/`I`/`A` insert transitions. `j`/`k` (no line to move to) recall
+//! input history, the natural single-line analog.
+//!
+//! [`VimState`] holds the mode and the small amount of pending state a modal
+//! editor needs (an operator awaiting its motion, a count prefix, the yank
+//! register, an undo stack). The key dispatch lives on
+//! [`App`](crate::app::App) so it can reuse the existing line-editing
+//! primitives; the pure motion math lives here, where it is unit-tested.
+
+/// Which half of modal editing the composer is in. When vim mode is disabled
+/// the composer behaves as if always in [`VimMode::Insert`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VimMode {
+    /// Keys are motions and operators; printable characters do not insert.
+    Normal,
+    /// Ordinary text entry (the default, and the only behavior when vim mode
+    /// is off).
+    #[default]
+    Insert,
+}
+
+/// A pending vim operator (`d`/`c`/`y`) — the half of a command that runs once
+/// its motion arrives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VimOp {
+    Delete,
+    Change,
+    Yank,
+}
+
+/// A multi-key command waiting for its next key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pending {
+    /// An operator (`d`/`c`/`y`) awaiting a motion, or a repeat of the same
+    /// key for the linewise form (`dd`/`cc`/`yy`).
+    Operator(VimOp),
+    /// `r` typed: the next printable key replaces the character under the
+    /// cursor.
+    Replace,
+}
+
+/// All modal-editing state for the composer.
+#[derive(Debug, Clone, Default)]
+pub struct VimState {
+    /// Whether modal editing is active at all (mirrors `[ui] vim` in config;
+    /// toggled live by `/vim`). When false the composer is always insert-like.
+    pub enabled: bool,
+    pub mode: VimMode,
+    /// A multi-key command in progress (operator awaiting a motion, or `r`).
+    pub pending: Option<Pending>,
+    /// Numeric count prefix being typed (`3w`, `d2w`), if any.
+    pub count: Option<usize>,
+    /// The yank/delete register, pasted by `p`/`P`.
+    pub register: String,
+    /// Undo snapshots `(input, cursor)` captured before each Normal-mode edit;
+    /// `u` pops the most recent.
+    pub undo: Vec<(String, usize)>,
+}
+
+/// Cap on the undo stack so a long session cannot grow it without bound.
+const UNDO_LIMIT: usize = 200;
+
+impl VimState {
+    /// True when keys should be read as motions/operators (vim on and in
+    /// Normal mode).
+    pub fn is_normal(&self) -> bool {
+        self.enabled && self.mode == VimMode::Normal
+    }
+
+    /// The status-bar mode tag, or `None` when modal editing is off.
+    pub fn label(&self) -> Option<&'static str> {
+        if !self.enabled {
+            return None;
+        }
+        Some(match self.mode {
+            VimMode::Normal => "NORMAL",
+            VimMode::Insert => "INSERT",
+        })
+    }
+
+    /// Clear the in-progress multi-key command (operator/count/replace).
+    pub fn clear_pending(&mut self) {
+        self.pending = None;
+        self.count = None;
+    }
+
+    /// Push an undo snapshot, trimming the oldest entry past [`UNDO_LIMIT`].
+    pub fn push_undo(&mut self, input: &str, cursor: usize) {
+        self.undo.push((input.to_string(), cursor));
+        if self.undo.len() > UNDO_LIMIT {
+            self.undo.remove(0);
+        }
+    }
+}
+
+/// Character class for word motions. Vim treats a run of "word" characters
+/// (alphanumeric + `_`), a run of punctuation, and whitespace as distinct, so
+/// `w` stops at a word↔punctuation boundary even without intervening space.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Class {
+    Blank,
+    Word,
+    Punct,
+}
+
+fn classify(c: char) -> Class {
+    if c.is_whitespace() {
+        Class::Blank
+    } else if c.is_alphanumeric() || c == '_' {
+        Class::Word
+    } else {
+        Class::Punct
+    }
+}
+
+/// `w`: start of the next word. Skips the rest of the current word/punct run,
+/// then any whitespace, landing on the next non-blank character (or the end).
+pub fn word_forward(chars: &[char], cursor: usize) -> usize {
+    let len = chars.len();
+    let mut i = cursor;
+    if i >= len {
+        return len;
+    }
+    let start = classify(chars[i]);
+    if start != Class::Blank {
+        while i < len && classify(chars[i]) == start {
+            i += 1;
+        }
+    }
+    while i < len && classify(chars[i]) == Class::Blank {
+        i += 1;
+    }
+    i
+}
+
+/// `b`: start of the current word, or of the previous word when already at a
+/// boundary.
+pub fn word_back(chars: &[char], cursor: usize) -> usize {
+    if cursor == 0 {
+        return 0;
+    }
+    let mut i = cursor - 1;
+    while i > 0 && classify(chars[i]) == Class::Blank {
+        i -= 1;
+    }
+    if classify(chars[i]) == Class::Blank {
+        return 0;
+    }
+    let class = classify(chars[i]);
+    while i > 0 && classify(chars[i - 1]) == class {
+        i -= 1;
+    }
+    i
+}
+
+/// `e`: end of the next word (the last character of that word).
+pub fn word_end(chars: &[char], cursor: usize) -> usize {
+    let len = chars.len();
+    if len == 0 {
+        return 0;
+    }
+    let mut i = cursor;
+    // `e` always advances at least one cell before looking for a word end.
+    if i < len {
+        i += 1;
+    }
+    while i < len && classify(chars[i]) == Class::Blank {
+        i += 1;
+    }
+    if i >= len {
+        return len - 1;
+    }
+    let class = classify(chars[i]);
+    while i + 1 < len && classify(chars[i + 1]) == class {
+        i += 1;
+    }
+    i
+}
+
+/// `^`: index of the first non-blank character (or 0 for an all-blank/empty
+/// line).
+pub fn first_non_blank(chars: &[char]) -> usize {
+    chars.iter().position(|c| !c.is_whitespace()).unwrap_or(0)
+}
+
+/// Where a motion key lands the cursor, and the character range an operator
+/// applied with that motion would cover. `start..end` is always normalized
+/// (`start <= end`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Motion {
+    /// Cursor destination for a bare motion.
+    pub target: usize,
+    /// Inclusive-start, exclusive-end character range for an operator.
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Resolve a motion key into a [`Motion`] over `chars` from `cursor`, applying
+/// the count `n`. Returns `None` for keys that are not motions.
+pub fn resolve_motion(key: char, n: usize, chars: &[char], cursor: usize) -> Option<Motion> {
+    let len = chars.len();
+    let n = n.max(1);
+    let range = |a: usize, b: usize| (a.min(b), a.max(b));
+    let (target, (start, end)) = match key {
+        'h' => {
+            let t = cursor.saturating_sub(n);
+            (t, range(t, cursor))
+        }
+        'l' | ' ' => {
+            let t = (cursor + n).min(len);
+            (t, range(cursor, t))
+        }
+        '0' => (0, range(0, cursor)),
+        '^' => {
+            let t = first_non_blank(chars);
+            (t, range(t, cursor))
+        }
+        '$' => (len, range(cursor, len)),
+        'w' => {
+            let mut t = cursor;
+            for _ in 0..n {
+                t = word_forward(chars, t);
+            }
+            (t, range(cursor, t))
+        }
+        'b' => {
+            let mut t = cursor;
+            for _ in 0..n {
+                t = word_back(chars, t);
+            }
+            (t, range(t, cursor))
+        }
+        'e' => {
+            let mut t = cursor;
+            for _ in 0..n {
+                t = word_end(chars, t);
+            }
+            // `e` is inclusive: an operator eats through the word-end cell.
+            (t, range(cursor, (t + 1).min(len)))
+        }
+        _ => return None,
+    };
+    Some(Motion { target, start, end })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cv(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    #[test]
+    fn word_forward_across_classes() {
+        let c = cv("foo bar.baz");
+        assert_eq!(word_forward(&c, 0), 4); // foo -> bar
+        assert_eq!(word_forward(&c, 4), 7); // bar -> .
+        assert_eq!(word_forward(&c, 7), 8); // . -> baz
+        assert_eq!(word_forward(&c, 8), c.len()); // baz -> end
+    }
+
+    #[test]
+    fn word_back_across_classes() {
+        let c = cv("foo bar.baz");
+        assert_eq!(word_back(&c, c.len()), 8); // from end -> baz
+        assert_eq!(word_back(&c, 8), 7); // baz -> .
+        assert_eq!(word_back(&c, 7), 4); // . -> bar
+        assert_eq!(word_back(&c, 4), 0); // bar -> foo
+        assert_eq!(word_back(&c, 0), 0);
+    }
+
+    #[test]
+    fn word_end_lands_on_last_char() {
+        let c = cv("foo bar");
+        assert_eq!(word_end(&c, 0), 2); // end of foo
+        assert_eq!(word_end(&c, 2), 6); // end of bar
+        assert_eq!(word_end(&c, 6), 6); // already at last
+    }
+
+    #[test]
+    fn first_non_blank_skips_leading_space() {
+        assert_eq!(first_non_blank(&cv("   hi")), 3);
+        assert_eq!(first_non_blank(&cv("hi")), 0);
+        assert_eq!(first_non_blank(&cv("   ")), 0);
+        assert_eq!(first_non_blank(&cv("")), 0);
+    }
+
+    #[test]
+    fn dollar_and_zero_motions() {
+        let c = cv("hello");
+        let m = resolve_motion('$', 1, &c, 0).unwrap();
+        assert_eq!((m.start, m.end), (0, 5));
+        let m = resolve_motion('0', 1, &c, 3).unwrap();
+        assert_eq!((m.start, m.end), (0, 3));
+    }
+
+    #[test]
+    fn counted_word_motion() {
+        let c = cv("a b c d");
+        let m = resolve_motion('w', 2, &c, 0).unwrap();
+        assert_eq!(m.target, 4); // a -> c
+    }
+
+    #[test]
+    fn e_motion_range_is_inclusive() {
+        let c = cv("foo bar");
+        // `de` from 0 should cover "foo" (chars 0..3).
+        let m = resolve_motion('e', 1, &c, 0).unwrap();
+        assert_eq!((m.start, m.end), (0, 3));
+    }
+
+    #[test]
+    fn non_motion_key_is_none() {
+        let c = cv("foo");
+        assert!(resolve_motion('z', 1, &c, 0).is_none());
+    }
+}


### PR DESCRIPTION
Two related composer upgrades.

## Vim mode

Opt-in modal editing for the input line, like Claude Code's. Toggle live with `/vim` (or `/settings → Vim mode`), or persist with `[ui] vim = true`.

- INSERT by default; **Esc** → NORMAL (status-bar tag + block cursor).
- Motions `h`/`l`/`0`/`^`/`$`/`w`/`b`/`e`, `j`/`k` recall history, count prefixes.
- Insert `i`/`a`/`I`/`A`/`o`/`O`; edits `x`/`X`/`r`, `d`/`c`/`y` operators (+ motion or doubled), `D`/`C`/`s`/`S`, `p`/`P`, `u`.
- Pure motion math in a new `vim` module (unit-tested); dispatch reuses the existing line-editing primitives. Off ⇒ unchanged behavior.

## Shift+Enter → newline (multi-line composer)

**Enter** still submits; **Shift+Enter** inserts a hard line break for multi-line prompts. The composer renders multi-line — growing one row per line up to a cap, then scrolling internally — with the cursor (and the vim block cursor) tracked across rows.

- `setup_terminal` pushes the Kitty `DISAMBIGUATE_ESCAPE_CODES` flag when the terminal supports it, so Shift+Enter is reported as Enter+SHIFT (popped on restore). **Alt+Enter** is the fallback elsewhere.
- `draw_input` rewritten for multi-line layout (per-row horizontal scroll on the cursor row, continuation-row indent, vertical windowing).
- Pasted multi-line text now renders correctly too.

## Tests

606 passing (motion math, modal key dispatch, newline insert/submit). `cargo clippy --all-targets` and `cargo fmt --check` clean.