### PR TITLE
NixOS support: flake + static musl binaries + NixOS-aware installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+          - target: aarch64-unknown-linux-musl
             runner: ubuntu-22.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
@@ -36,16 +40,26 @@ jobs:
           echo "Releasing version ${cargo_version}"
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install musl tooling
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
       - name: Build (release)
-        run: cargo build --release
+        env:
+          # Statically link the C runtime for the musl targets so the binary
+          # carries no dynamic loader dependency (runs on NixOS/Alpine/old glibc).
+          RUSTFLAGS: ${{ contains(matrix.target, '-musl') && '-C target-feature=+crt-static' || '' }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package
         run: |
-          strip target/release/wizard
-          tar -C target/release -czf "wizard-${{ matrix.target }}.tar.gz" wizard
+          strip "target/${{ matrix.target }}/release/wizard"
+          tar -C "target/${{ matrix.target }}/release" -czf "wizard-${{ matrix.target }}.tar.gz" wizard
 
       - uses: actions/upload-artifact@v7
         with:
@@ -71,5 +85,7 @@ jobs:
           prerelease: false
           files: |
             wizard-x86_64-unknown-linux-gnu.tar.gz
+            wizard-x86_64-unknown-linux-musl.tar.gz
             wizard-aarch64-unknown-linux-gnu.tar.gz
+            wizard-aarch64-unknown-linux-musl.tar.gz
             checksums.txt

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,155 @@
+{
+  description = "wizard — One line. Your sovereign agent. Self-extending. Fully local.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      # The fusion-core git dependency from Cargo.lock. buildRustPackage's
+      # cargoLock vendors crates.io crates by their lock hashes, but a git
+      # dependency needs its fixed-output hash supplied explicitly, keyed by
+      # "<name>-<version>".
+      fusionCoreHash = "sha256-zzXJTpv4JOLt7ubP4gRZn23VHPrrW1bjeF4AH1FLJUA=";
+
+      mkWizard =
+        pkgs:
+        let
+          inherit (pkgs) lib;
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+          # Runtime tools wizard shells out to for the default loadout:
+          # nodejs provides npx (Playwright MCP), llama-cpp provides
+          # llama-server, and ollama for local models.
+          runtimeBins = [
+            pkgs.nodejs
+            pkgs.llama-cpp
+            pkgs.ollama
+          ];
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          pname = "wizard";
+          version = cargoToml.package.version;
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "fusion-core-0.1.0" = fusionCoreHash;
+            };
+          };
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          # Put the optional runtime helpers on PATH so the default loadout
+          # (Playwright MCP via npx, local models via llama-server/ollama)
+          # works out of the box.
+          postInstall = ''
+            wrapProgram $out/bin/wizard \
+              --prefix PATH : ${lib.makeBinPath runtimeBins}
+          '';
+
+          doCheck = false;
+
+          meta = {
+            description = cargoToml.package.description;
+            homepage = cargoToml.package.repository;
+            license = lib.licenses.mit;
+            mainProgram = "wizard";
+          };
+        };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+      in
+      {
+        packages = {
+          default = pkgs.wizard;
+          wizard = pkgs.wizard;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${pkgs.wizard}/bin/wizard";
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ pkgs.wizard ];
+          packages = [
+            pkgs.rustc
+            pkgs.cargo
+            pkgs.clippy
+            pkgs.rustfmt
+            pkgs.nodejs
+            pkgs.llama-cpp
+          ];
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+        };
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        wizard = mkWizard final;
+      };
+
+      homeManagerModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.wizard;
+          tomlFormat = pkgs.formats.toml { };
+        in
+        {
+          options.programs.wizard = {
+            enable = lib.mkEnableOption "wizard, the sovereign self-extending agent";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = mkWizard pkgs;
+              defaultText = lib.literalExpression "wizard.packages.\${system}.default";
+              description = "The wizard package to install.";
+            };
+
+            settings = lib.mkOption {
+              type = tomlFormat.type;
+              default = { };
+              example = lib.literalExpression ''
+                {
+                  provider = "ollama";
+                  model = "qwen3:0.6b";
+                }
+              '';
+              description = ''
+                Declarative wizard configuration written to
+                {file}`~/.wizard/config.toml`. Leave empty to manage the
+                config imperatively.
+              '';
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+
+            home.file.".wizard/config.toml" = lib.mkIf (cfg.settings != { }) {
+              source = tomlFormat.generate "wizard-config.toml" cfg.settings;
+            };
+          };
+        };
+    };
+}

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,8 @@
 #                     loadout; the first `wizard` run starts onboarding
 #
 # Environment variables:
-#   WIZARD_INSTALL_DIR           where to place the binary    (default /usr/local/bin)
+#   WIZARD_INSTALL_DIR           where to place the binary    (default /usr/local/bin;
+#                                ~/.local/bin on NixOS)
 #   WIZARD_LOCAL                 1 = preinstall the llama.cpp stack and a model
 #                                    (see above)               (default 0)
 #   WIZARD_MINIMAL               1 = minimal install (see above)        (default 0)
@@ -72,9 +73,28 @@
 
 set -euo pipefail
 
+# --- NixOS detection ----------------------------------------------------
+# Defined early so the install-dir default below can branch on it. NixOS is
+# not an FHS distro: prebuilt glibc binaries can't find /lib64/ld-linux and
+# /usr/local/bin isn't on PATH, so the installer selects the static musl
+# asset and installs to ~/.local/bin instead.
+is_nixos() {
+    [ -f /etc/NIXOS ] && return 0
+    [ -r /etc/os-release ] && grep -qiE '^ID=nixos' /etc/os-release
+}
+
 # --- defaults -----------------------------------------------------------
 
-WIZARD_INSTALL_DIR="${WIZARD_INSTALL_DIR:-/usr/local/bin}"
+# /usr/local/bin is the right default on FHS distros, but not on NixOS (not on
+# PATH, wrong place for an FHS binary). An explicit WIZARD_INSTALL_DIR override
+# always wins; otherwise pick ~/.local/bin on NixOS, /usr/local/bin elsewhere.
+if [ -z "${WIZARD_INSTALL_DIR:-}" ]; then
+    if is_nixos; then
+        WIZARD_INSTALL_DIR="$HOME/.local/bin"
+    else
+        WIZARD_INSTALL_DIR="/usr/local/bin"
+    fi
+fi
 WIZARD_LOCAL="${WIZARD_LOCAL:-0}"
 WIZARD_MINIMAL="${WIZARD_MINIMAL:-0}"
 WIZARD_BYOM="${WIZARD_BYOM:-0}"
@@ -165,6 +185,20 @@ detect_platform() {
 
 require_curl() {
     command -v curl >/dev/null 2>&1 || die "curl is required but was not found on PATH"
+}
+
+nixos_banner() {
+    printf '\n'
+    say "NixOS detected."
+    warn "The supported, idiomatic way to run Wizard on NixOS is Nix, not this script:"
+    printf '\n' >&2
+    printf '    nix run github:%s              # run without installing\n' "$WIZARD_REPO" >&2
+    printf '    nix profile install github:%s  # add to your profile\n' "$WIZARD_REPO" >&2
+    printf '    # or add the flake as an input to your system/home configuration\n' >&2
+    printf '\n' >&2
+    warn "Proceeding with a static musl binary instead → ${WIZARD_INSTALL_DIR}"
+    warn "Set WIZARD_INSTALL_DIR to override the install location."
+    printf '\n'
 }
 
 # --- llama.cpp ----------------------------------------------------------
@@ -386,6 +420,18 @@ install_llamacpp() {
         say "Skipping llama.cpp install (WIZARD_SKIP_LLAMACPP_INSTALL=1)"
         return
     fi
+    # On NixOS, never compile from source or drop a prebuilt FHS binary — use an
+    # existing llama-server if present, otherwise point the user at Nix.
+    if is_nixos; then
+        if command -v llama-server >/dev/null 2>&1; then
+            say "llama-server already on PATH ($(command -v llama-server)) — wizard will use it"
+        else
+            warn "On NixOS, install llama.cpp declaratively instead of compiling it here:"
+            warn "    nix profile install nixpkgs#llama-cpp"
+            warn "then re-run (or add it to your system/home configuration). Skipping for now."
+        fi
+        return
+    fi
     # Decide the GPU strategy up front (needs to know whether a GPU is present).
     # NVIDIA → compile a CUDA build (the only reliable NVIDIA path; no prebuilt
     # CUDA asset exists and the Vulkan prebuilt can't see NVIDIA without an ICD).
@@ -500,6 +546,11 @@ install_ollama() {
     if command -v ollama >/dev/null 2>&1; then
         say "Ollama already installed"
         return
+    fi
+    # On NixOS the curl|sh Ollama installer drops an FHS binary that won't run —
+    # require a declarative install instead.
+    if is_nixos; then
+        die "On NixOS, install Ollama declaratively rather than via the curl installer — e.g. 'nix profile install nixpkgs#ollama' (or set services.ollama.enable = true), then re-run."
     fi
     say "Installing Ollama (official install script) ..."
     curl -fsSL https://ollama.com/install.sh | sh \
@@ -886,8 +937,18 @@ verify_checksum() {
 
 download_binary() {
     say "Downloading wizard binary from GitHub releases (${REPO}) ..."
-    local asset bin
-    for asset in "wizard-${ARCH}-unknown-linux-gnu.tar.gz" "wizard-linux-${ARCH}.tar.gz"; do
+    local asset bin assets
+    # NixOS can't run the glibc (gnu) binary — no dynamic loader at the FHS
+    # path — so prefer the static musl asset there. Elsewhere try gnu first,
+    # but keep musl as a fallback: if the gnu binary fails its sanity check
+    # (loader/glibc mismatch on an old or unusual host), the loop drops to the
+    # static musl build automatically.
+    if is_nixos; then
+        assets="wizard-${ARCH}-unknown-linux-musl.tar.gz wizard-${ARCH}-unknown-linux-gnu.tar.gz wizard-linux-${ARCH}.tar.gz"
+    else
+        assets="wizard-${ARCH}-unknown-linux-gnu.tar.gz wizard-${ARCH}-unknown-linux-musl.tar.gz wizard-linux-${ARCH}.tar.gz"
+    fi
+    for asset in $assets; do
         if download_release_asset "$asset" "${TMP_DIR}/${asset}"; then
             verify_checksum "${TMP_DIR}/${asset}" "${asset}"
             tar -xzf "${TMP_DIR}/${asset}" -C "$TMP_DIR" || continue
@@ -1306,6 +1367,10 @@ main() {
     fi
     require_curl
     detect_platform
+
+    if is_nixos; then
+        nixos_banner
+    fi
 
     if [ "$WIZARD_MINIMAL" = "1" ]; then
         say "Minimal install (WIZARD_MINIMAL=1): binary only — no model runtime, model, config, or loadout"


### PR DESCRIPTION
First-class NixOS support, addressing the core problem that the `curl | bash` one-liner ships a glibc binary that **cannot execute on NixOS** (no FHS dynamic loader).

## Static musl release targets (`release.yml`)
- Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` alongside the existing gnu targets. Fully static (`crt-static`, rustls — no native C deps), so the prebuilt binary now runs on NixOS, Alpine, containers, and old-glibc hosts.
- Artifact naming kept as `wizard-<triple>.tar.gz`; checksums + release upload extended.

## NixOS-aware installer (`install.sh`)
- `is_nixos()` detection (`/etc/NIXOS` or `ID=nixos`).
- On NixOS: selects the **musl** asset, defaults install dir to `~/.local/bin` (not `/usr/local/bin`), and prints a banner pointing at the idiomatic `nix run github:teddytennant/wizard`.
- Skips imperative llama.cpp source-compile and the `ollama` `curl | sh` installer on NixOS — points at `nixpkgs#llama-cpp` / `nixpkgs#ollama` (or reuses them if already on PATH).
- Resilience: non-NixOS hosts fall back from the gnu asset to musl if the gnu binary fails to execute.
- Non-NixOS glibc → `/usr/local/bin` flow is unchanged. shellcheck clean.

## Flake (`flake.nix` + `flake.lock`)
- `packages.default` / `packages.wizard` via `rustPlatform.buildRustPackage` (handles the `fusion-core` git dep via `cargoLock.outputHashes`), wrapped so `nodejs`/`llama-cpp`/`ollama` are on the binary's PATH.
- `apps.default` (`nix run`), `devShells.default`, `overlays.default`, and a `homeManagerModules.default` that can render `~/.wizard/config.toml` declaratively.
- Validated: `nix build .#default` → `wizard 0.3.5`; `nix flake check` passes.

## Validation
- `nix build` + `nix flake check`: pass
- `shellcheck install.sh install-byom.sh`: clean
- `release.yml` YAML parses