### PR TITLE
feat: externalize the full harness surface as loadable bundles

### DIFF
--- a/docs/evolve.md
+++ b/docs/evolve.md
@@ -58,6 +58,21 @@ Saved as `~/.wizard/tools/mermaid-png.sh` with a manifest describing its name, a
 
 The baked-in base personality prompt can be replaced at runtime by a file: `~/.wizard/system_prompt.md` (or the path in `$WIZARD_SYSTEM_PROMPT`, which wins). When present and non-empty, its contents replace the compiled prompt for the active mode; absent, behavior is identical to the default. The bundled `WIZARD.md` charter, skills, project instructions, and memory sections are always appended on top, so this override tunes personality/instructions without dropping the charter. This is the surface external harness-evolution tooling (e.g. AHE) mutates to measure and improve prompt quality.
 
+### Harness bundles
+
+The full evolvable surface — not just the prompt — can be externalized as a *harness bundle*: a directory activated with `--harness-dir <dir>` (or `$WIZARD_HARNESS_DIR`) whose files shadow the compiled defaults per component:
+
+```
+<bundle>/
+  system_prompt.md            # base personality prompt (highest-precedence override)
+  tool_descriptions/<tool>.md # description advertised to the model for that native tool
+  skills/<name>/SKILL.md      # shadows bundled and user skills by name
+  subagents/<name>.toml       # shadows user-defined and built-in subagents by name
+  HARNESS.md                  # generated guide for evolution agents
+```
+
+Any missing or empty file falls back to the compiled default, so a partial or broken bundle degrades gracefully and deleting a file reverts that component. `wizard harness export <dir>` dumps the current compiled defaults as a bundle — the seed an external harness-evolution loop (e.g. AHE) edits, measures, and hands back for review. Winning changes get baked into the source as new defaults and re-exported, which is what makes the loop recursive. Methodology credit: [Agentic Harness Engineering](https://github.com/china-qijizhifeng/agentic-harness-engineering) (arXiv:2604.25850).
+
 ### Subagents
 
 Configure a named, reusable subagent with its own prompt, tool scope, and step budget, for fan-out or specialized sub-tasks.

--- a/docs/evolve.md
+++ b/docs/evolve.md
@@ -54,6 +54,10 @@ The agent authors a small script (the Hermes `execute_code` analog), saved to `~
 
 Saved as `~/.wizard/tools/mermaid-png.sh` with a manifest describing its name, arguments, and description; exposed as a normal tool after `/reload`.
 
+### System prompt override
+
+The baked-in base personality prompt can be replaced at runtime by a file: `~/.wizard/system_prompt.md` (or the path in `$WIZARD_SYSTEM_PROMPT`, which wins). When present and non-empty, its contents replace the compiled prompt for the active mode; absent, behavior is identical to the default. The bundled `WIZARD.md` charter, skills, project instructions, and memory sections are always appended on top, so this override tunes personality/instructions without dropping the charter. This is the surface external harness-evolution tooling (e.g. AHE) mutates to measure and improve prompt quality.
+
 ### Subagents
 
 Configure a named, reusable subagent with its own prompt, tool scope, and step budget, for fan-out or specialized sub-tasks.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1488,6 +1488,7 @@ pub async fn build_headless_agent(
     if let Err(err) = base.attach_mcp(&manager).await {
         tracing::warn!("attaching MCP tools failed: {err}");
     }
+    base.apply_harness_overrides();
 
     let subagents_dir = Config::subagents_dir()?;
     let subagent_configs = subagent::available_configs(&subagents_dir);

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -128,9 +128,17 @@ fn base_system_prompt(mode: Mode) -> String {
         .unwrap_or_else(|| default.to_string())
 }
 
-/// The path an override would live at, if any: `$WIZARD_SYSTEM_PROMPT` wins,
-/// else the well-known `~/.wizard/system_prompt.md`.
+/// The path an override would live at, if any: the harness bundle's
+/// `system_prompt.md` wins when it exists (so a bundle missing the file
+/// degrades to the next candidate), then `$WIZARD_SYSTEM_PROMPT`, then the
+/// well-known `~/.wizard/system_prompt.md`.
 fn override_path() -> Option<PathBuf> {
+    if let Some(dir) = Config::harness_dir() {
+        let bundled = dir.join("system_prompt.md");
+        if bundled.exists() {
+            return Some(bundled);
+        }
+    }
     if let Some(p) = std::env::var_os("WIZARD_SYSTEM_PROMPT") {
         return Some(PathBuf::from(p));
     }

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -1,7 +1,9 @@
 //! System prompts: genie vs sovereign personalities, plus composition with
 //! skills, the bundled WIZARD.md charter, and project `AGENTS.md`.
 
-use crate::config::Mode;
+use std::path::{Path, PathBuf};
+
+use crate::config::{Config, Mode};
 use crate::llm::ToolSpec;
 use crate::skills::Skill;
 
@@ -83,6 +85,42 @@ record it with action \"save\" (kebab-case name, one-line description); it \
 will appear in your system prompt next session. Don't save things the repo \
 already records.";
 
+/// Resolve the base personality prompt for `mode`. An external override —
+/// `$WIZARD_SYSTEM_PROMPT` if set, otherwise `~/.wizard/system_prompt.md` —
+/// replaces the compiled default when it exists and is non-empty. This is the
+/// single file external harness-evolution tools (e.g. AHE) mutate; with no
+/// override present, the result is byte-identical to the baked prompt. The
+/// charter, skills, instructions, and memory sections are always appended on
+/// top by [`build_system_prompt`], so the charter cannot be evolved away here.
+fn base_system_prompt(mode: Mode) -> String {
+    let default = match mode {
+        Mode::Genie => GENIE_SYSTEM_PROMPT,
+        Mode::Sovereign => SOVEREIGN_SYSTEM_PROMPT,
+    };
+    override_path()
+        .as_deref()
+        .and_then(read_prompt_override)
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The path an override would live at, if any: `$WIZARD_SYSTEM_PROMPT` wins,
+/// else the well-known `~/.wizard/system_prompt.md`.
+fn override_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("WIZARD_SYSTEM_PROMPT") {
+        return Some(PathBuf::from(p));
+    }
+    Config::system_prompt_path().ok()
+}
+
+/// Read an override file, returning its trimmed contents only when the file
+/// exists and is non-empty. A missing or empty file yields `None` so the
+/// caller falls back to the baked default.
+fn read_prompt_override(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 /// Compose the full system prompt for `mode`: personality prompt, then the
 /// bundled `WIZARD.md` charter, then a rendered skills section, then the
 /// project's instruction hierarchy (`agents_md`, assembled by
@@ -95,12 +133,7 @@ pub fn build_system_prompt(
     agents_md: Option<&str>,
     memory_index: Option<&str>,
 ) -> String {
-    let base = match mode {
-        Mode::Genie => GENIE_SYSTEM_PROMPT,
-        Mode::Sovereign => SOVEREIGN_SYSTEM_PROMPT,
-    };
-
-    let mut prompt = base.to_string();
+    let mut prompt = base_system_prompt(mode);
 
     // Inject the bundled WIZARD.md charter so every session — genie and
     // sovereign alike — operates under it, and so forks inherit it.
@@ -198,6 +231,39 @@ mod tests {
         assert!(
             charter_pos < agents_pos,
             "charter must appear before project instructions"
+        );
+    }
+
+    /// `read_prompt_override` returns trimmed contents for a non-empty file,
+    /// and `None` for an empty or missing one (so the baked default is used).
+    #[test]
+    fn prompt_override_reads_nonempty_file_only() {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+
+        let present = dir.join(format!("wizard_prompt_override_{pid}.md"));
+        std::fs::write(&present, "  CUSTOM EVOLVED PROMPT\n").expect("write temp prompt");
+        assert_eq!(
+            read_prompt_override(&present).as_deref(),
+            Some("CUSTOM EVOLVED PROMPT"),
+            "non-empty override should be read and trimmed"
+        );
+        std::fs::remove_file(&present).ok();
+
+        let empty = dir.join(format!("wizard_prompt_override_empty_{pid}.md"));
+        std::fs::write(&empty, "   \n\t").expect("write empty temp prompt");
+        assert_eq!(
+            read_prompt_override(&empty),
+            None,
+            "whitespace-only override should fall back to default"
+        );
+        std::fs::remove_file(&empty).ok();
+
+        let missing = dir.join(format!("wizard_prompt_override_missing_{pid}.md"));
+        assert_eq!(
+            read_prompt_override(&missing),
+            None,
+            "missing override → None"
         );
     }
 

--- a/src/agent/subagent.rs
+++ b/src/agent/subagent.rs
@@ -102,17 +102,28 @@ pub fn load_dir(dir: &Path) -> Result<Vec<SubagentConfig>> {
     Ok(configs)
 }
 
-/// Built-in subagents plus any user-defined ones from `dir`; user
-/// definitions shadow built-ins by name.
+/// Built-in subagents plus any user-defined ones from `dir`, plus the active
+/// harness bundle's `subagents/` (if any); later sources shadow earlier ones
+/// by name, so bundle definitions win over user definitions win over
+/// built-ins.
 pub fn available_configs(dir: &Path) -> Vec<SubagentConfig> {
     let mut configs = builtin_configs();
-    let user = load_dir(dir).unwrap_or_else(|err| {
-        tracing::warn!("loading subagents from {} failed: {err}", dir.display());
-        Vec::new()
-    });
-    for config in user {
-        configs.retain(|existing| existing.name != config.name);
-        configs.push(config);
+    let mut merge_from = |dir: &Path| {
+        let loaded = load_dir(dir).unwrap_or_else(|err| {
+            tracing::warn!("loading subagents from {} failed: {err}", dir.display());
+            Vec::new()
+        });
+        for config in loaded {
+            configs.retain(|existing| existing.name != config.name);
+            configs.push(config);
+        }
+    };
+    merge_from(dir);
+    if let Some(harness) = crate::config::Config::harness_dir() {
+        let bundle = harness.join("subagents");
+        if bundle.is_dir() {
+            merge_from(&bundle);
+        }
     }
     configs
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3818,6 +3818,7 @@ async fn build_registry(
     if let Err(err) = base.attach_mcp(manager).await {
         tracing::warn!("attaching MCP tools: {err:#}");
     }
+    base.apply_harness_overrides();
 
     let subagents_dir = Config::subagents_dir()?;
     let subagent_configs = subagent::available_configs(&subagents_dir);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,13 @@ pub struct Cli {
     #[arg(long, value_name = "PROVIDER")]
     pub login: Option<String>,
 
+    /// Harness bundle directory (sets `$WIZARD_HARNESS_DIR`): per-component
+    /// overrides for the compiled harness defaults — system_prompt.md,
+    /// tool_descriptions/, skills/, subagents/. Missing files fall back to
+    /// the baked defaults. Produce a bundle with `wizard harness export`.
+    #[arg(long, value_name = "DIR")]
+    pub harness_dir: Option<PathBuf>,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -140,6 +147,29 @@ pub enum Command {
     /// Dispatch background sessions, watch their state, peek their output, and
     /// stop them. Same view as `/dashboard` inside a session.
     Agents,
+
+    /// Harness bundle tooling: export the compiled harness defaults
+    /// (system prompt, tool descriptions, skills, subagents) as an editable
+    /// bundle for external harness-evolution loops. Load one with
+    /// `--harness-dir` / `$WIZARD_HARNESS_DIR`.
+    Harness {
+        #[command(subcommand)]
+        cmd: HarnessCmd,
+    },
+}
+
+/// `wizard harness` subcommands. Self-contained like bench: no config load,
+/// no onboarding, no LLM.
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum HarnessCmd {
+    /// Write the compiled harness defaults into `dir` as a bundle:
+    /// `system_prompt.md`, `tool_descriptions/<tool>.md`,
+    /// `skills/<name>/SKILL.md`, `subagents/<name>.toml`, plus a generated
+    /// `HARNESS.md` describing each component.
+    Export {
+        /// Target directory (created if missing; existing files overwritten).
+        dir: PathBuf,
+    },
 }
 
 /// `wizard fleet` subcommands. `run` loads config (the coordinator drives a

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,6 +581,15 @@ impl Config {
         Ok(Self::wizard_dir()?.join("schedule.toml"))
     }
 
+    /// `~/.wizard/system_prompt.md` — optional override for the baked base
+    /// personality prompt. When this file (or the path in `$WIZARD_SYSTEM_PROMPT`)
+    /// exists and is non-empty, its contents replace the compiled prompt; this
+    /// is the surface external harness-evolution tools mutate. Absent → baked
+    /// default, so behavior is unchanged on a normal install.
+    pub fn system_prompt_path() -> Result<PathBuf> {
+        Ok(Self::wizard_dir()?.join("system_prompt.md"))
+    }
+
     /// Create the `~/.wizard` directory tree (sessions, tools, skills, logs)
     /// if it does not exist yet. Idempotent; called on every load so a fresh
     /// install is usable without running the installer.

--- a/src/config.rs
+++ b/src/config.rs
@@ -628,6 +628,22 @@ impl Config {
         Ok(Self::wizard_dir()?.join("system_prompt.md"))
     }
 
+    /// The active harness bundle directory, if any: `$WIZARD_HARNESS_DIR`
+    /// (set directly or via `--harness-dir`). A bundle shadows the compiled
+    /// harness defaults per component — `system_prompt.md`,
+    /// `tool_descriptions/<tool>.md`, `skills/<name>/SKILL.md`,
+    /// `subagents/<name>.toml` — and any missing file falls back to the
+    /// default, so a partial or broken bundle degrades gracefully. This is
+    /// the surface external harness-evolution tools (e.g. AHE) mutate;
+    /// `wizard harness export` produces a bundle of the current defaults.
+    pub fn harness_dir() -> Option<PathBuf> {
+        let raw = std::env::var_os("WIZARD_HARNESS_DIR")?;
+        if raw.is_empty() {
+            return None;
+        }
+        Some(PathBuf::from(raw))
+    }
+
     /// Create the `~/.wizard` directory tree (sessions, tools, skills, logs)
     /// if it does not exist yet. Idempotent; called on every load so a fresh
     /// install is usable without running the installer.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,0 +1,218 @@
+//! `wizard harness` subcommands: bundle tooling for external
+//! harness-evolution loops (e.g. AHE).
+//!
+//! A *harness bundle* is a directory holding the evolvable surface of the
+//! agent as plain files — `system_prompt.md`, `tool_descriptions/<tool>.md`,
+//! `skills/<name>/SKILL.md`, `subagents/<name>.toml`. At runtime a bundle is
+//! activated with `--harness-dir` / `$WIZARD_HARNESS_DIR` and each present
+//! file shadows the corresponding compiled default (missing files fall back,
+//! so a partial bundle degrades gracefully). `export` dumps the current
+//! compiled defaults as a bundle, which is what makes the evolution loop
+//! recursive: improvements merged back into the source become the next
+//! export's baseline.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::agent::prompts::SOVEREIGN_SYSTEM_PROMPT;
+use crate::agent::subagent;
+use crate::cli::HarnessCmd;
+use crate::tools::registry::ToolRegistry;
+
+/// Dispatch a `wizard harness` subcommand.
+pub fn run(cmd: HarnessCmd) -> Result<()> {
+    match cmd {
+        HarnessCmd::Export { dir } => export(&dir),
+    }
+}
+
+/// Write the compiled harness defaults into `dir` as a bundle. Existing
+/// files are overwritten; unrelated files already in `dir` are left alone.
+pub fn export(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+
+    // System prompt: the sovereign personality. Evolution loops drive
+    // headless (`wizard -p`) runs, which are sovereign; the charter and
+    // skills/instructions/memory sections are appended on top at runtime and
+    // are not part of the evolvable base prompt.
+    std::fs::write(
+        dir.join("system_prompt.md"),
+        format!("{}\n", SOVEREIGN_SYSTEM_PROMPT.trim_end()),
+    )?;
+
+    // Tool descriptions: one markdown file per native tool, named after the
+    // tool. Scripted and MCP tools are runtime-dependent and excluded.
+    let descriptions = dir.join("tool_descriptions");
+    std::fs::create_dir_all(&descriptions)?;
+    let registry = ToolRegistry::with_native_tools();
+    let mut tool_count = 0usize;
+    for spec in registry.specs() {
+        std::fs::write(
+            descriptions.join(format!("{}.md", spec.function.name)),
+            format!("{}\n", spec.function.description.trim_end()),
+        )?;
+        tool_count += 1;
+    }
+
+    // Skills: copy the bundled skill directories (repo checkout or
+    // exe-adjacent install), first found wins per name. User skills under
+    // ~/.wizard/skills are the user's, not compiled defaults.
+    let skills_out = dir.join("skills");
+    std::fs::create_dir_all(&skills_out)?;
+    let mut skill_count = 0usize;
+    for root in bundled_skill_roots() {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let src = entry.path();
+            if !src.join("SKILL.md").is_file() {
+                continue;
+            }
+            let Some(name) = src.file_name() else {
+                continue;
+            };
+            let dst = skills_out.join(name);
+            if dst.exists() {
+                continue; // earlier root already provided this skill
+            }
+            copy_dir(&src, &dst)?;
+            skill_count += 1;
+        }
+    }
+
+    // Subagents: the shipped loadout TOMLs when a loadout is discoverable,
+    // plus the built-in definitions (serialized) for names the loadout does
+    // not cover.
+    let subagents_out = dir.join("subagents");
+    std::fs::create_dir_all(&subagents_out)?;
+    let mut subagent_count = 0usize;
+    if let Some(loadout) = loadout_subagents_dir() {
+        for entry in std::fs::read_dir(&loadout)?.flatten() {
+            let src = entry.path();
+            if src.extension().and_then(|e| e.to_str()) != Some("toml") {
+                continue;
+            }
+            if let Some(name) = src.file_name() {
+                std::fs::copy(&src, subagents_out.join(name))?;
+                subagent_count += 1;
+            }
+        }
+    }
+    for config in subagent::builtin_configs() {
+        let path = subagents_out.join(format!("{}.toml", config.name));
+        if path.exists() {
+            continue;
+        }
+        let toml = toml::to_string_pretty(&config)
+            .with_context(|| format!("serializing builtin subagent '{}'", config.name))?;
+        std::fs::write(path, toml)?;
+        subagent_count += 1;
+    }
+
+    std::fs::write(dir.join("HARNESS.md"), harness_doc())?;
+
+    println!(
+        "exported harness bundle to {}: system_prompt.md, {tool_count} tool descriptions, \
+         {skill_count} skills, {subagent_count} subagents, HARNESS.md",
+        dir.display()
+    );
+    Ok(())
+}
+
+/// Bundled (non-user) skill roots: the repo checkout and exe-adjacent
+/// installs — the same discovery as `skills::default_roots` minus the user
+/// and harness roots, since export captures compiled defaults only.
+fn bundled_skill_roots() -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills");
+    if manifest.is_dir() {
+        roots.push(manifest);
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        for candidate in [dir.join("skills"), dir.join("../share/wizard/skills")] {
+            if candidate.is_dir() && !roots.contains(&candidate) {
+                roots.push(candidate);
+            }
+        }
+    }
+    roots
+}
+
+/// The shipped `loadout/subagents/` directory, when discoverable (repo
+/// checkout or exe-adjacent install).
+fn loadout_subagents_dir() -> Option<std::path::PathBuf> {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("loadout/subagents");
+    if manifest.is_dir() {
+        return Some(manifest);
+    }
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    for candidate in [
+        dir.join("loadout/subagents"),
+        dir.join("../share/wizard/loadout/subagents"),
+    ] {
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Recursively copy `src` into `dst` (regular files and directories only).
+fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)?.flatten() {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_dir(&from, &to)?;
+        } else if from.is_file() {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// The generated bundle guide. Rides inside every exported bundle so a
+/// harness-evolution agent working on the bundle knows what each component
+/// is and how edits take effect.
+fn harness_doc() -> &'static str {
+    "\
+# Wizard harness bundle
+
+This directory is a *harness bundle*: the evolvable surface of the wizard
+agent, externalized as plain files. Wizard loads it when started with
+`--harness-dir <this dir>` (or `$WIZARD_HARNESS_DIR`); every component
+present here shadows the corresponding compiled default, and a missing or
+empty file falls back to that default.
+
+## Components
+
+- `system_prompt.md` — the base personality prompt (sovereign mode). The
+  wizard charter, skills index, project instructions, and memory sections
+  are appended on top at runtime and cannot be edited from here.
+- `tool_descriptions/<tool>.md` — the description advertised to the model
+  for the named native tool. Only the description is overridable; tool
+  behavior, parameters, and access class are compiled in.
+- `skills/<name>/SKILL.md` — skills loaded into the prompt's skills section.
+  Bundle skills shadow bundled and user skills by name; new directories add
+  new skills.
+- `subagents/<name>.toml` — spawnable subagent definitions (`name`,
+  `description`, `system_prompt`, optional `tool_scope`, `max_steps`).
+  Bundle definitions shadow user-defined and built-in ones by name.
+
+## Editing rules for evolution loops
+
+- Keep names stable: a `tool_descriptions/` file must keep the exact tool
+  name as its stem, a subagent TOML must keep its `name` field matching new
+  file names you introduce.
+- Edits take effect on the next wizard start (or `/reload` in a session);
+  no rebuild is required.
+- Deleting a file reverts that component to the compiled default, so
+  destructive experiments are always recoverable.
+"
+}

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -151,15 +151,12 @@ fn loadout_subagents_dir() -> Option<std::path::PathBuf> {
     }
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
-    for candidate in [
+    [
         dir.join("loadout/subagents"),
         dir.join("../share/wizard/loadout/subagents"),
-    ] {
-        if candidate.is_dir() {
-            return Some(candidate);
-        }
-    }
-    None
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_dir())
 }
 
 /// Recursively copy `src` into `dst` (regular files and directories only).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod evolve;
 pub mod fleet;
 pub mod gateway;
 pub mod hardware;
+pub mod harness;
 pub mod hooks;
 pub mod import_claude;
 pub mod instructions;
@@ -52,6 +53,16 @@ use crate::config::Mode;
 /// limit); every other mode exits 0 on success. Hard errors surface as `Err`
 /// and exit 1 from `main`.
 pub async fn run(cli: cli::Cli) -> Result<i32> {
+    // Harness bundle tooling is self-contained: no config, no LLM.
+    // (`--harness-dir` itself is published as `$WIZARD_HARNESS_DIR` in
+    // `main`, pre-runtime.)
+    if let Some(cli::Command::Harness { cmd }) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return harness::run(cmd.clone()).map(|()| 0);
+    }
+
     // Bench is self-contained tooling: it must work with no config and no
     // LLM, so dispatch before onboarding and before the config load.
     if let Some(cli::Command::Bench { cmd }) = &cli.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,18 @@ use clap::Parser;
 
 use wizard::cli::Cli;
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    let cli = Cli::parse();
+
+    // Publish `--harness-dir` as `$WIZARD_HARNESS_DIR` before the tokio
+    // runtime exists: every subsystem (prompts, registry, skills, subagents)
+    // and every spawned wizard child process then resolves the same bundle
+    // from one source.
+    // SAFETY: no other threads have been spawned yet.
+    if let Some(dir) = &cli.harness_dir {
+        unsafe { std::env::set_var("WIZARD_HARNESS_DIR", dir) };
+    }
+
     // If the TUI is up when something panics, raw mode and the alternate
     // screen must be torn down before the panic message prints, or the
     // terminal is left unusable.
@@ -17,8 +27,11 @@ async fn main() {
         default_hook(info);
     }));
 
-    let cli = Cli::parse();
-    let code = match wizard::run(cli).await {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+    let code = match runtime.block_on(wizard::run(cli)) {
         Ok(code) => code,
         Err(err) => {
             // Make sure the error lands on a sane terminal even when the TUI

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -36,7 +36,7 @@ pub struct Skill {
 /// Default skill roots, in shadowing order (later roots win on name
 /// collision): the repo checkout's `skills/` (dev builds), `skills/` next to
 /// the installed binary, then the user's `~/.wizard/skills/` where `/evolve`
-/// writes new skills.
+/// writes new skills, then the active harness bundle's `skills/` (if any).
 pub fn default_roots() -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
 
@@ -57,9 +57,18 @@ pub fn default_roots() -> Vec<PathBuf> {
         }
     }
 
-    // User skills last so they shadow bundled ones.
+    // User skills after bundled ones so they shadow them.
     if let Ok(user) = crate::config::Config::skills_dir() {
         roots.push(user);
+    }
+
+    // Harness bundle skills very last: the active bundle shadows everything,
+    // since it is the surface harness-evolution loops mutate.
+    if let Some(harness) = crate::config::Config::harness_dir() {
+        let skills = harness.join("skills");
+        if skills.is_dir() {
+            roots.push(skills);
+        }
     }
 
     roots

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -8,9 +8,11 @@ use std::sync::Arc;
 use anyhow::Result;
 use serde_json::Value;
 
+use async_trait::async_trait;
+
 use crate::llm::ToolSpec;
 use crate::mcp::McpManager;
-use crate::tools::{Tool, ToolContext, ToolError, ToolOutput};
+use crate::tools::{Tool, ToolAccess, ToolContext, ToolError, ToolKind, ToolOutput};
 
 use super::file::{EditFileTool, ListFilesTool, ReadFileTool, SearchFilesTool, WriteFileTool};
 use super::git::{GitDiffTool, GitStatusTool};
@@ -128,12 +130,106 @@ impl ToolRegistry {
     }
 
     /// `/reload`: drop scripted and MCP tools, re-register natives, and
-    /// reload both dynamic sources.
+    /// reload both dynamic sources. Harness description overrides are
+    /// re-applied last so they keep shadowing across reloads.
     pub async fn reload(&mut self, scripted_dir: &Path, manager: &McpManager) -> Result<()> {
         *self = Self::with_native_tools();
         self.load_scripted(scripted_dir)?;
         self.attach_mcp(manager).await?;
+        self.apply_harness_overrides();
         Ok(())
+    }
+
+    /// Apply the active harness bundle's tool-description overrides
+    /// (`<harness_dir>/tool_descriptions/<tool>.md`), if a bundle is set.
+    /// Returns how many descriptions were replaced.
+    pub fn apply_harness_overrides(&mut self) -> usize {
+        match crate::config::Config::harness_dir() {
+            Some(dir) => self.apply_description_overrides(&dir.join("tool_descriptions")),
+            None => 0,
+        }
+    }
+
+    /// Replace the advertised description of every registered tool that has
+    /// a matching non-empty `<dir>/<tool_name>.md`. Files that name no
+    /// registered tool are skipped with a warning (the evolve loop may edit
+    /// a description for a tool this build doesn't ship). Returns how many
+    /// descriptions were replaced.
+    pub fn apply_description_overrides(&mut self, dir: &Path) -> usize {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return 0, // no overrides shipped — the common case
+        };
+        let mut replaced = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Some(name) = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            let Some(tool) = self.tools.get(&name) else {
+                tracing::warn!(
+                    "harness description override {} names no registered tool",
+                    path.display()
+                );
+                continue;
+            };
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                tracing::warn!("unreadable harness description override {}", path.display());
+                continue;
+            };
+            let description = text.trim().to_string();
+            if description.is_empty() {
+                continue; // empty file ⇒ keep the compiled default
+            }
+            self.register(Arc::new(DescriptionOverride {
+                inner: Arc::clone(tool),
+                description,
+            }));
+            replaced += 1;
+        }
+        replaced
+    }
+}
+
+/// A registered tool with its advertised description replaced by a harness
+/// bundle override. Everything except the description delegates to the
+/// wrapped tool, so behavior, access class, and origin are unchanged.
+struct DescriptionOverride {
+    inner: Arc<dyn Tool>,
+    description: String,
+}
+
+#[async_trait]
+impl Tool for DescriptionOverride {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn parameters(&self) -> Value {
+        self.inner.parameters()
+    }
+
+    fn access(&self) -> ToolAccess {
+        self.inner.access()
+    }
+
+    fn kind(&self) -> ToolKind {
+        self.inner.kind()
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
+        self.inner.execute(args, ctx).await
     }
 }
 
@@ -340,6 +436,63 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.content, "v2");
+    }
+
+    #[tokio::test]
+    async fn description_overrides_shadow_matching_tools_only() {
+        let tmp = TempDir::new();
+        let dir = tmp.0.join("tool_descriptions");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("read_file.md"), "EVOLVED read_file description\n").unwrap();
+        std::fs::write(dir.join("no_such_tool.md"), "orphan override\n").unwrap();
+        std::fs::write(dir.join("todo.md"), "  \n").unwrap(); // empty ⇒ keep default
+        std::fs::write(dir.join("execute.txt"), "wrong extension\n").unwrap();
+
+        let mut registry = ToolRegistry::with_native_tools();
+        let default_todo = registry.get("todo").unwrap().description().to_string();
+        let order_before: Vec<String> = registry
+            .specs()
+            .into_iter()
+            .map(|spec| spec.function.name)
+            .collect();
+
+        assert_eq!(registry.apply_description_overrides(&dir), 1);
+
+        let read_file = registry.get("read_file").unwrap();
+        assert_eq!(read_file.description(), "EVOLVED read_file description");
+        assert_eq!(
+            read_file.access(),
+            ToolAccess::ReadOnly,
+            "override keeps the wrapped tool's access class"
+        );
+        assert_eq!(registry.get("todo").unwrap().description(), default_todo);
+        assert!(registry.get("no_such_tool").is_none());
+        let order_after: Vec<String> = registry
+            .specs()
+            .into_iter()
+            .map(|spec| spec.function.name)
+            .collect();
+        assert_eq!(order_before, order_after, "overrides keep spec order");
+
+        // The wrapped tool still executes: behavior is untouched.
+        std::fs::write(tmp.0.join("hello.txt"), "hello override\n").unwrap();
+        let out = registry
+            .execute("read_file", json!({ "path": "hello.txt" }), &tmp.ctx())
+            .await
+            .unwrap();
+        assert!(!out.is_error);
+        assert!(out.content.contains("hello override"));
+    }
+
+    #[test]
+    fn description_overrides_missing_dir_is_a_noop() {
+        let tmp = TempDir::new();
+        let mut registry = ToolRegistry::with_native_tools();
+        assert_eq!(
+            registry.apply_description_overrides(&tmp.0.join("absent")),
+            0
+        );
+        assert_eq!(registry.len(), 14);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -39,6 +39,8 @@ fn run_wizard(home: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
         .env_remove("WIZARD_OLLAMA_HOST")
         .env_remove("WIZARD_LLAMACPP_HOST")
         .env_remove("WIZARD_GGUF_PATH")
+        .env_remove("WIZARD_SYSTEM_PROMPT")
+        .env_remove("WIZARD_HARNESS_DIR")
         .current_dir(home);
     for (key, value) in envs {
         command.env(key, value);
@@ -421,4 +423,52 @@ fn e2e_inference_with_auto_spawned_llama_server() {
         "wizard must report the server it spawned:\n{stdout}"
     );
     assert!(!stderr.contains("panicked"), "must not panic:\n{stderr}");
+}
+
+#[test]
+fn harness_export_writes_a_complete_bundle() {
+    let home = TempDir::new();
+    let bundle = home.0.join("bundle");
+    let output = run_wizard(
+        &home.0,
+        &["harness", "export", bundle.to_str().unwrap()],
+        &[],
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "harness export must exit 0.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let prompt = std::fs::read_to_string(bundle.join("system_prompt.md"))
+        .expect("bundle has system_prompt.md");
+    assert!(!prompt.trim().is_empty(), "exported prompt is non-empty");
+
+    // One description file per native tool, contents matching the compiled
+    // defaults' non-empty guarantee.
+    for tool in ["read_file", "write_file", "execute", "web_search"] {
+        let path = bundle.join("tool_descriptions").join(format!("{tool}.md"));
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("bundle has tool_descriptions/{tool}.md"));
+        assert!(!text.trim().is_empty(), "{tool} description is non-empty");
+    }
+
+    // Bundled skills and loadout subagents ride along (dev-build discovery
+    // via the repo checkout), plus the built-in worker definition.
+    assert!(
+        bundle.join("skills/coding/SKILL.md").is_file(),
+        "bundled coding skill exported"
+    );
+    assert!(
+        bundle.join("subagents/reviewer.toml").is_file(),
+        "loadout reviewer subagent exported"
+    );
+    assert!(
+        bundle.join("subagents/worker.toml").is_file(),
+        "built-in worker subagent exported"
+    );
+    assert!(bundle.join("HARNESS.md").is_file(), "bundle guide exported");
+    assert!(stdout.contains("exported harness bundle"), "{stdout}");
 }


### PR DESCRIPTION
A harness bundle (--harness-dir / $WIZARD_HARNESS_DIR) shadows the
compiled defaults per component: system_prompt.md, tool_descriptions/,
skills/, subagents/. Missing files fall back, so partial or broken
bundles degrade gracefully. `wizard harness export` dumps the current
defaults as a bundle, making external harness-evolution loops (AHE)
recursive: merged-back improvements become the next export's baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)