### PR TITLE
progress: extend indicatif into downloads, doctor, and fleet

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1681,7 +1681,7 @@ pub async fn build_headless_agent(
     // stdout lines when stderr is not a terminal).
     if active.kind == ProviderKind::LlamaCpp {
         let wait = crate::progress::ServerSpinner::start();
-        let outcome = crate::server::ensure_running(&active, &|line: &str| wait.update(line)).await;
+        let outcome = crate::server::ensure_running(&active, &wait).await;
         wait.finish(outcome.is_ok());
         outcome?;
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -4091,7 +4091,7 @@ async fn try_provider(provider: &ProviderConfig) -> Result<Arc<dyn LlmProvider>>
         .with_context(|| format!("building provider '{}'", provider.name))?;
     if provider.kind == ProviderKind::LlamaCpp {
         let wait = crate::progress::ServerSpinner::start();
-        let outcome = server::ensure_running(provider, &|line: &str| wait.update(line)).await;
+        let outcome = server::ensure_running(provider, &wait).await;
         wait.finish(outcome.is_ok());
         outcome?;
     }
@@ -6073,17 +6073,8 @@ impl CommandContext<'_> {
     fn start_server_task(&self, provider: ProviderConfig) {
         let notify = self.events.sender();
         tokio::spawn(async move {
-            let progress = {
-                let notify = notify.clone();
-                move |line: &str| {
-                    // The progress callback is sync; relay each line through
-                    // its own send task.
-                    let notify = notify.clone();
-                    let line = line.to_string();
-                    tokio::spawn(async move {
-                        let _ = notify.send(Event::Notice(line)).await;
-                    });
-                }
+            let progress = NoticeProgress {
+                notify: notify.clone(),
             };
             let message = match server::ensure_running(&provider, &progress).await {
                 Ok(()) => format!("llama-server at {} is ready", provider.base_url),
@@ -6091,6 +6082,76 @@ impl CommandContext<'_> {
             };
             let _ = notify.send(Event::Notice(message)).await;
         });
+    }
+}
+
+/// [`crate::server::Progress`] adapter for the TUI's `/server start`: relays
+/// status lines and download milestones into the transcript as notices (the
+/// callback is sync, so each line is sent from its own task). Byte progress
+/// is throttled to whole-percent steps, the way the plain-terminal download
+/// bar fills, so a multi-GB pull does not flood the transcript.
+struct NoticeProgress {
+    notify: mpsc::Sender<Event>,
+}
+
+impl NoticeProgress {
+    fn notice(notify: &mpsc::Sender<Event>, line: String) {
+        let notify = notify.clone();
+        tokio::spawn(async move {
+            let _ = notify.send(Event::Notice(line)).await;
+        });
+    }
+}
+
+impl server::Progress for NoticeProgress {
+    fn status(&self, line: &str) {
+        Self::notice(&self.notify, line.to_string());
+    }
+
+    fn bytes(&self, label: &str, total: Option<u64>) -> Box<dyn server::ByteProgress> {
+        Box::new(NoticeBytes {
+            notify: self.notify.clone(),
+            label: label.to_string(),
+            total: total.filter(|total| *total > 0),
+            written: std::sync::atomic::AtomicU64::new(0),
+            last_percent: std::sync::atomic::AtomicU64::new(0),
+        })
+    }
+}
+
+/// Byte-progress guard for [`NoticeProgress`]: emits a transcript notice on
+/// each whole-percent advance and a closing milestone on finish.
+struct NoticeBytes {
+    notify: mpsc::Sender<Event>,
+    label: String,
+    total: Option<u64>,
+    written: std::sync::atomic::AtomicU64,
+    last_percent: std::sync::atomic::AtomicU64,
+}
+
+impl server::ByteProgress for NoticeBytes {
+    fn inc(&self, n: u64) {
+        use std::sync::atomic::Ordering;
+        let written = self.written.fetch_add(n, Ordering::Relaxed) + n;
+        if let Some(total) = self.total {
+            let percent = written * 100 / total;
+            if percent > self.last_percent.swap(percent, Ordering::Relaxed) {
+                NoticeProgress::notice(
+                    &self.notify,
+                    format!(
+                        "{} — {percent}% of {:.1} GB",
+                        self.label,
+                        total as f64 / 1e9
+                    ),
+                );
+            }
+        }
+    }
+
+    fn finish(self: Box<Self>, msg: &str) {
+        if !msg.is_empty() {
+            NoticeProgress::notice(&self.notify, msg.to_string());
+        }
     }
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -394,10 +394,16 @@ pub async fn run_checks(project_root: &Path) -> Vec<Check> {
     checks
 }
 
-/// `wizard doctor`: print the report, exit 0 when nothing failed.
+/// `wizard doctor`: print the report, exit 0 when nothing failed. A spinner
+/// covers the network probes (capped at [`PROBE_TIMEOUT`] each) while they
+/// run, then clears before the report so the rendered output is unchanged;
+/// it is silent when stderr is not a terminal. The TUI `/doctor` calls
+/// [`run_checks`] directly — it owns the screen and draws no spinner here.
 pub async fn run() -> Result<i32> {
     let project_root = std::env::current_dir()?;
+    let spinner = crate::progress::Spinner::start("running checks…");
     let checks = run_checks(&project_root).await;
+    spinner.finish();
     println!("{}", render(&checks));
     Ok(if has_failures(&checks) { 1 } else { 0 })
 }

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -21,11 +21,13 @@
 
 use std::collections::HashSet;
 use std::fmt::Write as _;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use indicatif::{MultiProgress, ProgressBar};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -690,13 +692,79 @@ fn heartbeat_note(status: &str, age: Option<u64>) -> Option<String> {
     })
 }
 
+/// Live supervision display: one spinner per worker slot when stderr is a
+/// terminal, plain `println!` lines otherwise (logs, pipes). The periodic
+/// status lines route above the bars so they never tear.
+struct FleetReporter {
+    bars: Option<(MultiProgress, Vec<ProgressBar>)>,
+}
+
+impl FleetReporter {
+    fn new(slot_count: usize) -> Self {
+        let bars = std::io::stderr()
+            .is_terminal()
+            .then(|| crate::progress::fleet_bars(slot_count));
+        Self { bars }
+    }
+
+    /// Print a status line above the bars (or plainly off-terminal).
+    fn println(&self, line: impl AsRef<str>) {
+        match &self.bars {
+            Some((multi, _)) => {
+                let _ = multi.println(line.as_ref());
+            }
+            None => println!("{}", line.as_ref()),
+        }
+    }
+
+    /// Refresh each slot's spinner from its current worker — claimed task id
+    /// and elapsed seconds, or "idle".
+    fn sync(&self, slots: &[Slot]) {
+        let Some((_, bars)) = &self.bars else {
+            return;
+        };
+        for (bar, slot) in bars.iter().zip(slots) {
+            let message = match &slot.running {
+                Some(worker) => {
+                    format!(
+                        "{} · {}s",
+                        worker.task.id,
+                        worker.started.elapsed().as_secs()
+                    )
+                }
+                None => "idle".to_string(),
+            };
+            bar.set_message(message);
+        }
+    }
+
+    /// Flag slot `i`'s spinner with a ✓ for the task that just completed.
+    fn mark_done(&self, i: usize, task_id: &str) {
+        if let Some((_, bars)) = &self.bars
+            && let Some(bar) = bars.get(i)
+        {
+            bar.set_message(format!("{task_id} ✓"));
+        }
+    }
+
+    /// Clear the bars at the end of supervision.
+    fn finish(&self) {
+        if let Some((multi, bars)) = &self.bars {
+            for bar in bars {
+                bar.finish_and_clear();
+            }
+            let _ = multi.clear();
+        }
+    }
+}
+
 /// Kill every running child and record killed-task results. Used by the
 /// stop sentinel and ctrl-c paths.
-async fn stop_all(slots: &mut [Slot], dirs: &FleetDirs) {
+async fn stop_all(slots: &mut [Slot], dirs: &FleetDirs, reporter: &FleetReporter) {
     for slot in slots.iter_mut() {
         if let Some(mut worker) = slot.running.take() {
             worker.child.kill().await.ok();
-            println!("✗ killed task '{}' on shutdown", worker.task.id);
+            reporter.println(format!("✗ killed task '{}' on shutdown", worker.task.id));
             if let Err(err) = write_result(
                 dirs,
                 &worker.task,
@@ -713,11 +781,26 @@ async fn stop_all(slots: &mut [Slot], dirs: &FleetDirs) {
 
 /// The real supervision loop around [`tick`]. Returns `true` when the queue
 /// drained and every child finished, `false` on a stop (sentinel or ctrl-c).
+/// Wraps the loop in a [`FleetReporter`] so the per-slot bars are always
+/// cleared, whichever way the loop exits.
 async fn supervise(
     dirs: &FleetDirs,
     slots: &mut [Slot],
     state: &mut FleetState,
     max_minutes: u64,
+) -> Result<bool> {
+    let reporter = FleetReporter::new(slots.len());
+    let result = supervise_loop(dirs, slots, state, max_minutes, &reporter).await;
+    reporter.finish();
+    result
+}
+
+async fn supervise_loop(
+    dirs: &FleetDirs,
+    slots: &mut [Slot],
+    state: &mut FleetState,
+    max_minutes: u64,
+    reporter: &FleetReporter,
 ) -> Result<bool> {
     let max_age = Duration::from_secs(max_minutes.saturating_mul(60));
     loop {
@@ -756,8 +839,8 @@ async fn supervise(
         for action in actions {
             match action {
                 TickAction::StopAll => {
-                    println!("fleet: stop requested — winding down");
-                    stop_all(slots, dirs).await;
+                    reporter.println("fleet: stop requested — winding down");
+                    stop_all(slots, dirs, reporter).await;
                     return Ok(false);
                 }
                 TickAction::Reap(i) => {
@@ -771,12 +854,13 @@ async fn supervise(
                             false,
                             &worker.stdout_path,
                         )?;
-                        println!(
+                        reporter.mark_done(i, &worker.task.id);
+                        reporter.println(format!(
                             "← task '{}' finished ({}) on {}",
                             worker.task.id,
                             describe_exit(&result),
                             slot.branch
-                        );
+                        ));
                     }
                 }
                 TickAction::Kill(i) => {
@@ -791,20 +875,20 @@ async fn supervise(
                             true,
                             &worker.stdout_path,
                         )?;
-                        println!(
+                        reporter.println(format!(
                             "⏱ task '{}' exceeded {max_minutes} min — killed",
                             worker.task.id
-                        );
+                        ));
                     }
                 }
                 TickAction::Spawn(i) => {
                     if let Some(task) = claim_next(&dirs.queue(), &dirs.claimed())? {
                         let slot = &mut slots[i];
                         let worker = spawn_worker(task, &slot.worktree, dirs)?;
-                        println!(
+                        reporter.println(format!(
                             "→ task '{}' ({}) started on {}",
                             worker.task.id, worker.task.title, slot.branch
-                        );
+                        ));
                         slot.running = Some(worker);
                     }
                 }
@@ -822,11 +906,14 @@ async fn supervise(
             save_state(&dirs.state_path(), state)?;
         }
 
+        // Refresh the per-slot bars (elapsed advances every tick).
+        reporter.sync(slots);
+
         tokio::select! {
             result = tokio::signal::ctrl_c() => {
                 result.context("listening for ctrl-c")?;
-                println!("\nfleet: interrupt — winding down");
-                stop_all(slots, dirs).await;
+                reporter.println("fleet: interrupt — winding down");
+                stop_all(slots, dirs, reporter).await;
                 return Ok(false);
             }
             () = tokio::time::sleep(TICK) => {}

--- a/src/local_setup.rs
+++ b/src/local_setup.rs
@@ -41,8 +41,8 @@ pub fn bin_dir() -> Result<PathBuf> {
 // ---------------------------------------------------------------------------
 
 /// Download `tier` to `dest`, resuming `dest.partial` if a previous attempt
-/// was interrupted. Reports progress as whole-percent steps.
-pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: Progress<'_>) -> Result<()> {
+/// was interrupted. Reports progress on a byte-counted bar.
+pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: &dyn Progress) -> Result<()> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
@@ -50,7 +50,7 @@ pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: Progress<'_>
     let partial = dest.with_extension("gguf.partial");
     let mut offset = std::fs::metadata(&partial).map(|m| m.len()).unwrap_or(0);
 
-    progress(&format!(
+    progress.status(&format!(
         "downloading {} ({}) — several GB, one-time…",
         tier.file, tier.name
     ));
@@ -94,24 +94,17 @@ pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: Progress<'_>
         .with_context(|| format!("opening {}", partial.display()))?;
 
     let mut written = offset;
-    let mut last_percent = 0u64;
+    let bar = progress.bytes(&format!("downloading {}", tier.file), total);
+    // Resumed bytes are already on disk; count them so the bar starts where
+    // the previous attempt left off.
+    bar.inc(offset);
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.with_context(|| format!("reading from {}", tier.url))?;
         std::io::Write::write_all(&mut file, &chunk)
             .with_context(|| format!("writing {}", partial.display()))?;
         written += chunk.len() as u64;
-        if let Some(total) = total.filter(|total| *total > 0) {
-            let percent = written * 100 / total;
-            if percent > last_percent {
-                last_percent = percent;
-                progress(&format!(
-                    "downloading {} — {percent}% of {:.1} GB",
-                    tier.file,
-                    total as f64 / 1e9
-                ));
-            }
-        }
+        bar.inc(chunk.len() as u64);
     }
     drop(file);
 
@@ -125,7 +118,7 @@ pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: Progress<'_>
     }
     std::fs::rename(&partial, dest)
         .with_context(|| format!("moving {} into place", partial.display()))?;
-    progress(&format!("saved {}", dest.display()));
+    bar.finish(&format!("saved {}", dest.display()));
     Ok(())
 }
 
@@ -139,8 +132,8 @@ pub async fn download_gguf(tier: &GgufModel, dest: &Path, progress: Progress<'_>
 /// `~/.wizard/llama.cpp` (the binary resolves its shared libraries via an
 /// `$ORIGIN` runpath, so the `.so` files must stay beside it), and link it
 /// from `~/.wizard/bin/llama-server`. Returns the linked path.
-pub async fn install_llama_server(progress: Progress<'_>) -> Result<PathBuf> {
-    progress("llama-server not found — installing llama.cpp (official releases)…");
+pub async fn install_llama_server(progress: &dyn Progress) -> Result<PathBuf> {
+    progress.status("llama-server not found — installing llama.cpp (official releases)…");
 
     let http = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(20))
@@ -156,7 +149,7 @@ pub async fn install_llama_server(progress: Progress<'_>) -> Result<PathBuf> {
         match install_from_asset(&http, &url, progress).await {
             Ok(path) => return Ok(path),
             Err(error) => {
-                progress(&format!(
+                progress.status(&format!(
                     "the {variant} build did not work — trying the next variant"
                 ));
                 last_error = error;
@@ -225,10 +218,10 @@ async fn asset_url(http: &reqwest::Client, variant: &str) -> Option<String> {
 async fn install_from_asset(
     http: &reqwest::Client,
     url: &str,
-    progress: Progress<'_>,
+    progress: &dyn Progress,
 ) -> Result<PathBuf> {
     let file_name = url.rsplit('/').next().unwrap_or("llamacpp.tar.gz");
-    progress(&format!("downloading {file_name}…"));
+    progress.status(&format!("downloading {file_name}…"));
 
     let work = Config::wizard_dir()?.join("tmp-llamacpp");
     let _ = std::fs::remove_dir_all(&work);
@@ -242,19 +235,30 @@ async fn install_from_asset_in(
     http: &reqwest::Client,
     url: &str,
     work: &Path,
-    progress: Progress<'_>,
+    progress: &dyn Progress,
 ) -> Result<PathBuf> {
     let archive = work.join("llamacpp.tar.gz");
-    let bytes = http
+    let file_name = url.rsplit('/').next().unwrap_or("llamacpp.tar.gz");
+    let response = http
         .get(url)
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .with_context(|| format!("downloading {url}"))?
-        .bytes()
-        .await
-        .with_context(|| format!("reading {url}"))?;
-    std::fs::write(&archive, &bytes).with_context(|| format!("writing {}", archive.display()))?;
+        .with_context(|| format!("downloading {url}"))?;
+    let total = response.content_length();
+    let mut out = std::fs::File::create(&archive)
+        .with_context(|| format!("writing {}", archive.display()))?;
+    let bar = progress.bytes(&format!("downloading {file_name}"), total);
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.with_context(|| format!("reading {url}"))?;
+        std::io::Write::write_all(&mut out, &chunk)
+            .with_context(|| format!("writing {}", archive.display()))?;
+        bar.inc(chunk.len() as u64);
+    }
+    std::io::Write::flush(&mut out).with_context(|| format!("writing {}", archive.display()))?;
+    drop(out);
+    bar.finish("");
 
     let extracted = work.join("extracted");
     std::fs::create_dir_all(&extracted)?;
@@ -304,7 +308,7 @@ async fn install_from_asset_in(
     #[cfg(not(unix))]
     std::fs::copy(&target, &link).with_context(|| format!("copying to {}", link.display()))?;
 
-    progress(&format!("installed llama-server to {}", dest.display()));
+    progress.status(&format!("installed llama-server to {}", dest.display()));
     Ok(link)
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -14,7 +14,9 @@ use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+
+use crate::server::{ByteProgress, Progress};
 
 /// Braille frames matching the TUI spinner in `src/ui.rs`, plus a final
 /// check mark shown when a spinner finishes with a message.
@@ -46,6 +48,34 @@ fn bar_style() -> ProgressStyle {
 /// [`ProgressBar::suspend`] so lines land above the bar.
 pub fn bar(len: u64) -> ProgressBar {
     let bar = ProgressBar::new(len).with_style(bar_style());
+    bar.enable_steady_tick(TICK_INTERVAL);
+    bar
+}
+
+/// Byte-counted style for downloads: a determinate bar with transfer rate and
+/// ETA when the total is known, an indeterminate spinner+counter otherwise.
+fn download_style(total_known: bool) -> ProgressStyle {
+    let template = if total_known {
+        "{spinner:.white} {msg:.dim} [{bar:24.white/black}] {bytes}/{total_bytes} \
+         {binary_bytes_per_sec:.dim} {eta:.dim}"
+    } else {
+        "{spinner:.white} {msg:.dim} {bytes} {binary_bytes_per_sec:.dim}"
+    };
+    ProgressStyle::with_template(template)
+        .expect("static download template is valid")
+        .tick_chars(TICK_CHARS)
+        .progress_chars("█▓░")
+}
+
+/// A byte-counted progress bar drawn to stderr (hidden automatically when
+/// stderr is not a terminal). `total` is the expected byte count; `None`
+/// gives an indeterminate spinner that still shows bytes transferred.
+pub fn download_bar(total: Option<u64>) -> ProgressBar {
+    let bar = match total {
+        Some(total) => ProgressBar::new(total),
+        None => ProgressBar::new_spinner(),
+    }
+    .with_style(download_style(total.is_some()));
     bar.enable_steady_tick(TICK_INTERVAL);
     bar
 }
@@ -129,6 +159,10 @@ pub struct ServerSpinner {
     /// Whether any status line arrived — i.e. the server was actually
     /// spawned or waited on rather than already answering.
     waited: AtomicBool,
+    /// Whether stderr is a terminal. When false the spinner draws nothing
+    /// and status falls back to plain `println!` lines (matching the prior
+    /// behavior for scripts and piped runs).
+    enabled: bool,
 }
 
 impl ServerSpinner {
@@ -142,16 +176,7 @@ impl ServerSpinner {
         Self {
             bar,
             waited: AtomicBool::new(false),
-        }
-    }
-
-    /// Report a status line ("waiting for the model to load…").
-    pub fn update(&self, line: &str) {
-        self.waited.store(true, Ordering::SeqCst);
-        if self.bar.is_hidden() {
-            println!("{line}");
-        } else {
-            self.bar.set_message(line.to_string());
+            enabled: std::io::stderr().is_terminal(),
         }
     }
 
@@ -161,16 +186,147 @@ impl ServerSpinner {
     /// are reported by the caller.
     pub fn finish(&self, ok: bool) {
         if ok && self.waited.load(Ordering::SeqCst) {
-            if self.bar.is_hidden() {
+            if self.enabled {
+                self.bar.finish_with_message("llama-server ready");
+            } else {
                 self.bar.finish_and_clear();
                 println!("llama-server ready");
-            } else {
-                self.bar.finish_with_message("llama-server ready");
             }
         } else {
             self.bar.finish_and_clear();
         }
     }
+}
+
+impl Progress for ServerSpinner {
+    /// Report a status line ("waiting for the model to load…").
+    fn status(&self, line: &str) {
+        self.waited.store(true, Ordering::SeqCst);
+        if self.enabled {
+            self.bar.set_message(line.to_string());
+        } else {
+            println!("{line}");
+        }
+    }
+
+    /// Open a byte-counted download phase: suspend the spinner, hand back a
+    /// determinate byte bar, and restore the spinner when the guard finishes
+    /// or drops. A no-op guard off-terminal, where downloads stay silent.
+    fn bytes(&self, label: &str, total: Option<u64>) -> Box<dyn ByteProgress> {
+        self.waited.store(true, Ordering::SeqCst);
+        if !self.enabled {
+            return Box::new(ServerByteProgress {
+                spinner: self.bar.clone(),
+                download: None,
+                restored: AtomicBool::new(false),
+            });
+        }
+        // Hand the screen to the byte bar while the download runs.
+        self.bar.disable_steady_tick();
+        self.bar.set_draw_target(ProgressDrawTarget::hidden());
+        let download = download_bar(total);
+        download.set_message(label.to_string());
+        Box::new(ServerByteProgress {
+            spinner: self.bar.clone(),
+            download: Some(download),
+            restored: AtomicBool::new(false),
+        })
+    }
+}
+
+/// Guard for a [`ServerSpinner`] byte phase: ticks a determinate byte bar and
+/// restores the spinner (clearing the byte bar) when finished or dropped.
+struct ServerByteProgress {
+    /// Clone of the [`ServerSpinner`] bar (indicatif bars are `Arc`-backed,
+    /// so this shares state with the original).
+    spinner: ProgressBar,
+    /// The byte bar, or `None` off-terminal where the phase is a no-op.
+    download: Option<ProgressBar>,
+    restored: AtomicBool,
+}
+
+impl ServerByteProgress {
+    /// Clear the byte bar and bring the spinner back, optionally leaving
+    /// `msg` as its status. Idempotent across `finish` and `Drop`.
+    fn restore(&self, msg: Option<&str>) {
+        if self.restored.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        match &self.download {
+            Some(download) => {
+                download.finish_and_clear();
+                if let Some(msg) = msg.filter(|msg| !msg.is_empty()) {
+                    self.spinner.set_message(msg.to_string());
+                }
+                self.spinner.set_draw_target(ProgressDrawTarget::stderr());
+                self.spinner.enable_steady_tick(TICK_INTERVAL);
+            }
+            // Off-terminal: surface a closing message as a plain line, the
+            // way status lines fall back when there is no spinner to update.
+            None => {
+                if let Some(msg) = msg.filter(|msg| !msg.is_empty()) {
+                    println!("{msg}");
+                }
+            }
+        }
+    }
+}
+
+impl ByteProgress for ServerByteProgress {
+    fn inc(&self, n: u64) {
+        if let Some(download) = &self.download {
+            download.inc(n);
+        }
+    }
+
+    fn finish(self: Box<Self>, msg: &str) {
+        self.restore(Some(msg));
+    }
+}
+
+impl Drop for ServerByteProgress {
+    fn drop(&mut self) {
+        self.restore(None);
+    }
+}
+
+/// A bare spinner for an indeterminate wait (e.g. `wizard doctor`'s network
+/// probes): shows `msg`, animates on a terminal, and is silent otherwise.
+/// [`Spinner::finish`] clears it before any report is printed.
+pub struct Spinner {
+    bar: ProgressBar,
+}
+
+impl Spinner {
+    /// Start a spinner showing `msg`.
+    pub fn start(msg: &str) -> Self {
+        let bar = ProgressBar::new_spinner()
+            .with_style(spinner_style())
+            .with_message(msg.to_string());
+        bar.enable_steady_tick(TICK_INTERVAL);
+        Self { bar }
+    }
+
+    /// Clear the spinner.
+    pub fn finish(self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+/// One [`MultiProgress`] with a spinner per worker slot, sharing the TUI
+/// look. Callers route interleaved lines through [`MultiProgress::println`]
+/// (or `suspend`) so they land above the bars without tearing. Off-terminal
+/// the bars draw nothing; callers TTY-gate the whole surface upstream.
+pub fn fleet_bars(slots: usize) -> (MultiProgress, Vec<ProgressBar>) {
+    let multi = MultiProgress::new();
+    let bars = (0..slots)
+        .map(|_| {
+            let bar = multi.add(ProgressBar::new_spinner().with_style(spinner_style()));
+            bar.enable_steady_tick(TICK_INTERVAL);
+            bar
+        })
+        .collect();
+    (multi, bars)
 }
 
 #[cfg(test)]
@@ -182,6 +338,59 @@ mod tests {
     fn styles_construct_without_panicking() {
         let _ = spinner_style();
         let _ = bar_style();
+        let _ = download_style(true);
+        let _ = download_style(false);
+    }
+
+    #[test]
+    fn download_bar_counts_in_both_modes() {
+        // Determinate: a known total caps the bar's length.
+        let bar = download_bar(Some(1_000));
+        bar.inc(400);
+        assert_eq!(bar.position(), 400);
+        bar.finish_and_clear();
+
+        // Indeterminate: no length, but bytes still accumulate.
+        let bar = download_bar(None);
+        bar.inc(128);
+        assert_eq!(bar.position(), 128);
+        bar.finish_and_clear();
+    }
+
+    #[test]
+    fn server_byte_progress_is_safe_off_terminal() {
+        // Under captured stderr `bytes()` returns a no-op guard; ticking and
+        // finishing it must stay quiet and not touch the spinner state.
+        let spinner = ServerSpinner::start();
+        let bar = spinner.bytes("downloading model", Some(2_048));
+        bar.inc(1_024);
+        bar.finish("saved /tmp/model.gguf");
+        // A dropped (unfinished) guard restores cleanly too.
+        let bar = spinner.bytes("downloading again", None);
+        bar.inc(10);
+        drop(bar);
+        spinner.finish(true);
+    }
+
+    #[test]
+    fn spinner_lifecycle_is_safe_off_terminal() {
+        let spinner = Spinner::start("running checks…");
+        spinner.finish();
+    }
+
+    #[test]
+    fn fleet_bars_yields_one_bar_per_slot() {
+        let (multi, bars) = fleet_bars(3);
+        assert_eq!(bars.len(), 3);
+        for (i, bar) in bars.iter().enumerate() {
+            bar.set_message(format!("task-{i} · 0s"));
+        }
+        // Routing a line through the group is a quiet no-op off-terminal.
+        let _ = multi.println("→ task-0 started");
+        for bar in &bars {
+            bar.finish_and_clear();
+        }
+        let _ = multi.clear();
     }
 
     #[test]
@@ -228,7 +437,7 @@ mod tests {
         wait.finish(true); // fast path: no "ready" line, just a clear
 
         let wait = ServerSpinner::start();
-        wait.update("waiting for the model to load…");
+        wait.status("waiting for the model to load…");
         assert!(wait.waited.load(Ordering::SeqCst));
         wait.finish(false); // failure: cleared, the caller prints the error
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,8 +33,31 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// How long to wait for a TCP connection on a single health probe.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// User-visible progress callback for the slow paths (spawn, model load).
-pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
+/// User-visible progress sink for the slow paths (spawn, model load,
+/// downloads). [`crate::progress::ServerSpinner`] is the terminal
+/// implementation; other surfaces (the TUI's `/server start`) supply their
+/// own. `status` reports a one-line update; `bytes` opens a determinate
+/// byte-counted phase whose guard is ticked with [`ByteProgress::inc`] and
+/// restores the prior UI on finish or drop.
+pub trait Progress: Send + Sync {
+    /// Report a one-line status update.
+    fn status(&self, line: &str);
+    /// Begin a byte-counted download phase. `total` is the expected byte
+    /// count when the server advertised a `Content-Length`, `None` for an
+    /// indeterminate stream.
+    fn bytes(&self, label: &str, total: Option<u64>) -> Box<dyn ByteProgress>;
+}
+
+/// A determinate byte-counted phase opened by [`Progress::bytes`]. Dropping
+/// the guard restores the surface's prior UI; [`ByteProgress::finish`] does
+/// the same after recording a closing message.
+pub trait ByteProgress: Send {
+    /// Account for `n` more bytes transferred.
+    fn inc(&self, n: u64);
+    /// Close the phase, optionally leaving `msg` as the surface's status
+    /// (an empty `msg` means no closing message).
+    fn finish(self: Box<Self>, msg: &str);
+}
 
 /// What `GET {base_url}/health` says about the server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,12 +95,12 @@ pub async fn probe(base_url: &str) -> Health {
 /// `llama-server` is on `PATH`, and the provider has a usable `gguf_path` —
 /// and waits for it; anything less is an actionable error telling the user
 /// how to start the server themselves.
-pub async fn ensure_running(provider: &ProviderConfig, progress: Progress<'_>) -> Result<()> {
+pub async fn ensure_running(provider: &ProviderConfig, progress: &dyn Progress) -> Result<()> {
     let base_url = provider.base_url.trim_end_matches('/');
     match probe(base_url).await {
         Health::Ready => return Ok(()),
         Health::Loading => {
-            progress(&format!(
+            progress.status(&format!(
                 "llama-server at {base_url} is loading its model — waiting…"
             ));
             return wait_ready(base_url, None, progress).await;
@@ -149,11 +172,11 @@ pub async fn ensure_running(provider: &ProviderConfig, progress: Progress<'_>) -
     };
 
     let pid = spawn(&binary, gguf, port)?;
-    progress(&format!(
+    progress.status(&format!(
         "started llama-server (PID {pid}, port {port}) — log: {}",
         log_path()?.display()
     ));
-    progress(&format!(
+    progress.status(&format!(
         "waiting for the model to load (up to {}s)…",
         READY_TIMEOUT.as_secs()
     ));
@@ -164,7 +187,7 @@ pub async fn ensure_running(provider: &ProviderConfig, progress: Progress<'_>) -
 /// [`READY_TIMEOUT`] (GGUF loads are slow). When `pid` names a server Wizard
 /// just spawned, its early death short-circuits the wait with a pointer to
 /// the log instead of timing out.
-pub async fn wait_ready(base_url: &str, pid: Option<u32>, progress: Progress<'_>) -> Result<()> {
+pub async fn wait_ready(base_url: &str, pid: Option<u32>, progress: &dyn Progress) -> Result<()> {
     let started = Instant::now();
     let mut reported_loading = false;
     while started.elapsed() < READY_TIMEOUT {
@@ -172,7 +195,7 @@ pub async fn wait_ready(base_url: &str, pid: Option<u32>, progress: Progress<'_>
             Health::Ready => return Ok(()),
             Health::Loading if !reported_loading => {
                 reported_loading = true;
-                progress("llama-server is up — loading the model…");
+                progress.status("llama-server is up — loading the model…");
             }
             _ => {}
         }


### PR DESCRIPTION
Promotes the server progress callback to a trait (status + byte-counted bytes) so downloads drive a real byte bar instead of percent strings.

- server: replace the `Fn(&str)` alias with `Progress`/`ByteProgress` traits.
- progress: implement `Progress` for `ServerSpinner` (`bytes()` suspends the spinner, runs a determinate download bar, restores on finish/drop); add `download_bar`, a bare `Spinner`, and `fleet_bars` helpers.
- local_setup: `download_gguf` and the llama.cpp installer stream to a byte bar; the installer archive is written chunk-by-chunk.
- app: `/server start` relays status + whole-percent download notices via a `NoticeProgress` adapter.
- doctor: wrap the CLI probe phase in a spinner (TUI `/doctor` unchanged).
- fleet: `MultiProgress` with one spinner per worker slot during supervision, status lines routed above the bars; plain on non-TTY.

All surfaces stay silent / plain when stderr is not a terminal.

Rebased onto main (kept both the heartbeat-staleness helpers and `FleetReporter` in `fleet/mod.rs`). 740 tests pass; clippy clean.