### PR TITLE
fix: RAM/cgroup-aware local model sizing and OOM diagnosis

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -690,6 +690,21 @@ detect_memory() {
     if is_uint "$mem_kb" && [ "$mem_kb" -gt 0 ]; then
         MEM_GB=$((mem_kb / 1024 / 1024))
         MEM_SOURCE="system RAM (no GPU detected)"
+        # In a container MemTotal reports the host's RAM; cap it with the
+        # cgroup memory limit (v2 then v1) when one applies. "max" (v2) and
+        # huge sentinels (v1's PAGE_COUNTER_MAX, here >= 1<<60) mean no limit.
+        local cgroup_file limit_b limit_gb
+        for cgroup_file in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+            [ -r "$cgroup_file" ] || continue
+            limit_b="$(cat "$cgroup_file" 2>/dev/null || true)"
+            is_uint "$limit_b" || continue
+            [ "$limit_b" -lt 1152921504606846976 ] || continue
+            limit_gb=$((limit_b / 1024 / 1024 / 1024))
+            if [ "$limit_gb" -lt "$MEM_GB" ]; then
+                MEM_GB="$limit_gb"
+                MEM_SOURCE="system RAM (cgroup limit)"
+            fi
+        done
         return
     fi
 

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -81,14 +81,68 @@ fn sysfs_vram_gb() -> Option<u64> {
     (gb > 0).then_some(gb)
 }
 
-/// Total system RAM in GB from `/proc/meminfo` (`MemTotal`, kB).
-fn system_ram_gb() -> Option<u64> {
-    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+/// `MemTotal` in GB from `/proc/meminfo` contents.
+fn parse_meminfo_total_gb(meminfo: &str) -> Option<u64> {
     let line = meminfo.lines().find(|line| line.starts_with("MemTotal:"))?;
     // Format: "MemTotal:       16312456 kB"
     let kb = line.split_whitespace().nth(1).and_then(parse_positive)?;
     let gb = kb / (1024 * 1024);
     (gb > 0).then_some(gb)
+}
+
+/// A cgroup memory limit in bytes from the raw file contents. `None` for
+/// "no limit": cgroup v2 spells that `max`, cgroup v1 reports
+/// `PAGE_COUNTER_MAX` (~`LONG_MAX`, far beyond any real machine).
+fn parse_cgroup_limit_bytes(contents: &str) -> Option<u64> {
+    /// Anything this large (1 EiB) is a no-limit sentinel, not a limit.
+    const NO_LIMIT: u64 = 1 << 60;
+    match contents.trim() {
+        "max" => None,
+        raw => parse_positive(raw).filter(|&bytes| bytes < NO_LIMIT),
+    }
+}
+
+/// The cgroup memory limit confining this process, in GB. Checks cgroup v2
+/// (`memory.max`) then v1 (`memory.limit_in_bytes`); `None` outside
+/// containers, or when no readable file carries a real limit.
+fn cgroup_limit_gb() -> Option<u64> {
+    [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ]
+    .iter()
+    .filter_map(|path| std::fs::read_to_string(path).ok())
+    .filter_map(|raw| parse_cgroup_limit_bytes(&raw))
+    .min()
+    .map(|bytes| bytes / (1024 * 1024 * 1024))
+}
+
+/// Cap a `MemTotal` reading with an optional cgroup limit. The bool is true
+/// when the limit is what set the number.
+fn cap_to_cgroup(total_gb: u64, limit_gb: Option<u64>) -> (u64, bool) {
+    match limit_gb {
+        Some(limit) if limit < total_gb => (limit, true),
+        _ => (total_gb, false),
+    }
+}
+
+/// Total system RAM in GB from `/proc/meminfo` (`MemTotal`, kB), capped by
+/// the cgroup memory limit when one is smaller — in a container `MemTotal`
+/// reports the host's RAM, not what this process may actually use. The bool
+/// is true when the cgroup limit won.
+fn system_ram_gb() -> Option<(u64, bool)> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let total_gb = parse_meminfo_total_gb(&meminfo)?;
+    let (gb, capped) = cap_to_cgroup(total_gb, cgroup_limit_gb());
+    (gb > 0).then_some((gb, capped))
+}
+
+/// System RAM usable by this process, in GB ([`system_ram_gb`] including any
+/// cgroup cap). This is what a spawned llama-server can actually allocate:
+/// [`crate::server::spawn`] passes no GPU-offload flags, so the weights load
+/// into system memory even on GPU machines.
+pub fn usable_ram_gb() -> Option<u64> {
+    system_ram_gb().map(|(gb, _)| gb)
 }
 
 /// Detect the memory budget, preferring GPU VRAM (nvidia → rocm → sysfs) and
@@ -112,10 +166,14 @@ pub fn detect_memory() -> Option<Detected> {
             source: "GPU VRAM (sysfs)".to_string(),
         });
     }
-    if let Some(gb) = system_ram_gb() {
+    if let Some((gb, capped)) = system_ram_gb() {
         return Some(Detected {
             gb,
-            source: "system RAM (no GPU detected)".to_string(),
+            source: if capped {
+                "system RAM (cgroup limit)".to_string()
+            } else {
+                "system RAM (no GPU detected)".to_string()
+            },
         });
     }
     None
@@ -173,6 +231,9 @@ pub struct GgufModel {
     pub file: &'static str,
     /// Hugging Face download URL for [`Self::file`].
     pub url: &'static str,
+    /// Approximate file size in GB, used to refuse a model that cannot fit
+    /// in RAM before downloading it.
+    pub approx_gb: u64,
 }
 
 /// GGUF tiers (largest first), the Q4_K_M counterparts of the Ollama tags in
@@ -183,16 +244,19 @@ pub const GGUF_TIERS: &[GgufModel] = &[
         name: "Qwen3.6 35B",
         file: "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
         url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+        approx_gb: 20,
     },
     GgufModel {
         name: "Qwen3.6 27B",
         file: "Qwen3.6-27B-Q4_K_M.gguf",
         url: "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q4_K_M.gguf",
+        approx_gb: 16,
     },
     GgufModel {
         name: "Qwen3.5 9B",
         file: "Qwen3.5-9B-Q4_K_M.gguf",
         url: "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf",
+        approx_gb: 6,
     },
 ];
 
@@ -214,16 +278,36 @@ pub fn suggest_gguf_model(gb: u64) -> &'static GgufModel {
     }
 }
 
+/// Memory budget for the GGUF tier choice: a GPU VRAM reading is capped by
+/// system RAM, because the spawned llama-server runs without GPU offload
+/// (no `-ngl`; [`crate::server::spawn`]) and the prebuilts are CPU/Vulkan —
+/// the weights must fit in RAM regardless of VRAM. The bool is true when
+/// the RAM cap won.
+fn gguf_budget_gb(detected: &Detected, ram_gb: Option<u64>) -> (u64, bool) {
+    match ram_gb {
+        Some(ram) if detected.source.starts_with("GPU VRAM") && ram < detected.gb => (ram, true),
+        _ => (detected.gb, false),
+    }
+}
+
 /// Run detection and return `(tier, explanation)` for llama.cpp. Falls back to
 /// the smallest tier with an explanatory note when nothing can be detected.
 pub fn suggest_gguf() -> (&'static GgufModel, String) {
     match detect_memory() {
         Some(detected) => {
-            let tier = suggest_gguf_model(detected.gb);
-            let explanation = format!(
-                "Detected {} GB of {} → {}",
-                detected.gb, detected.source, tier.file
-            );
+            let (budget, ram_capped) = gguf_budget_gb(&detected, usable_ram_gb());
+            let tier = suggest_gguf_model(budget);
+            let explanation = if ram_capped {
+                format!(
+                    "Detected {} GB of {}, capped by {budget} GB of system RAM → {}",
+                    detected.gb, detected.source, tier.file
+                )
+            } else {
+                format!(
+                    "Detected {} GB of {} → {}",
+                    detected.gb, detected.source, tier.file
+                )
+            };
             (tier, explanation)
         }
         None => {
@@ -259,6 +343,57 @@ mod tests {
         assert_eq!(parse_positive("12 kB"), None);
         assert_eq!(parse_positive("MemTotal:"), None);
         assert_eq!(parse_positive(""), None);
+    }
+
+    #[test]
+    fn parse_meminfo_total_gb_reads_memtotal() {
+        let meminfo = "MemTotal:       16312456 kB\nMemFree:         1234 kB\n";
+        assert_eq!(parse_meminfo_total_gb(meminfo), Some(15));
+        assert_eq!(parse_meminfo_total_gb("MemFree: 1234 kB\n"), None);
+        assert_eq!(parse_meminfo_total_gb("MemTotal: garbage kB\n"), None);
+        assert_eq!(parse_meminfo_total_gb(""), None);
+    }
+
+    #[test]
+    fn parse_cgroup_limit_rejects_no_limit_sentinels() {
+        // cgroup v2 spells "no limit" as the literal string `max`.
+        assert_eq!(parse_cgroup_limit_bytes("max\n"), None);
+        // cgroup v1 reports PAGE_COUNTER_MAX (~LONG_MAX) when unconfined.
+        assert_eq!(parse_cgroup_limit_bytes("9223372036854771712\n"), None);
+        assert_eq!(parse_cgroup_limit_bytes(&(1u64 << 60).to_string()), None);
+        // A real limit (12 GiB, like a Colab container) is taken at face value.
+        assert_eq!(
+            parse_cgroup_limit_bytes("12884901888\n"),
+            Some(12_884_901_888)
+        );
+        assert_eq!(parse_cgroup_limit_bytes("0"), None);
+        assert_eq!(parse_cgroup_limit_bytes("not a number"), None);
+        assert_eq!(parse_cgroup_limit_bytes(""), None);
+    }
+
+    #[test]
+    fn cap_to_cgroup_only_lowers() {
+        assert_eq!(cap_to_cgroup(64, Some(12)), (12, true), "container cap");
+        assert_eq!(cap_to_cgroup(16, Some(32)), (16, false), "limit above RAM");
+        assert_eq!(cap_to_cgroup(16, Some(16)), (16, false), "equal is no cap");
+        assert_eq!(cap_to_cgroup(16, None), (16, false), "no limit");
+    }
+
+    #[test]
+    fn gguf_budget_caps_vram_by_system_ram() {
+        let gpu = Detected {
+            gb: 24,
+            source: "GPU VRAM (nvidia-smi)".to_string(),
+        };
+        // No -ngl is passed when spawning, so RAM is the binding constraint.
+        assert_eq!(gguf_budget_gb(&gpu, Some(12)), (12, true));
+        assert_eq!(gguf_budget_gb(&gpu, Some(64)), (24, false));
+        assert_eq!(gguf_budget_gb(&gpu, None), (24, false));
+        let ram = Detected {
+            gb: 12,
+            source: "system RAM (cgroup limit)".to_string(),
+        };
+        assert_eq!(gguf_budget_gb(&ram, Some(12)), (12, false));
     }
 
     #[test]

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1820,6 +1820,7 @@ mod tests {
             name: "Test",
             file,
             url: "https://example.com/x.gguf",
+            approx_gb: 1,
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,13 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// How long to wait for a TCP connection on a single health probe.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// RAM headroom beyond the raw weights (KV cache, compute buffers) demanded
+/// by the preflight fit check in [`ensure_running`].
+const FIT_HEADROOM_GB: u64 = 2;
+
+/// How many log lines a startup-failure error quotes.
+const LOG_TAIL_LINES: usize = 20;
+
 /// User-visible progress callback for the slow paths (spawn, model load).
 pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
 
@@ -115,6 +122,22 @@ pub async fn ensure_running(provider: &ProviderConfig, progress: Progress<'_>) -
              in ~/.wizard/config.toml"
         );
     };
+    // A model that cannot fit in this machine's RAM is refused up front —
+    // before a multi-GB download, and before llama-server gets OOM-killed
+    // halfway through loading it. [`spawn`] passes no GPU-offload flags, so
+    // the weights load into system memory even on GPU machines. Undetectable
+    // RAM or an unknown model size skips the check.
+    if let Some(ram_gb) = crate::hardware::usable_ram_gb()
+        && let Some(model_gb) = model_size_gb(Path::new(gguf))
+        && model_gb + FIT_HEADROOM_GB > ram_gb
+    {
+        bail!(
+            "the model {gguf} is ~{model_gb} GB but this machine has only {ram_gb} GB of usable \
+             RAM, so llama-server would be killed loading it — run `wizard --onboard` to pick a \
+             smaller model (the 9B tier), or point `gguf_path` in ~/.wizard/config.toml at one \
+             that fits"
+        );
+    }
     // A missing GGUF that names a known tier is downloaded into place (the
     // one-click local onboarding writes exactly such a path); anything else
     // stays an actionable error.
@@ -162,8 +185,8 @@ pub async fn ensure_running(provider: &ProviderConfig, progress: Progress<'_>) -
 
 /// Poll `{base_url}/health` until the server reports ready, up to
 /// [`READY_TIMEOUT`] (GGUF loads are slow). When `pid` names a server Wizard
-/// just spawned, its early death short-circuits the wait with a pointer to
-/// the log instead of timing out.
+/// just spawned, its early death short-circuits the wait. Both failure paths
+/// quote the tail of the server log ([`diagnose`]) so the cause is visible.
 pub async fn wait_ready(base_url: &str, pid: Option<u32>, progress: Progress<'_>) -> Result<()> {
     let started = Instant::now();
     let mut reported_loading = false;
@@ -180,16 +203,16 @@ pub async fn wait_ready(base_url: &str, pid: Option<u32>, progress: Progress<'_>
             && !process_name(pid).is_some_and(|name| is_llama_server(&name))
         {
             bail!(
-                "llama-server (PID {pid}) exited during startup — check {}",
-                log_path()?.display()
+                "llama-server (PID {pid}) exited during startup — {}",
+                diagnose(&log_path()?)
             );
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
     bail!(
-        "llama-server at {base_url} did not become ready within {}s — check {}",
+        "llama-server at {base_url} did not become ready within {}s — {}",
         READY_TIMEOUT.as_secs(),
-        log_path()?.display()
+        diagnose(&log_path()?)
     )
 }
 
@@ -217,6 +240,74 @@ fn server_args(gguf_path: &str, port: u16, gpu: bool) -> Vec<String> {
         args.push(GPU_OFFLOAD_ALL.to_string());
     }
     args
+}
+
+/// Approximate size of the model at `path` in GB: the file's real size when
+/// it exists, else the known tier's [`crate::hardware::GgufModel::approx_gb`]
+/// when the file name matches one. `None` for unknown missing files.
+fn model_size_gb(path: &Path) -> Option<u64> {
+    if let Ok(meta) = std::fs::metadata(path) {
+        return Some(meta.len() / (1024 * 1024 * 1024));
+    }
+    let tier = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(crate::hardware::gguf_tier_for_file)?;
+    Some(tier.approx_gb)
+}
+
+/// The tail of the llama-server log plus, when it smells like memory
+/// exhaustion, a pointer at onboarding. Shared by both startup-failure bails
+/// in [`wait_ready`] so the user sees the actual failure, not just a path.
+fn diagnose(log: &Path) -> String {
+    let tail = match std::fs::read_to_string(log) {
+        Ok(contents) if !contents.trim().is_empty() => tail_lines(&contents),
+        _ => "  (log is empty or unreadable)".to_string(),
+    };
+    let hint = if looks_like_oom(&tail) {
+        "\nthe log suggests the model did not fit in memory — run `wizard --onboard` to pick a \
+         smaller model"
+    } else {
+        ""
+    };
+    format!("tail of {}:\n{tail}{hint}", log.display())
+}
+
+/// Last [`LOG_TAIL_LINES`] lines of `contents`, indented two spaces, with
+/// over-long lines cut so one giant line cannot flood the error.
+fn tail_lines(contents: &str) -> String {
+    /// Per-line cap; llama-server lines are normally well under this.
+    const MAX_LINE_CHARS: usize = 200;
+    let lines: Vec<&str> = contents.lines().collect();
+    let start = lines.len().saturating_sub(LOG_TAIL_LINES);
+    lines[start..]
+        .iter()
+        .map(|line| {
+            if line.chars().count() > MAX_LINE_CHARS {
+                let cut: String = line.chars().take(MAX_LINE_CHARS).collect();
+                format!("  {cut}…")
+            } else {
+                format!("  {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Whether a log tail looks like llama-server died of memory exhaustion:
+/// allocator failures from llama.cpp/ggml, or the shell/kernel reporting an
+/// OOM kill.
+fn looks_like_oom(tail: &str) -> bool {
+    let lower = tail.to_lowercase();
+    [
+        "out of memory",
+        "failed to allocate",
+        "cannot allocate",
+        "ggml_aligned_malloc",
+        "killed",
+    ]
+    .iter()
+    .any(|signature| lower.contains(signature))
 }
 
 /// Start a detached `llama-server` serving `gguf_path` on `port`. The child
@@ -556,6 +647,80 @@ mod tests {
             !port_in_use(port)
         });
         assert!(freed, "a released port eventually reads as free");
+    }
+
+    #[test]
+    fn every_suggested_tier_passes_the_fit_check_at_its_boundary() {
+        // The tier table and the preflight check must agree: a machine with
+        // exactly the RAM that selects a tier must also be allowed to run it.
+        for gb in [8, 18, 24, 48] {
+            let tier = crate::hardware::suggest_gguf_model(gb);
+            assert!(
+                tier.approx_gb + FIT_HEADROOM_GB <= gb,
+                "{} (~{} GB) does not fit the {gb} GB budget that selects it",
+                tier.name,
+                tier.approx_gb
+            );
+        }
+    }
+
+    #[test]
+    fn model_size_gb_prefers_the_real_file_then_known_tiers() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("tiny.gguf");
+        std::fs::write(&path, b"stub").expect("write stub");
+        assert_eq!(model_size_gb(&path), Some(0), "real file: real size");
+        // Missing but a known tier: the tier's approximate size.
+        let missing = dir.path().join("Qwen3.5-9B-Q4_K_M.gguf");
+        assert_eq!(model_size_gb(&missing), Some(6));
+        // Missing and unknown: no size, the preflight check is skipped.
+        assert_eq!(model_size_gb(&dir.path().join("custom.gguf")), None);
+    }
+
+    #[test]
+    fn tail_lines_keeps_the_last_lines_and_cuts_long_ones() {
+        let contents: String = (1..=30).map(|n| format!("line {n}\n")).collect();
+        let tail = tail_lines(&contents);
+        assert!(!tail.contains("line 10"), "older lines dropped");
+        assert!(tail.starts_with("  line 11"));
+        assert!(tail.ends_with("  line 30"));
+        assert_eq!(tail.lines().count(), LOG_TAIL_LINES);
+
+        let long = "x".repeat(500);
+        let cut = tail_lines(&long);
+        assert!(cut.ends_with('…'), "over-long line is cut");
+        assert!(cut.chars().count() < 250);
+    }
+
+    #[test]
+    fn looks_like_oom_matches_llama_cpp_failure_signatures() {
+        assert!(looks_like_oom(
+            "ggml_backend_cpu_buffer_type_alloc_buffer: failed to allocate"
+        ));
+        assert!(looks_like_oom("llama_model_load: error: Out of memory"));
+        assert!(looks_like_oom("mmap: Cannot allocate memory"));
+        assert!(looks_like_oom("Killed"));
+        assert!(!looks_like_oom("main: server is listening on 127.0.0.1"));
+        assert!(!looks_like_oom(""));
+    }
+
+    #[test]
+    fn diagnose_quotes_the_log_and_hints_at_onboarding_on_oom() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log = dir.path().join("llama-server.log");
+
+        // Missing log: still a readable message, never an error.
+        assert!(diagnose(&log).contains("(log is empty or unreadable)"));
+
+        std::fs::write(&log, "loading model\nfailed to allocate 20 GiB\n").expect("write log");
+        let message = diagnose(&log);
+        assert!(message.contains("failed to allocate 20 GiB"));
+        assert!(message.contains("wizard --onboard"), "OOM hint present");
+
+        std::fs::write(&log, "wrong chat template\n").expect("write log");
+        let message = diagnose(&log);
+        assert!(message.contains("wrong chat template"));
+        assert!(!message.contains("wizard --onboard"), "no hint without OOM");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Picking a local GGUF by VRAM alone lets a 13GB model onto a 14GiB-RAM box, where llama-server OOMs (or takes the machine down with it). Size against what the process can actually get, and say so when it dies anyway:

- hardware: parse `MemTotal` from `/proc/meminfo`, cap it by the cgroup v2/v1 memory limit when one applies (containers report host RAM), expose `usable_ram_gb()`; the GGUF budget is min(VRAM, usable RAM) with headroom.
- onboarding: model entries carry `approx_gb` so the picker can filter choices that cannot fit.
- server: preflight the model size against the budget (`FIT_HEADROOM_GB` margin) before launch; on startup failure, tail the server log and diagnose OOM-looking exits with a pointer at `wizard --onboard`.
- install.sh: `detect_memory` caps `MemTotal` with the cgroup limit too.

Rebased onto main (kept `server_args` alongside the new sizing/diagnosis helpers in `server.rs`). 745 tests pass; clippy and fmt clean.