### PR TITLE
feat: Cloudflare Workers AI provider (GLM 5.2 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 curl -fsSL https://raw.githubusercontent.com/teddytennant/wizard/main/install.sh | bash
 ```
 
-One command installs the `wizard` binary and a small default loadout (a Playwright browser over MCP and four subagents). The first run asks which provider you want and sets up the rest. Pick **Local** and Wizard sizes a Qwen 3 GGUF to your hardware and runs [llama.cpp](https://github.com/ggml-org/llama.cpp)'s `llama-server` itself — no API key. Or bring a key for OpenAI, Anthropic, xAI, OpenRouter, or any OpenAI-compatible endpoint, and switch live with `/provider`. It's one fast Rust binary on Linux and macOS; everything it learns is plain TOML under `~/.wizard/` that you can edit or delete.
+One command installs the `wizard` binary and a small default loadout (a Playwright browser over MCP and four subagents). The first run asks which provider you want and sets up the rest. Pick **Local** and Wizard sizes a Qwen 3 GGUF to your hardware and runs [llama.cpp](https://github.com/ggml-org/llama.cpp)'s `llama-server` itself — no API key. Or bring a key for OpenAI, Anthropic, xAI, OpenRouter, Cloudflare Workers AI, or any OpenAI-compatible endpoint, and switch live with `/provider`. It's one fast Rust binary on Linux and macOS; everything it learns is plain TOML under `~/.wizard/` that you can edit or delete.
 
 > **Other ways to install** — local-stack preinstall, minimal, bring-your-own-model, Nix, macOS — plus a first-run walkthrough are in **[Getting started](docs/getting-started.md)**.
 
@@ -18,7 +18,7 @@ One command installs the `wizard` binary and a small default loadout (a Playwrig
 
 ## What it does
 
-- **Any model, switchable live.** Speaks the OpenAI-compatible chat API (streaming + native tool calls, with a prompt-based JSON fallback), so OpenAI, Groq, vLLM, LM Studio, OpenRouter, Anthropic, xAI, and Ollama all work. `/provider` switches the live agent between them; keys live in env vars or `~/.wizard/credentials.toml` (mode 0600), never in plaintext config. → [Providers](docs/getting-started.md#using-a-cloud-or-remote-provider)
+- **Any model, switchable live.** Speaks the OpenAI-compatible chat API (streaming + native tool calls, with a prompt-based JSON fallback), so OpenAI, Groq, vLLM, LM Studio, OpenRouter, Cloudflare Workers AI, Anthropic, xAI, and Ollama all work. `/provider` switches the live agent between them; keys live in env vars or `~/.wizard/credentials.toml` (mode 0600), never in plaintext config. → [Providers](docs/getting-started.md#using-a-cloud-or-remote-provider)
 - **Runs models locally, fully managed.** Pick Local and Wizard downloads a GGUF sized to your VRAM, then starts, supervises, and reuses `llama-server` for you — including a Metal build on Apple Silicon. → [Model tiers](docs/getting-started.md#model-tiers-automatic) · [Bring your own model](docs/byom.md)
 - **Model fusion (`/fusion`).** Run a panel of your providers as a debate and synthesize one tool-capable answer that tends to beat the best single model in the panel. → [Fusion](docs/fusion.md)
 - **Self-extension (`/evolve`).** Add skills, MCP servers, scripted tools, and subagents as plain files that go live on `/reload` — and, gated by a clean `cargo build` and a smoke test, rebuild its own binary. Every change is logged, and the prior binary is kept one `mv` from rollback. → [Self-extension](docs/evolve.md)
@@ -38,7 +38,7 @@ Verified against each tool's documentation as of June 2026:
 
 | | **Wizard** | **aider** | **goose** (Block / AAIF) | **opencode** |
 |---|---|---|---|---|
-| Providers | Any OpenAI-compatible endpoint + OpenRouter + Anthropic + xAI (API key or account sign-in), switchable at runtime via `/provider`; local llama.cpp with Wizard managing `llama-server` itself; Ollama | Ollama + any OpenAI-compatible endpoint; top results come from cloud models | 15+ providers incl. Ollama | 75+ providers incl. Ollama |
+| Providers | Any OpenAI-compatible endpoint + OpenRouter + Cloudflare Workers AI + Anthropic + xAI (API key or account sign-in), switchable at runtime via `/provider`; local llama.cpp with Wizard managing `llama-server` itself; Ollama | Ollama + any OpenAI-compatible endpoint; top results come from cloud models | 15+ providers incl. Ollama | 75+ providers incl. Ollama |
 | MCP | Yes: stdio + HTTP, registerable at runtime via `/evolve` | No native support (open RFC) | Yes: one of the earliest and deepest integrations, 70+ documented extensions | Yes: local + remote servers, OAuth for remote |
 | Self-extension | Tiered `/evolve`, up to and including rebuilding its own binary (gated + rollback) | None | Extensions and recipes via MCP | TypeScript/JS plugin system |
 | Interface | Ratatui TUI | Terminal chat CLI | CLI + native desktop app (macOS/Linux/Windows) | Polished TUI |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Wizard installs in one command and launches as a terminal UI agent. The default install puts down the binary and the [default loadout](loadout.md) — no model, no config — and the first `wizard` run opens [onboarding](#first-run) to pick a provider. Local is one pick: Wizard detects your hardware, downloads a fitting GGUF, and sets up [llama.cpp](https://github.com/ggml-org/llama.cpp)'s `llama-server` itself (or reuses an existing Ollama install), so no API key is needed. Or bring a key for any OpenAI-compatible endpoint (OpenAI, OpenRouter, Groq, vLLM, LM Studio, llama.cpp, Ollama), Anthropic, or xAI (API key or account sign-in). See [Using a cloud or remote provider](#using-a-cloud-or-remote-provider) and [Using Ollama instead](#using-ollama-instead).
+Wizard installs in one command and launches as a terminal UI agent. The default install puts down the binary and the [default loadout](loadout.md) — no model, no config — and the first `wizard` run opens [onboarding](#first-run) to pick a provider. Local is one pick: Wizard detects your hardware, downloads a fitting GGUF, and sets up [llama.cpp](https://github.com/ggml-org/llama.cpp)'s `llama-server` itself (or reuses an existing Ollama install), so no API key is needed. Or bring a key for any OpenAI-compatible endpoint (OpenAI, OpenRouter, Cloudflare Workers AI, Groq, vLLM, LM Studio, llama.cpp, Ollama), Anthropic, or xAI (API key or account sign-in). See [Using a cloud or remote provider](#using-a-cloud-or-remote-provider) and [Using Ollama instead](#using-ollama-instead).
 
 ## Install
 
@@ -116,7 +116,7 @@ These override `~/.wizard/config.toml` for a single run:
 wizard
 ```
 
-With no config present (the default and minimal installs), the first launch opens onboarding: a Ratatui wizard that asks which provider to use (provider, model, messaging gateway, mode) and writes `~/.wizard/config.toml`. Picking Local is one step — Wizard detects your hardware, downloads a GGUF sized to it, and installs and starts `llama-server` itself (or reuses an existing Ollama install). The other options take an API key: OpenRouter, xAI (Grok), OpenAI, Anthropic, or any OpenAI-compatible endpoint. Alongside them sit two BYOM picks — llama.cpp (your own GGUF and server URL) and Ollama (your own model tag) — for bringing a model you already have. Re-run it any time with `wizard --onboard`.
+With no config present (the default and minimal installs), the first launch opens onboarding: a Ratatui wizard that asks which provider to use (provider, model, messaging gateway, mode) and writes `~/.wizard/config.toml`. Picking Local is one step — Wizard detects your hardware, downloads a GGUF sized to it, and installs and starts `llama-server` itself (or reuses an existing Ollama install). The other options take an API key: OpenRouter, Cloudflare Workers AI (GLM 5.2), xAI (Grok), OpenAI, Anthropic, or any OpenAI-compatible endpoint. Alongside them sit two BYOM picks — llama.cpp (your own GGUF and server URL) and Ollama (your own model tag) — for bringing a model you already have. Re-run it any time with `wizard --onboard`.
 
 With a config present (after onboarding, or a `WIZARD_LOCAL=1` install), launching Wizard with a local llama.cpp provider:
 
@@ -224,7 +224,7 @@ Or pick the local Ollama option in onboarding (`wizard --onboard`). Wizard speak
 
 ## Using a cloud or remote provider
 
-Any OpenAI-compatible endpoint, OpenRouter, Anthropic, or xAI works. The simplest path is `/provider` inside the TUI: it opens a menu of your configured providers (Enter switches to one) with an **Add provider…** entry that walks you through each type. Pick xAI (API key or account sign-in), OpenRouter, OpenAI, Anthropic, or an OpenAI-compatible custom endpoint; you type the API key inline (hidden) and it is stored in `~/.wizard/credentials.toml` (file mode 0600). xAI account sign-in runs the OAuth flow and adds the provider for you.
+Any OpenAI-compatible endpoint, OpenRouter, Cloudflare Workers AI, Anthropic, or xAI works. The simplest path is `/provider` inside the TUI: it opens a menu of your configured providers (Enter switches to one) with an **Add provider…** entry that walks you through each type. Pick xAI (API key or account sign-in), OpenRouter, Cloudflare Workers AI, OpenAI, Anthropic, or an OpenAI-compatible custom endpoint; you type the API key inline (hidden) and it is stored in `~/.wizard/credentials.toml` (file mode 0600). xAI account sign-in runs the OAuth flow and adds the provider for you.
 
 The same thing is scriptable with explicit arguments:
 
@@ -246,6 +246,20 @@ OpenRouter serves hundreds of hosted models behind one OpenAI-compatible endpoin
 ```
 
 `openrouter/auto` is OpenRouter's Auto Router, which picks a model per prompt; any `vendor/model` tag from openrouter.ai/models works instead. Wizard sends OpenRouter's recommended attribution headers (`HTTP-Referer`, `X-Title`) on every request.
+
+### Using Cloudflare Workers AI
+
+[Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) serves open models (GLM, Llama, Qwen, …) on serverless GPUs behind an account-scoped OpenAI-compatible endpoint. It needs two things: your **account id** (Cloudflare dashboard → Workers AI, or `wrangler whoami`) and an **API token** with the Workers AI permission. The default model is **GLM 5.2** (`@cf/zai-org/glm-5.2`).
+
+The interactive `/provider` menu is the easiest path — pick **Cloudflare Workers AI — API token**, paste the account id (folded into the endpoint URL) then the token (stored in `~/.wizard/credentials.toml`). Scripted, the account id goes in the base URL:
+
+```
+export CLOUDFLARE_API_TOKEN=...
+/provider add cloudflare cloudflare https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1 @cf/zai-org/glm-5.2 CLOUDFLARE_API_TOKEN
+/provider use cloudflare
+```
+
+Any `@cf/...` text-generation tag works in place of the model (see [the catalog](https://developers.cloudflare.com/workers-ai/models/)); `/model` lists what your account can serve. Workers AI's OpenAI-compatible surface exposes only chat completions (no `/v1/models`), so Wizard discovers models and probes health against Cloudflare's native account catalog.
 
 ### Signing in with an xAI account
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -315,7 +315,10 @@ const PROVIDER_TYPES: &[(&str, &str)] = &[
         "stored in ~/.wizard/credentials.toml",
     ),
     ("OpenRouter — API key", "openrouter.ai"),
-    ("Cloudflare Workers AI — API token", "GLM 5.2 · account id + token"),
+    (
+        "Cloudflare Workers AI — API token",
+        "GLM 5.2 · account id + token",
+    ),
     ("OpenAI — API key", "api.openai.com"),
     ("Anthropic (Claude) — API key", "api.anthropic.com"),
     ("OpenAI-compatible — custom", "any base URL + key"),

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,6 +98,9 @@ pub enum InputMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PromptField {
     Name,
+    /// Cloudflare account id — substituted into the base-URL template before
+    /// the provider is built (Cloudflare setup only).
+    AccountId,
     BaseUrl,
     Model,
     ApiKey,
@@ -257,7 +260,7 @@ fn parse_provider(args: &[&str]) -> Result<SlashCommand, String> {
         Some("add") => {
             if args.len() < 5 {
                 return Err(
-                    "usage: /provider add <name> <llamacpp|ollama|openai|anthropic|openrouter|xai|xaioauth> <base_url> <model> [API_KEY_ENV]"
+                    "usage: /provider add <name> <llamacpp|ollama|openai|anthropic|openrouter|xai|xaioauth|cloudflare> <base_url> <model> [API_KEY_ENV]"
                         .to_string(),
                 );
             }
@@ -269,9 +272,10 @@ fn parse_provider(args: &[&str]) -> Result<SlashCommand, String> {
                 "openrouter" => ProviderKind::OpenRouter,
                 "xai" => ProviderKind::Xai,
                 "xaioauth" => ProviderKind::XaiOauth,
+                "cloudflare" => ProviderKind::Cloudflare,
                 other => {
                     return Err(format!(
-                        "unknown provider kind '{other}' (llamacpp|ollama|openai|anthropic|openrouter|xai|xaioauth)"
+                        "unknown provider kind '{other}' (llamacpp|ollama|openai|anthropic|openrouter|xai|xaioauth|cloudflare)"
                     ));
                 }
             };
@@ -311,6 +315,7 @@ const PROVIDER_TYPES: &[(&str, &str)] = &[
         "stored in ~/.wizard/credentials.toml",
     ),
     ("OpenRouter — API key", "openrouter.ai"),
+    ("Cloudflare Workers AI — API token", "GLM 5.2 · account id + token"),
     ("OpenAI — API key", "api.openai.com"),
     ("Anthropic (Claude) — API key", "api.anthropic.com"),
     ("OpenAI-compatible — custom", "any base URL + key"),
@@ -361,6 +366,7 @@ fn provider_display(kind: ProviderKind) -> &'static str {
         ProviderKind::OpenRouter => "OpenRouter",
         ProviderKind::Openai => "OpenAI-compatible",
         ProviderKind::Anthropic => "Anthropic",
+        ProviderKind::Cloudflare => "Cloudflare",
         ProviderKind::LlamaCpp => "llama.cpp",
         ProviderKind::Ollama => "Ollama",
     }
@@ -370,6 +376,9 @@ fn provider_display(kind: ProviderKind) -> &'static str {
 fn prompt_question(field: PromptField, prompt: &ProviderPrompt) -> String {
     match field {
         PromptField::Name => "Provider name (id):".to_string(),
+        PromptField::AccountId => {
+            "Cloudflare account ID (dash.cloudflare.com → Workers AI → account id):".to_string()
+        }
         PromptField::BaseUrl => "Base URL:".to_string(),
         PromptField::Model => "Model:".to_string(),
         PromptField::ApiKey => format!(
@@ -1705,6 +1714,18 @@ impl App {
         let field = prompt.queue.pop_front()?;
         match field {
             PromptField::Name => prompt.name = value,
+            PromptField::AccountId => {
+                if value.is_empty() {
+                    // No account id is treated as "never mind".
+                    self.cancel_prompt();
+                    return None;
+                }
+                // Substitute the account id into the base-URL template
+                // (e.g. `.../accounts/{account_id}/ai/v1`).
+                prompt.base_url = prompt
+                    .base_url
+                    .replace(crate::llm::cloudflare::ACCOUNT_ID_PLACEHOLDER, &value);
+            }
             PromptField::BaseUrl => prompt.base_url = value,
             PromptField::Model => prompt.model = value,
             PromptField::ApiKey => {
@@ -2858,7 +2879,7 @@ impl App {
                             )))
                         }
                         PickerKind::ProviderType => {
-                            use crate::llm::{openrouter, xai_oauth};
+                            use crate::llm::{cloudflare, openrouter, xai_oauth};
                             use std::collections::VecDeque;
                             match picker.selected {
                                 // xAI sign-in: run the OAuth flow; login()
@@ -2894,8 +2915,24 @@ impl App {
                                         ]),
                                     });
                                 }
-                                // OpenAI — model + key.
+                                // Cloudflare Workers AI — account id (folded
+                                // into the base URL) + token; model defaults to
+                                // GLM 5.2 and can be changed later via /model.
                                 3 => {
+                                    self.begin_provider_prompt(ProviderPrompt {
+                                        kind: ProviderKind::Cloudflare,
+                                        name: "cloudflare".to_string(),
+                                        base_url: cloudflare::BASE_URL_TEMPLATE.to_string(),
+                                        model: cloudflare::DEFAULT_MODEL.to_string(),
+                                        api_key: None,
+                                        queue: VecDeque::from([
+                                            PromptField::AccountId,
+                                            PromptField::ApiKey,
+                                        ]),
+                                    });
+                                }
+                                // OpenAI — model + key.
+                                4 => {
                                     self.begin_provider_prompt(ProviderPrompt {
                                         kind: ProviderKind::Openai,
                                         name: "openai".to_string(),
@@ -2909,7 +2946,7 @@ impl App {
                                     });
                                 }
                                 // Anthropic — model + key.
-                                4 => {
+                                5 => {
                                     self.begin_provider_prompt(ProviderPrompt {
                                         kind: ProviderKind::Anthropic,
                                         name: "claude".to_string(),
@@ -2924,7 +2961,7 @@ impl App {
                                 }
                                 // OpenAI-compatible custom — everything is
                                 // prompted, starting with the name.
-                                5 => {
+                                6 => {
                                     self.begin_provider_prompt(ProviderPrompt {
                                         kind: ProviderKind::Openai,
                                         name: String::new(),
@@ -6753,6 +6790,25 @@ mod tests {
             .expect("is a slash command");
         let message = parsed.expect_err("unknown kind");
         assert!(message.contains("openrouter"), "got: {message}");
+    }
+
+    #[test]
+    fn provider_add_accepts_cloudflare_kind() {
+        let parsed = SlashCommand::parse(
+            "/provider add cf cloudflare https://api.cloudflare.com/client/v4/accounts/acc/ai/v1 @cf/zai-org/glm-5.2 CLOUDFLARE_API_TOKEN",
+        )
+        .expect("is a slash command")
+        .expect("parses");
+        assert_eq!(
+            parsed,
+            SlashCommand::Provider(ProviderAction::Add {
+                name: "cf".to_string(),
+                kind: ProviderKind::Cloudflare,
+                base_url: "https://api.cloudflare.com/client/v4/accounts/acc/ai/v1".to_string(),
+                model: "@cf/zai-org/glm-5.2".to_string(),
+                api_key_env: Some("CLOUDFLARE_API_TOKEN".to_string()),
+            })
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cli::Cli;
 use crate::llm::anthropic::AnthropicProvider;
+use crate::llm::cloudflare::{self, CloudflareProvider};
 use crate::llm::llamacpp::LlamaCppProvider;
 use crate::llm::ollama::OllamaClient;
 use crate::llm::openai::{OpenAiProvider, StaticToken};
@@ -84,6 +85,11 @@ pub enum ProviderKind {
     /// xAI via account sign-in: OAuth tokens from `wizard --login xai`
     /// (stored in `~/.wizard/xai_oauth.json`), no API key needed.
     XaiOauth,
+    /// Cloudflare Workers AI: serverless open models (GLM, Llama, Qwen, ...)
+    /// behind an account-scoped OpenAI-compatible endpoint
+    /// (`https://api.cloudflare.com/client/v4/accounts/<id>/ai/v1`) with a
+    /// Cloudflare API token (default env var `CLOUDFLARE_API_TOKEN`).
+    Cloudflare,
 }
 
 impl fmt::Display for ProviderKind {
@@ -96,6 +102,7 @@ impl fmt::Display for ProviderKind {
             ProviderKind::OpenRouter => write!(f, "openrouter"),
             ProviderKind::Xai => write!(f, "xai"),
             ProviderKind::XaiOauth => write!(f, "xaioauth"),
+            ProviderKind::Cloudflare => write!(f, "cloudflare"),
         }
     }
 }
@@ -326,7 +333,8 @@ pub struct ProviderConfig {
     /// `http://127.0.0.1:11434`; openai `https://api.openai.com/v1`;
     /// anthropic `https://api.anthropic.com`; openrouter
     /// `https://openrouter.ai/api/v1`; xai / xaioauth
-    /// `https://api.x.ai/v1`.
+    /// `https://api.x.ai/v1`; cloudflare
+    /// `https://api.cloudflare.com/client/v4/accounts/<id>/ai/v1`.
     pub base_url: String,
     /// Model tag.
     pub model: String,
@@ -430,6 +438,24 @@ impl ProviderConfig {
                     self.model.clone(),
                     Arc::new(source),
                     "xai",
+                )))
+            }
+            // Cloudflare Workers AI speaks the OpenAI-compatible Chat
+            // Completions API, but has no `/v1/models`, so it needs its own
+            // client for health/model-listing (see `CloudflareProvider`).
+            ProviderKind::Cloudflare => {
+                let key = self.resolved_key(Some(cloudflare::DEFAULT_KEY_ENV));
+                if key.is_empty() {
+                    tracing::warn!(
+                        "provider '{}' has no API token (store one via /provider or set {}); requests will likely 401",
+                        self.name,
+                        self.api_key_env.as_deref().unwrap_or(cloudflare::DEFAULT_KEY_ENV)
+                    );
+                }
+                Ok(Arc::new(CloudflareProvider::new(
+                    self.base_url.clone(),
+                    self.model.clone(),
+                    key,
                 )))
             }
         }
@@ -1318,6 +1344,41 @@ mod tests {
     }
 
     #[test]
+    fn cloudflare_kind_round_trips_through_toml() {
+        let original = Config {
+            providers: vec![ProviderConfig {
+                name: "cloudflare".to_string(),
+                kind: ProviderKind::Cloudflare,
+                base_url: "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1"
+                    .to_string(),
+                model: "@cf/zai-org/glm-5.2".to_string(),
+                api_key_env: Some("CLOUDFLARE_API_TOKEN".to_string()),
+                gguf_path: None,
+                usd_per_mtok_in: None,
+                usd_per_mtok_out: None,
+            }],
+            active_provider: Some("cloudflare".to_string()),
+            ..Config::default()
+        };
+        let raw = toml::to_string_pretty(&original).expect("serialize");
+        // The serde name is what the /provider parser and Display use.
+        assert!(raw.contains("kind = \"cloudflare\""), "raw: {raw}");
+        let parsed: Config = toml::from_str(&raw).expect("parse back");
+        assert_eq!(parsed.providers[0].kind, ProviderKind::Cloudflare);
+        assert_eq!(parsed.providers[0].model, "@cf/zai-org/glm-5.2");
+        assert_eq!(
+            parsed.providers[0].api_key_env.as_deref(),
+            Some("CLOUDFLARE_API_TOKEN")
+        );
+        assert_eq!(parsed.active().kind, ProviderKind::Cloudflare);
+
+        // build() dispatches to the Cloudflare client (labeled by vendor+model),
+        // proving the wiring from config to provider.
+        let client = parsed.active().build().expect("builds a cloudflare client");
+        assert_eq!(client.label(), "cloudflare:@cf/zai-org/glm-5.2");
+    }
+
+    #[test]
     fn provider_cost_rates_parse_and_round_trip() {
         let raw = "\
 [[providers]]
@@ -1356,6 +1417,7 @@ usd_per_mtok_out = 15.0
             (ProviderKind::OpenRouter, "openrouter"),
             (ProviderKind::Xai, "xai"),
             (ProviderKind::XaiOauth, "xaioauth"),
+            (ProviderKind::Cloudflare, "cloudflare"),
         ] {
             assert_eq!(kind.to_string(), name);
             let json = serde_json::to_value(kind).expect("serialize kind");

--- a/src/config.rs
+++ b/src/config.rs
@@ -449,7 +449,9 @@ impl ProviderConfig {
                     tracing::warn!(
                         "provider '{}' has no API token (store one via /provider or set {}); requests will likely 401",
                         self.name,
-                        self.api_key_env.as_deref().unwrap_or(cloudflare::DEFAULT_KEY_ENV)
+                        self.api_key_env
+                            .as_deref()
+                            .unwrap_or(cloudflare::DEFAULT_KEY_ENV)
                     );
                 }
                 Ok(Arc::new(CloudflareProvider::new(
@@ -1349,8 +1351,7 @@ mod tests {
             providers: vec![ProviderConfig {
                 name: "cloudflare".to_string(),
                 kind: ProviderKind::Cloudflare,
-                base_url: "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1"
-                    .to_string(),
+                base_url: "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1".to_string(),
                 model: "@cf/zai-org/glm-5.2".to_string(),
                 api_key_env: Some("CLOUDFLARE_API_TOKEN".to_string()),
                 gguf_path: None,

--- a/src/llm/cloudflare.rs
+++ b/src/llm/cloudflare.rs
@@ -1,0 +1,342 @@
+//! Cloudflare Workers AI: serverless inference for open models (GLM, Llama,
+//! Qwen, ...) behind an OpenAI-compatible Chat Completions endpoint scoped to a
+//! Cloudflare account and authenticated with an API token.
+//!
+//! Chat uses the OpenAI wire shape, handled by [`super::openai::OpenAiProvider`].
+//! This module wraps that client to override the health probe and model listing:
+//! Workers AI's OpenAI-compatible surface exposes only `/v1/chat/completions`
+//! (there is no `/v1/models`), so reachability/auth and model discovery instead
+//! use Cloudflare's native account-scoped catalog (`/ai/models/search`).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::openai::{OpenAiProvider, StaticToken};
+use super::provider::LlmProvider;
+use super::{ChatRequest, ChatStream, ProviderError};
+
+/// Default model: GLM 5.2 (Z.ai), the most capable text model in the Workers
+/// AI catalog.
+pub const DEFAULT_MODEL: &str = "@cf/zai-org/glm-5.2";
+/// Default env var holding the Cloudflare API token.
+pub const DEFAULT_KEY_ENV: &str = "CLOUDFLARE_API_TOKEN";
+/// Placeholder in [`BASE_URL_TEMPLATE`] replaced by the account id.
+pub const ACCOUNT_ID_PLACEHOLDER: &str = "{account_id}";
+/// Base URL template for the OpenAI-compatible endpoint; the placeholder is
+/// substituted with the user's Cloudflare account id (see [`base_url`]).
+pub const BASE_URL_TEMPLATE: &str =
+    "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1";
+
+/// Curated fallback list of Workers AI text-generation models, used only when
+/// the live catalog query fails. GLM 5.2 leads (the default).
+const FALLBACK_MODELS: &[&str] = &[
+    "@cf/zai-org/glm-5.2",
+    "@cf/zai-org/glm-4.7-flash",
+    "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    "@cf/qwen/qwen2.5-coder-32b-instruct",
+];
+
+/// Build the OpenAI-compatible base URL for `account_id` by substituting it
+/// into [`BASE_URL_TEMPLATE`].
+pub fn base_url(account_id: &str) -> String {
+    BASE_URL_TEMPLATE.replace(ACCOUNT_ID_PLACEHOLDER, account_id.trim())
+}
+
+/// Cloudflare Workers AI client. Chat requests are delegated to the wrapped
+/// [`OpenAiProvider`]; health and model discovery hit the account-scoped native
+/// catalog endpoint instead of the (nonexistent) OpenAI `/v1/models`.
+#[derive(Debug, Clone)]
+pub struct CloudflareProvider {
+    /// Handles the OpenAI-compatible `/chat/completions` wire protocol.
+    inner: OpenAiProvider,
+    http: reqwest::Client,
+    /// Account-scoped catalog base, e.g.
+    /// `https://api.cloudflare.com/client/v4/accounts/<id>/ai` (the OpenAI
+    /// base URL with the trailing `/v1` stripped).
+    account_base: String,
+    /// API token; empty means none configured (health will then 401).
+    api_key: String,
+    /// Model tag, for [`LlmProvider::label`].
+    model: String,
+}
+
+impl CloudflareProvider {
+    /// Build a client for `base_url` (the OpenAI-compatible endpoint, ending in
+    /// `/ai/v1`) authenticated with the Cloudflare API token `api_key`.
+    pub fn new(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> Self {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let model = model.into();
+        let api_key = api_key.into();
+        let inner = OpenAiProvider::with_token_source(
+            base_url.clone(),
+            model.clone(),
+            Arc::new(StaticToken::new(api_key.clone())),
+            "cloudflare",
+        );
+        let account_base = base_url
+            .strip_suffix("/v1")
+            .unwrap_or(&base_url)
+            .trim_end_matches('/')
+            .to_string();
+        Self {
+            inner,
+            http: reqwest::Client::builder().build().unwrap_or_default(),
+            account_base,
+            api_key,
+            model,
+        }
+    }
+
+    /// The native model-catalog endpoint for this account.
+    fn models_search_url(&self) -> String {
+        format!("{}/models/search", self.account_base)
+    }
+
+    /// GET the account's text-generation model catalog. Errors (transport,
+    /// non-2xx, rejected token) propagate so [`list_models`](Self::list_models)
+    /// can fall back to the curated list.
+    async fn fetch_models(&self) -> Result<Vec<String>> {
+        let mut request = self
+            .http
+            .get(self.models_search_url())
+            .query(&[("task", "Text Generation"), ("per_page", "100")]);
+        if !self.api_key.is_empty() {
+            request = request.bearer_auth(&self.api_key);
+        }
+        let response = request.send().await.map_err(|source| {
+            anyhow::Error::new(ProviderError::transport(format!(
+                "HTTP request to {} failed: {source}",
+                self.account_base
+            )))
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow::Error::new(ProviderError::http(
+                status.as_u16(),
+                format!(
+                    "{} returned HTTP {status}: {body}",
+                    self.models_search_url()
+                ),
+            )));
+        }
+        let parsed: ModelSearch = response
+            .json()
+            .await
+            .context("parsing Cloudflare model catalog")?;
+        Ok(parsed
+            .result
+            .into_iter()
+            .map(|model| model.name)
+            .filter(|name| !name.is_empty())
+            .collect())
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CloudflareProvider {
+    async fn health(&self) -> Result<()> {
+        // Workers AI has no OpenAI-style `/v1/models`, so probe the native
+        // account catalog. A 401/403 is a real auth failure (bad or missing
+        // token, or wrong Workers-AI permissions); any other response means we
+        // reached Cloudflare and the token was not rejected, which is enough to
+        // consider the backend healthy without spending inference tokens.
+        let mut request = self.http.get(self.models_search_url());
+        if !self.api_key.is_empty() {
+            request = request.bearer_auth(&self.api_key);
+        }
+        let response = request.send().await.map_err(|source| {
+            anyhow::Error::new(ProviderError::transport(format!(
+                "cannot reach {}: {source}",
+                self.account_base
+            )))
+        })?;
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+        {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow::Error::new(ProviderError::http(
+                status.as_u16(),
+                format!(
+                    "Cloudflare rejected the API token (HTTP {status}): {body}; \
+                     set {DEFAULT_KEY_ENV} and check the account id in the base URL"
+                ),
+            )));
+        }
+        Ok(())
+    }
+
+    async fn supports_native_tools(&self, model: &str) -> Result<bool> {
+        // OpenAI-compatible endpoint: structured tool calling is supported
+        // (GLM 5.2 and the other catalog models call tools natively).
+        self.inner.supports_native_tools(model).await
+    }
+
+    async fn list_models(&self) -> Result<Vec<String>> {
+        match self.fetch_models().await {
+            Ok(models) if !models.is_empty() => Ok(models),
+            Ok(_) => Ok(fallback_models()),
+            Err(err) => {
+                tracing::warn!(
+                    "Cloudflare model catalog query failed: {err:#}; using the curated fallback list"
+                );
+                Ok(fallback_models())
+            }
+        }
+    }
+
+    async fn chat_stream(&self, request: ChatRequest) -> Result<ChatStream> {
+        self.inner.chat_stream(request).await
+    }
+
+    async fn context_window(&self, model: &str) -> Option<u32> {
+        context_window(model)
+    }
+
+    fn label(&self) -> String {
+        format!("cloudflare:{}", self.model)
+    }
+}
+
+/// The curated fallback model list as owned strings.
+fn fallback_models() -> Vec<String> {
+    FALLBACK_MODELS.iter().map(|m| (*m).to_string()).collect()
+}
+
+/// Context windows for the common Workers AI text models. Deliberately
+/// conservative — underestimating only makes history compaction engage a little
+/// earlier, whereas overestimating risks overflowing the real window. Unknown
+/// tags report `None` so compaction falls back to the byte threshold.
+fn context_window(model: &str) -> Option<u32> {
+    let model = model.to_ascii_lowercase();
+    if model.contains("glm-5") || model.contains("glm-4") {
+        return Some(128_000);
+    }
+    if model.contains("llama-3.3") || model.contains("llama-3.1") {
+        return Some(128_000);
+    }
+    if model.contains("qwen") {
+        return Some(32_768);
+    }
+    None
+}
+
+/// Envelope of `GET /ai/models/search` (Cloudflare v4 API — subset).
+#[derive(Debug, Deserialize)]
+struct ModelSearch {
+    #[serde(default)]
+    result: Vec<ModelInfo>,
+}
+
+/// One entry in the model catalog (subset — only the `@cf/...` name is used).
+#[derive(Debug, Deserialize)]
+struct ModelInfo {
+    #[serde(default)]
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_docs() {
+        assert_eq!(DEFAULT_MODEL, "@cf/zai-org/glm-5.2");
+        assert_eq!(DEFAULT_KEY_ENV, "CLOUDFLARE_API_TOKEN");
+        assert_eq!(
+            BASE_URL_TEMPLATE,
+            "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+        );
+    }
+
+    #[test]
+    fn base_url_substitutes_the_account_id() {
+        assert_eq!(
+            base_url("abc123"),
+            "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1"
+        );
+        // Surrounding whitespace (from a pasted answer) is trimmed.
+        assert_eq!(
+            base_url("  abc123  "),
+            "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1"
+        );
+    }
+
+    #[test]
+    fn account_base_strips_the_v1_suffix_for_the_catalog_url() {
+        let provider = CloudflareProvider::new(base_url("acc"), DEFAULT_MODEL, "token");
+        assert_eq!(
+            provider.models_search_url(),
+            "https://api.cloudflare.com/client/v4/accounts/acc/ai/models/search"
+        );
+        // Chat still targets the OpenAI-compatible `/v1` endpoint.
+        assert_eq!(provider.label(), "cloudflare:@cf/zai-org/glm-5.2");
+    }
+
+    #[test]
+    fn account_base_tolerates_a_trailing_slash() {
+        let provider = CloudflareProvider::new(
+            "https://api.cloudflare.com/client/v4/accounts/acc/ai/v1/",
+            DEFAULT_MODEL,
+            "token",
+        );
+        assert_eq!(
+            provider.models_search_url(),
+            "https://api.cloudflare.com/client/v4/accounts/acc/ai/models/search"
+        );
+    }
+
+    #[test]
+    fn context_window_covers_glm_and_unknowns() {
+        assert_eq!(context_window("@cf/zai-org/glm-5.2"), Some(128_000));
+        assert_eq!(context_window("@cf/zai-org/glm-4.7-flash"), Some(128_000));
+        assert_eq!(
+            context_window("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
+            Some(128_000)
+        );
+        assert_eq!(
+            context_window("@cf/qwen/qwen2.5-coder-32b-instruct"),
+            Some(32_768)
+        );
+        assert_eq!(context_window("@cf/mistral/mistral-7b-instruct"), None);
+    }
+
+    #[test]
+    fn model_catalog_response_parses_and_filters_blanks() {
+        let raw = r#"{
+            "success": true,
+            "result": [
+                { "name": "@cf/zai-org/glm-5.2", "task": { "name": "Text Generation" } },
+                { "name": "" },
+                { "name": "@cf/meta/llama-3.3-70b-instruct-fp8-fast" }
+            ]
+        }"#;
+        let parsed: ModelSearch = serde_json::from_str(raw).expect("valid catalog json");
+        let names: Vec<String> = parsed
+            .result
+            .into_iter()
+            .map(|m| m.name)
+            .filter(|n| !n.is_empty())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "@cf/zai-org/glm-5.2".to_string(),
+                "@cf/meta/llama-3.3-70b-instruct-fp8-fast".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn fallback_list_leads_with_glm_5_2() {
+        assert_eq!(fallback_models()[0], DEFAULT_MODEL);
+    }
+}

--- a/src/llm/cloudflare.rs
+++ b/src/llm/cloudflare.rs
@@ -159,9 +159,7 @@ impl LlmProvider for CloudflareProvider {
             )))
         })?;
         let status = response.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED
-            || status == reqwest::StatusCode::FORBIDDEN
-        {
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             let body = response.text().await.unwrap_or_default();
             return Err(anyhow::Error::new(ProviderError::http(
                 status.as_u16(),

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -3,6 +3,7 @@
 //! registry, and the TUI.
 
 pub mod anthropic;
+pub mod cloudflare;
 pub mod fusion;
 pub mod llamacpp;
 pub mod ollama;

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -54,6 +54,8 @@ pub enum ProviderChoice {
     Anthropic,
     /// OpenRouter with a plain API key.
     OpenRouter,
+    /// Cloudflare Workers AI with an API token (account-scoped endpoint).
+    Cloudflare,
     /// xAI (Grok) with a plain API key.
     Xai,
     /// xAI via account sign-in (OAuth, `wizard --login xai`).
@@ -205,6 +207,10 @@ const XAI_KEY_ENV: &str = crate::llm::xai_oauth::DEFAULT_KEY_ENV;
 const OPENROUTER_KEY_ENV: &str = crate::llm::openrouter::DEFAULT_KEY_ENV;
 /// Default OpenRouter model (the Auto Router).
 const OPENROUTER_MODEL: &str = crate::llm::openrouter::DEFAULT_MODEL;
+/// Default env var name for the Cloudflare API token.
+const CLOUDFLARE_KEY_ENV: &str = crate::llm::cloudflare::DEFAULT_KEY_ENV;
+/// Default Cloudflare Workers AI model (GLM 5.2).
+const CLOUDFLARE_MODEL: &str = crate::llm::cloudflare::DEFAULT_MODEL;
 
 // ---------------------------------------------------------------------------
 // TUI entry point
@@ -297,6 +303,10 @@ fn collect_answers(terminal: &mut Tui) -> Result<Option<Answers>> {
              private, no API key",
         ),
         Opt::new("OpenRouter", "hundreds of models via OPENROUTER_API_KEY"),
+        Opt::new(
+            "Cloudflare Workers AI",
+            "GLM 5.2 via CLOUDFLARE_API_TOKEN (+ account id)",
+        ),
         Opt::new("xAI (Grok), API key", "grok-4.3 via XAI_API_KEY"),
         Opt::new("xAI account sign-in", "grok-4.3 via OAuth, no API key"),
         Opt::new("OpenAI / OpenAI-compatible", "gpt-4o and friends"),
@@ -327,27 +337,31 @@ fn collect_answers(terminal: &mut Tui) -> Result<Option<Answers>> {
             Some(c) => c,
             None => return Ok(None),
         },
-        2 => match collect_xai(terminal)? {
+        2 => match collect_cloudflare(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
-        3 => match collect_xai_oauth(terminal)? {
+        3 => match collect_xai(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
-        4 => match collect_openai(terminal)? {
+        4 => match collect_xai_oauth(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
-        5 => match collect_anthropic(terminal)? {
+        5 => match collect_openai(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
-        6 => match collect_custom(terminal)? {
+        6 => match collect_anthropic(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
-        7 => match collect_llamacpp(terminal)? {
+        7 => match collect_custom(terminal)? {
+            Some(c) => c,
+            None => return Ok(None),
+        },
+        8 => match collect_llamacpp(terminal)? {
             Some(c) => c,
             None => return Ok(None),
         },
@@ -1013,6 +1027,57 @@ fn collect_openrouter(terminal: &mut Tui) -> Result<Option<ProviderAnswers>> {
     }))
 }
 
+fn collect_cloudflare(terminal: &mut Tui) -> Result<Option<ProviderAnswers>> {
+    // The account id is folded into the endpoint URL (Workers AI is
+    // account-scoped); the token is read from an env var at request time.
+    let account_id = match text_input(
+        terminal,
+        "Cloudflare account ID",
+        "Dashboard → Workers AI (or `wrangler whoami`). Folded into the endpoint URL.",
+        "",
+    )? {
+        Some(value) => value,
+        None => return Ok(None),
+    };
+    let models: Vec<(String, String)> = vec![
+        (
+            CLOUDFLARE_MODEL.to_string(),
+            "GLM 5.2 — most capable (default)".to_string(),
+        ),
+        (
+            "@cf/zai-org/glm-4.7-flash".to_string(),
+            "GLM 4.7 Flash — cheaper, faster".to_string(),
+        ),
+    ];
+    let model = match pick_model(
+        terminal,
+        "Cloudflare Workers AI model (any @cf/... text-generation tag).",
+        &models,
+        CLOUDFLARE_MODEL,
+    )? {
+        Some(model) => model,
+        None => return Ok(None),
+    };
+    let api_key_env = match text_input(
+        terminal,
+        "API token env var",
+        "Wizard reads your Cloudflare API token from this env var (never stored on disk).",
+        CLOUDFLARE_KEY_ENV,
+    )? {
+        Some(value) => value,
+        None => return Ok(None),
+    };
+    Ok(Some(ProviderAnswers {
+        provider: ProviderChoice::Cloudflare,
+        provider_name: "cloudflare".to_string(),
+        kind: ProviderKind::Cloudflare,
+        base_url: crate::llm::cloudflare::base_url(&account_id),
+        model,
+        api_key_env: Some(api_key_env),
+        gguf_path: None,
+    }))
+}
+
 fn collect_xai(terminal: &mut Tui) -> Result<Option<ProviderAnswers>> {
     let models: Vec<(String, String)> = XAI_MODELS
         .iter()
@@ -1182,7 +1247,8 @@ fn print_summary(config: &Config) {
         ProviderKind::Openai
         | ProviderKind::Anthropic
         | ProviderKind::OpenRouter
-        | ProviderKind::Xai => {
+        | ProviderKind::Xai
+        | ProviderKind::Cloudflare => {
             if let Some(env) = provider.api_key_env.as_deref() {
                 println!("  • export your key: export {env}=...");
             }
@@ -1769,6 +1835,31 @@ mod tests {
         let defaults = Config::default();
         assert_eq!(config.model, defaults.model);
         assert_eq!(config.ollama_host, defaults.ollama_host);
+    }
+
+    #[test]
+    fn cloudflare_answers_build_the_expected_provider() {
+        let answers = Answers {
+            provider: ProviderChoice::Cloudflare,
+            provider_name: "cloudflare".to_string(),
+            kind: ProviderKind::Cloudflare,
+            base_url: crate::llm::cloudflare::base_url("acc123"),
+            model: CLOUDFLARE_MODEL.to_string(),
+            api_key_env: Some(CLOUDFLARE_KEY_ENV.to_string()),
+            ..base_answers()
+        };
+        let config = answers.into_config();
+        assert_eq!(config.active().name, "cloudflare");
+        assert_eq!(config.active().kind, ProviderKind::Cloudflare);
+        assert_eq!(
+            config.active().base_url,
+            "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1"
+        );
+        assert_eq!(config.active().model, "@cf/zai-org/glm-5.2");
+        assert_eq!(
+            config.active().api_key_env.as_deref(),
+            Some("CLOUDFLARE_API_TOKEN")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a `cloudflare` provider kind for [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/), authenticated with a Cloudflare API token and defaulting to **GLM 5.2** (`@cf/zai-org/glm-5.2`).

## Why it needs its own provider (not just OpenAI-compat reuse)

Workers AI's OpenAI-compatible surface is **account-scoped** — `https://api.cloudflare.com/client/v4/accounts/<id>/ai/v1` — and exposes only `/v1/chat/completions`. There is **no `/v1/models`**, so the stock `OpenAiProvider::health()`/`list_models()` (which `GET /models`) would 404, and `health()` is fatal at startup.

`CloudflareProvider` therefore delegates `chat_stream` to an inner `OpenAiProvider` but overrides:
- **`health()`** — probes Cloudflare's native account catalog (`/ai/models/search`); only a `401/403` is fatal (bad/missing token or wrong permissions), everything else counts as reachable. No inference tokens spent.
- **`list_models()`** — queries the same catalog (filtered to Text Generation), with a curated fallback list led by GLM 5.2.
- **`context_window()`** — conservative per-model table.

## Configuration

The account id is Cloudflare's wrinkle — it lives in the endpoint path. Both the interactive `/provider` menu and first-run onboarding prompt for it and fold it into the base URL via a new `AccountId` prompt field. Scripted:

```
export CLOUDFLARE_API_TOKEN=...
/provider add cloudflare cloudflare https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1 @cf/zai-org/glm-5.2 CLOUDFLARE_API_TOKEN
```

## Touchpoints

- `src/llm/cloudflare.rs` (new) · `src/llm/mod.rs`
- `src/config.rs` — `ProviderKind::Cloudflare`, `Display`, `build()`
- `src/app.rs` — `/provider add` parser, interactive menu row + dispatch, `AccountId` prompt field
- `src/onboarding.rs` — provider choice, collector, next-steps hint
- README + `docs/getting-started.md`

## Tests

Full suite green (737 lib + integration); clippy clean. New coverage: base-URL/account-id construction, catalog parse + blank filtering, context windows, config round-trip, config→build→label wiring, `/provider add` parse, and the onboarding answer→config path.

> Note: the live chat/health round-trip against real Cloudflare credentials was not exercised (no account/token available in this environment); pure logic is unit-tested.