### PR TITLE
fix(tui): persistent mouse selection and quiet failed tool cards

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3521,9 +3521,10 @@ impl App {
                 match card {
                     Some((slot, is_error, collapsed)) => {
                         *is_error = output.is_error;
-                        // Long, successful outputs start collapsed; errors
-                        // stay expanded so they are visible.
-                        *collapsed = !output.is_error && output.content.lines().count() > 6;
+                        // Long successful outputs start collapsed, and so do
+                        // errors — the ✗ glyph carries the signal without
+                        // dumping the payload; Ctrl-T expands it on demand.
+                        *collapsed = output.is_error || output.content.lines().count() > 6;
                         *slot = Some(output.content);
                     }
                     None => {
@@ -3534,7 +3535,7 @@ impl App {
                             args: Value::Null,
                             output: Some(output.content),
                             is_error: output.is_error,
-                            collapsed: false,
+                            collapsed: output.is_error,
                         });
                     }
                 }
@@ -4707,13 +4708,19 @@ pub async fn run_tui(mut config: Config, cli: Cli) -> Result<i32> {
                     }
                 }
                 AppAction::CopySelection => {
-                    // The drag finished: read the just-rendered cells under the
-                    // selection straight from the terminal's current buffer and
-                    // copy their text. The highlight stays on screen until the
-                    // next keystroke / click / scroll.
+                    // The drag finished: re-render and read the cells under the
+                    // selection from the fresh frame. (After a completed
+                    // `Terminal::draw` the swapped-in current buffer is reset,
+                    // so reading `current_buffer_mut` here would find only
+                    // blanks — clearing the selection the moment the button is
+                    // released.) The highlight stays on screen until the next
+                    // keystroke / click / scroll.
                     if let Some(selection) = app.selection {
-                        let text =
-                            crate::ui::selection_text(terminal.current_buffer_mut(), &selection);
+                        let mut text = String::new();
+                        terminal.draw(|frame| {
+                            crate::ui::draw(frame, &app);
+                            text = crate::ui::selection_text(frame.buffer_mut(), &selection);
+                        })?;
                         if text.is_empty() {
                             app.selection = None;
                         } else if let Err(err) = copy_to_clipboard(&text) {
@@ -7350,6 +7357,48 @@ mod tests {
             app.status.background_tasks, 0,
             "marker clears once all finish"
         );
+    }
+
+    #[test]
+    fn failed_tool_cards_start_collapsed() {
+        let mut app = app();
+        app.handle_agent_event(AgentEvent::ToolStarted {
+            name: "web_fetch".to_string(),
+            args: serde_json::json!({"url": "https://example.com"}),
+        });
+        app.handle_agent_event(AgentEvent::ToolFinished {
+            name: "web_fetch".to_string(),
+            output: crate::tools::ToolOutput::error("HTTP 403 Forbidden\n<!DOCTYPE html>\n..."),
+        });
+        assert!(
+            matches!(
+                app.transcript.last(),
+                Some(TranscriptEntry::ToolCard {
+                    is_error: true,
+                    collapsed: true,
+                    ..
+                })
+            ),
+            "errors show only the ✗ card line until expanded via Ctrl-T"
+        );
+
+        // Short successful outputs still arrive expanded.
+        app.handle_agent_event(AgentEvent::ToolStarted {
+            name: "read_file".to_string(),
+            args: serde_json::json!({"path": "a.txt"}),
+        });
+        app.handle_agent_event(AgentEvent::ToolFinished {
+            name: "read_file".to_string(),
+            output: crate::tools::ToolOutput::ok("one line"),
+        });
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptEntry::ToolCard {
+                is_error: false,
+                collapsed: false,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -518,7 +518,7 @@ fn tool_label(name: &str, args: &serde_json::Value) -> (String, String) {
 
 /// Render one tool invocation as a compact single-line card: status glyph,
 /// tool name in accent, truncated args in dim. Output expands below only
-/// when relevant (errors, or Ctrl-T).
+/// when relevant (short successful outputs, or Ctrl-T).
 fn tool_card_lines(
     lines: &mut Vec<Line<'static>>,
     name: &str,


### PR DESCRIPTION
Two TUI bug fixes:

**Mouse selection vanished on release.** The `CopySelection` handler read `terminal.current_buffer_mut()`, but ratatui's `swap_buffers` resets that buffer at the end of every `draw` — so the handler always saw blank cells, extracted an empty string, and cleared the selection (and never copied anything). The handler now re-renders and extracts the text from the fresh frame buffer. The highlight persists after release until the next click, keystroke, or scroll.

**Failed tools dumped their full error payload.** A failed `web_fetch` would spill hundreds of lines of HTML into the transcript. Error tool cards now start collapsed: just the ✗ glyph, tool name, and args, with a dim `+N lines` hint. Ctrl-T still expands the last card's output on demand.

Includes a regression test (`failed_tool_cards_start_collapsed`). Full suite: 776 passed.