### PR TITLE
feat(tui): collapse long tool output, click a card to expand it

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,13 @@ pub enum TranscriptEntry {
     Notice(String),
 }
 
+/// Whether a finished tool's output is long enough to start collapsed: more
+/// than six source lines, or a payload that would wrap well past that (one
+/// giant minified line counts as 1 by `lines()` but fills the screen anyway).
+fn collapse_long(content: &str) -> bool {
+    content.lines().count() > 6 || content.chars().count() > 600
+}
+
 /// Outcome of a background agent rebuild (model switch, crash recovery),
 /// delivered to the main loop via [`Event::AgentRebuilt`].
 pub struct AgentRebuild {
@@ -1070,6 +1077,11 @@ pub struct App {
     /// Active or just-completed mouse text selection, if any. Drives the
     /// highlight overlay and clipboard copy.
     pub selection: Option<Selection>,
+    /// Screen rows of tool-card header lines visible in the last-drawn frame,
+    /// as `(row, transcript index)` — the click-to-toggle hit map. Rebuilt by
+    /// [`crate::ui::draw`] every frame (hence the interior mutability: draw
+    /// takes `&App`) and emptied while an overlay covers the transcript.
+    pub card_hits: std::cell::RefCell<Vec<(u16, usize)>>,
     pub should_quit: bool,
     /// Tick counter driving the busy spinner.
     pub tick: u64,
@@ -1212,6 +1224,7 @@ impl App {
             peek_lines: Vec::new(),
             scroll: 0,
             selection: None,
+            card_hits: std::cell::RefCell::new(Vec::new()),
             should_quit: false,
             tick: 0,
             suggestions: Vec::new(),
@@ -2590,6 +2603,27 @@ impl App {
         }
     }
 
+    /// Toggle the tool card whose header line was drawn on screen row `row`
+    /// in the last frame (a plain click on it). No-op off-card, on a
+    /// still-running card, or while an overlay covers the transcript (the
+    /// hit map is empty then — see `card_hits`).
+    fn toggle_card_at(&mut self, row: u16) {
+        let hit = self
+            .card_hits
+            .borrow()
+            .iter()
+            .find(|(y, _)| *y == row)
+            .map(|(_, index)| *index);
+        if let Some(index) = hit
+            && let Some(TranscriptEntry::ToolCard {
+                output, collapsed, ..
+            }) = self.transcript.get_mut(index)
+            && output.is_some()
+        {
+            *collapsed = !*collapsed;
+        }
+    }
+
     /// Dispatch one event from the merged stream. Returns the user action
     /// the main loop must perform (start a turn, run a slash command, ...).
     pub fn handle_event(&mut self, event: Event) -> Result<Option<AppAction>> {
@@ -2625,9 +2659,11 @@ impl App {
                             sel.head = cell;
                             sel.dragging = false;
                             if sel.is_empty() {
-                                // A plain click (no drag) just clears any
-                                // previous selection.
+                                // A plain click (no drag) clears any previous
+                                // selection, and on a tool-card header line
+                                // toggles that card's output.
                                 self.selection = None;
+                                self.toggle_card_at(cell.1);
                             } else {
                                 // Hand off to the main loop: it owns the
                                 // terminal, so it reads the rendered cells and
@@ -3576,19 +3612,20 @@ impl App {
                         *is_error = output.is_error;
                         // Long successful outputs start collapsed, and so do
                         // errors — the ✗ glyph carries the signal without
-                        // dumping the payload; Ctrl-T expands it on demand.
-                        *collapsed = output.is_error || output.content.lines().count() > 6;
+                        // dumping the payload; a click or Ctrl-T expands it.
+                        *collapsed = output.is_error || collapse_long(&output.content);
                         *slot = Some(output.content);
                     }
                     None => {
                         // No matching running card (e.g. denied before start
                         // was emitted) — record the result standalone.
+                        let collapsed = output.is_error || collapse_long(&output.content);
                         self.transcript.push(TranscriptEntry::ToolCard {
                             name,
                             args: Value::Null,
                             output: Some(output.content),
                             is_error: output.is_error,
-                            collapsed: output.is_error,
+                            collapsed,
                         });
                     }
                 }
@@ -4204,6 +4241,7 @@ Shift+Tab                   toggle plan mode\n  \
 ↑ / ↓                       select suggestion · browse input history\n  \
 PgUp/PgDn · wheel           scroll the transcript\n  \
 drag                        select text — copied to the clipboard on release\n  \
+click a tool card           expand / collapse its output\n  \
 Ctrl-P                      model picker  ·  Ctrl-T toggle last tool card\n  \
 Ctrl-A/E Home/End ←/→       move cursor   ·  Ctrl-W/U/K kill word/to start/to end\n  \
 Ctrl-C                      quit";
@@ -7529,6 +7567,90 @@ mod tests {
             Some(TranscriptEntry::ToolCard {
                 is_error: false,
                 collapsed: false,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn long_outputs_start_collapsed_by_lines_or_length() {
+        assert!(!collapse_long("short output"));
+        assert!(!collapse_long(&"line\n".repeat(6)));
+        assert!(collapse_long(&"line\n".repeat(7)), "more than six lines");
+        assert!(
+            collapse_long(&"x".repeat(601)),
+            "a giant single line wraps to fill the screen just the same"
+        );
+    }
+
+    fn click(app: &mut App, column: u16, row: u16) {
+        use crossterm::event::MouseEvent;
+        for kind in [
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+        ] {
+            let _ = app.handle_event(Event::Mouse(MouseEvent {
+                kind,
+                column,
+                row,
+                modifiers: KeyModifiers::NONE,
+            }));
+        }
+    }
+
+    #[test]
+    fn clicking_a_tool_card_header_toggles_its_output() {
+        let mut app = app();
+        app.handle_agent_event(AgentEvent::ToolStarted {
+            name: "execute".to_string(),
+            args: serde_json::json!({"command": "ls"}),
+        });
+        app.handle_agent_event(AgentEvent::ToolFinished {
+            name: "execute".to_string(),
+            output: crate::tools::ToolOutput::ok("a\nb\nc\nd\ne\nf\ng\nh"),
+        });
+        let index = app.transcript.len() - 1;
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptEntry::ToolCard {
+                collapsed: true,
+                ..
+            })
+        ));
+
+        // Render a frame so the click hit map is populated.
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &app))
+            .unwrap();
+        let (row, hit_index) = *app
+            .card_hits
+            .borrow()
+            .first()
+            .expect("the card header should be clickable");
+        assert_eq!(hit_index, index);
+
+        // A plain click on the header expands the card...
+        click(&mut app, 2, row);
+        assert!(matches!(
+            app.transcript.get(index),
+            Some(TranscriptEntry::ToolCard {
+                collapsed: false,
+                ..
+            })
+        ));
+
+        // ...and a second click (at its possibly-shifted row) collapses it.
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &app))
+            .unwrap();
+        let row = app.card_hits.borrow().first().map(|(y, _)| *y).unwrap();
+        click(&mut app, 2, row);
+        assert!(matches!(
+            app.transcript.get(index),
+            Some(TranscriptEntry::ToolCard {
+                collapsed: true,
                 ..
             })
         ));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -128,6 +128,17 @@ pub fn draw(frame: &mut Frame, app: &App) {
         draw_subagents(frame, app);
     }
 
+    // With any overlay floating above the transcript, a click belongs to the
+    // overlay — drop the card hit map so it can't toggle a card underneath.
+    if app.picker.is_some()
+        || app.plan_review.is_some()
+        || app.interview.is_some()
+        || app.show_dashboard
+        || app.show_subagents
+    {
+        app.card_hits.borrow_mut().clear();
+    }
+
     // The selection highlight paints last so it reverses whatever ended up on
     // screen — transcript, sidebar, or an overlay the user dragged across.
     if let Some(selection) = app.selection {
@@ -200,6 +211,10 @@ pub fn selection_text(buf: &Buffer, selection: &Selection) -> String {
 /// collapsible tool cards. Borderless; a one-column side margin keeps the
 /// text off the terminal edge. Shows the welcome screen while empty.
 fn draw_transcript(frame: &mut Frame, app: &App, area: Rect) {
+    // Rebuilt from scratch every frame; cleared up front so the early
+    // returns below can't leave stale clickable rows behind.
+    app.card_hits.borrow_mut().clear();
+
     // Stay on the welcome screen until the conversation actually begins (see
     // `App::has_conversation`: early system notices alone don't dismiss it).
     if !app.has_conversation() && app.streaming.is_empty() && !app.status.busy {
@@ -227,13 +242,32 @@ fn draw_transcript(frame: &mut Frame, app: &App, area: Rect) {
     let inner_width = inner.width as usize;
     let inner_height = inner.height as usize;
 
-    let lines = wrap_lines(transcript_text(app), inner_width);
+    // Wrap each source line separately, fanning its tag out over the rows it
+    // becomes, so a click on any wrapped row still traces back to its card.
+    let (text, line_tags) = transcript_text(app);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut row_tags: Vec<Option<usize>> = Vec::new();
+    for (line, tag) in text.lines.into_iter().zip(line_tags) {
+        let before = lines.len();
+        lines.append(&mut wrap_lines(Text::from(vec![line]), inner_width));
+        row_tags.extend(std::iter::repeat_n(tag, lines.len() - before));
+    }
     let total = lines.len();
     let max_scroll = total.saturating_sub(inner_height);
     let scroll = (app.scroll as usize).min(max_scroll);
     let start = max_scroll - scroll;
     let end = (start + inner_height).min(total);
     let visible: Vec<Line<'static>> = lines[start..end].to_vec();
+
+    // Record where card headers landed on screen for click-to-toggle.
+    {
+        let mut hits = app.card_hits.borrow_mut();
+        for (offset, tag) in row_tags[start..end].iter().enumerate() {
+            if let Some(index) = tag {
+                hits.push((inner.y + offset as u16, *index));
+            }
+        }
+    }
 
     frame.render_widget(Paragraph::new(Text::from(visible)), inner);
 
@@ -373,14 +407,17 @@ fn thinking_text(message: &str) -> Text<'static> {
     Text::from(lines)
 }
 
-/// Build the full (unwrapped) transcript text from app state.
-fn transcript_text(app: &App) -> Text<'static> {
+/// Build the full (unwrapped) transcript text from app state, plus a
+/// parallel per-line tag holding the transcript index of the tool card
+/// whose header the line is — the click-to-toggle targets.
+fn transcript_text(app: &App) -> (Text<'static>, Vec<Option<usize>>) {
     let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut tags: Vec<Option<usize>> = Vec::new();
     let mut prev_tool = false;
     let mut prev_notice = false;
     let mut first = true;
 
-    for entry in &app.transcript {
+    for (index, entry) in app.transcript.iter().enumerate() {
         let is_tool = matches!(entry, TranscriptEntry::ToolCard { .. });
         let is_notice = matches!(entry, TranscriptEntry::Notice(_));
         // Comfortable spacing between turns; runs of tool cards or notices
@@ -392,6 +429,9 @@ fn transcript_text(app: &App) -> Text<'static> {
         first = false;
         prev_tool = is_tool;
         prev_notice = is_notice;
+
+        // A tool card's first pushed line is its header (glyph + name).
+        let header_at = lines.len();
 
         match entry {
             TranscriptEntry::User(message) => {
@@ -450,6 +490,13 @@ fn transcript_text(app: &App) -> Text<'static> {
                 }
             }
         }
+
+        // Keep the tags in lockstep with whatever the entry pushed; only a
+        // tool card's header line is clickable.
+        tags.resize(lines.len(), None);
+        if is_tool && header_at < lines.len() {
+            tags[header_at] = Some(index);
+        }
     }
 
     if !app.streaming_thinking.is_empty() {
@@ -489,7 +536,8 @@ fn transcript_text(app: &App) -> Text<'static> {
         ]));
     }
 
-    Text::from(lines)
+    tags.resize(lines.len(), None);
+    (Text::from(lines), tags)
 }
 
 /// Human label + one-line summary for a tool call. `spawn_subagent` reads as


### PR DESCRIPTION
Follow-up to #20:

**Long command output no longer floods the transcript.** Output collapsed past 6 lines already, but a giant single-line payload (minified HTML/JSON) counted as one line and wrapped to fill the screen anyway. Collapse now also triggers past 600 chars.

**Tool cards are clickable.** The transcript renderer tags each card's header line through wrapping/scrolling into a per-frame hit map; a plain click on a header row toggles that card's output — any card, not just the last one like Ctrl-T. The map is emptied while an overlay (picker, dashboard, plan review, interview, subagents) covers the transcript so clicks can't toggle cards underneath. /help documents it.

Tests: `long_outputs_start_collapsed_by_lines_or_length`, plus an end-to-end `clicking_a_tool_card_header_toggles_its_output` that renders on a TestBackend and clicks the real hit map. Full suite: 789 passed, clippy clean.