### PR TITLE
fix(llm): timeouts for cloud streams, discard partials on retry

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -102,6 +102,11 @@ pub enum AgentEvent {
     StepCompleted { step: u32 },
     /// Non-fatal error surfaced to the user; the loop may continue.
     Error(String),
+    /// A completion stream died mid-response and is about to be retried from
+    /// scratch. Whatever partial text was streamed so far never entered
+    /// history and will be re-generated — consumers rendering deltas must
+    /// discard their partial buffer or the retry duplicates it.
+    StreamRetrying,
     /// A lifecycle hook did something worth surfacing (rewrote arguments,
     /// appended context, blocked, or failed). Plain successes are silent.
     /// Rendered as a dim log line.
@@ -1302,6 +1307,9 @@ impl Agent {
                             .saturating_mul(2u64.saturating_pow(attempt)),
                     );
                     let n = attempt + 1;
+                    // The retry re-generates the response from the top; tell
+                    // consumers to drop any partial text this attempt streamed.
+                    let _ = emit(events, AgentEvent::StreamRetrying).await;
                     let _ = emit(
                         events,
                         AgentEvent::Error(format!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -3637,6 +3637,12 @@ impl App {
                 self.flush_streaming();
                 self.notice(format!("error: {message}"));
             }
+            AgentEvent::StreamRetrying => {
+                // The partial completion is being re-generated from scratch;
+                // flushing it would double the text once the retry streams.
+                self.streaming.clear();
+                self.streaming_thinking.clear();
+            }
             AgentEvent::HookFired {
                 event,
                 command,
@@ -7570,6 +7576,31 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn stream_retry_discards_the_partial_streamed_text() {
+        let mut app = app();
+        app.handle_agent_event(AgentEvent::TextDelta("half an ans".to_string()));
+        app.handle_agent_event(AgentEvent::StreamRetrying);
+        app.handle_agent_event(AgentEvent::Error(
+            "LLM unavailable (stream stalled); sleeping 5s then retrying (attempt 1)".to_string(),
+        ));
+        assert!(
+            app.streaming.is_empty(),
+            "the doomed attempt's partial text is dropped, not flushed"
+        );
+        assert!(
+            !app
+                .transcript
+                .iter()
+                .any(|entry| matches!(entry, TranscriptEntry::Assistant(text) if text.contains("half an ans"))),
+            "no assistant entry made of the discarded partial"
+        );
+
+        // The retry streams the full answer; only that lands.
+        app.handle_agent_event(AgentEvent::TextDelta("the full answer".to_string()));
+        assert_eq!(app.streaming, "the full answer");
     }
 
     #[test]

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -49,7 +49,7 @@ impl AnthropicProvider {
         api_key: impl Into<String>,
     ) -> Self {
         let base_url = base_url.into().trim_end_matches('/').to_string();
-        let http = reqwest::Client::builder().build().unwrap_or_default();
+        let http = crate::llm::cloud_http_builder().build().unwrap_or_default();
         Self {
             http,
             base_url,

--- a/src/llm/cloudflare.rs
+++ b/src/llm/cloudflare.rs
@@ -87,7 +87,7 @@ impl CloudflareProvider {
             .to_string();
         Self {
             inner,
-            http: reqwest::Client::builder().build().unwrap_or_default(),
+            http: crate::llm::cloud_http_builder().build().unwrap_or_default(),
             account_base,
             api_key,
             model,

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -22,6 +22,24 @@ use serde::{Deserialize, Serialize};
 /// Shared across [`llamacpp`], [`ollama`], [`openai`], and [`anthropic`].
 pub type ChatStream = Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>;
 
+/// HTTP client builder for the cloud chat backends. A generation can
+/// legitimately stream for many minutes, so there is no overall request
+/// timeout; instead the client fails fast when it can't connect, errors out
+/// of a stream that has gone completely silent (a live SSE stream never goes
+/// minutes without a frame — even keep-alive comments count as reads), and
+/// keepalive-probes idle connections so a dead peer is noticed. A stream
+/// read that times out surfaces as a transient error, which the agent's
+/// backoff-retry loop picks up — instead of the turn hanging forever on a
+/// stalled connection. Local backends (llama.cpp, Ollama) keep their own
+/// clients: a big model can silently prefill for a long time on weak
+/// hardware, which this would misread as a stall.
+pub(crate) fn cloud_http_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(20))
+        .read_timeout(std::time::Duration::from_secs(300))
+        .tcp_keepalive(std::time::Duration::from_secs(30))
+}
+
 /// Typed error returned by every HTTP-based provider adapter for failed
 /// responses and transport failures. Always reachable from the `anyhow`
 /// chain via `err.downcast_ref::<ProviderError>()`, so the agent loop can

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -107,7 +107,7 @@ impl OpenAiProvider {
         vendor: &'static str,
     ) -> Self {
         let base_url = base_url.into().trim_end_matches('/').to_string();
-        let http = reqwest::Client::builder().build().unwrap_or_default();
+        let http = crate::llm::cloud_http_builder().build().unwrap_or_default();
         Self {
             http,
             base_url,
@@ -130,7 +130,7 @@ impl OpenAiProvider {
                 map.insert(name, value);
             }
         }
-        self.http = reqwest::Client::builder()
+        self.http = crate::llm::cloud_http_builder()
             .default_headers(map)
             .build()
             .unwrap_or_default();

--- a/src/output.rs
+++ b/src/output.rs
@@ -117,6 +117,12 @@ impl EventSink for TextSink {
             AgentEvent::StepCompleted { step } => {
                 tracing::debug!("step {step} completed");
             }
+            AgentEvent::StreamRetrying => {
+                // Text already printed can't be unprinted; mark the cut so
+                // the re-generated response below isn't read as a duplicate.
+                self.spinner.hide();
+                println!("\x1b[2m\n… stream interrupted — the response restarts below …\x1b[0m");
+            }
             AgentEvent::Error(message) => {
                 self.spinner.hide();
                 eprintln!("\nwizard error: {message}");
@@ -231,6 +237,9 @@ struct ToolCallsEntry {
 pub struct JsonSink<W: Write + Send> {
     out: W,
     result: String,
+    /// Length of `result` at the last completed step — the truncation point
+    /// when a mid-stream retry discards the current attempt's partial text.
+    committed: usize,
     turns: u64,
     steps: u64,
     prompt_tokens: u64,
@@ -250,6 +259,7 @@ impl<W: Write + Send> JsonSink<W> {
         Self {
             out,
             result: String::new(),
+            committed: 0,
             turns: 0,
             steps: 0,
             prompt_tokens: 0,
@@ -281,8 +291,16 @@ impl<W: Write + Send> EventSink for JsonSink<W> {
                     entry.errors += 1;
                 }
             }
-            AgentEvent::StepCompleted { .. } => self.steps += 1,
+            AgentEvent::StepCompleted { .. } => {
+                self.steps += 1;
+                self.committed = self.result.len();
+            }
             AgentEvent::Error(message) => self.errors.push(message),
+            AgentEvent::StreamRetrying => {
+                // The attempt's partial text never entered history; the retry
+                // re-streams it, so keeping it would double the text.
+                self.result.truncate(self.committed);
+            }
             AgentEvent::PlanReady { respond, .. } => {
                 // No human in the loop: approve so the turn executes.
                 let _ = respond.send(PlanVerdict::approve());
@@ -391,6 +409,9 @@ impl<W: Write + Send> EventSink for StreamJsonSink<W> {
             }
             AgentEvent::Error(message) => {
                 self.emit(json!({"type": "error", "message": message}));
+            }
+            AgentEvent::StreamRetrying => {
+                self.emit(json!({"type": "stream_retrying"}));
             }
             AgentEvent::HookFired {
                 event,
@@ -609,6 +630,22 @@ pub(crate) mod tests {
         assert_eq!(value["tool_calls"][0]["calls"], 2);
         assert_eq!(value["tool_calls"][0]["errors"], 1);
         assert_eq!(value["errors"].as_array().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn json_sink_drops_a_retried_attempts_partial_text() {
+        let buf = SharedBuf::default();
+        let mut sink = JsonSink::new(buf.clone());
+        sink.event(AgentEvent::TextDelta("looked around. ".to_string()));
+        sink.event(AgentEvent::StepCompleted { step: 1 });
+        // A second completion streams half an answer, dies, and is retried.
+        sink.event(AgentEvent::TextDelta("the ans".to_string()));
+        sink.event(AgentEvent::StreamRetrying);
+        sink.event(AgentEvent::TextDelta("the answer is 42".to_string()));
+        sink.finish(DoneReason::Completed);
+        let value: serde_json::Value =
+            serde_json::from_str(buf.contents().trim()).expect("valid JSON");
+        assert_eq!(value["result"], "looked around. the answer is 42");
     }
 
     #[test]


### PR DESCRIPTION
Diagnosed from a live session that hung for 50 minutes on grok-4.5: the turn made 4 tool round-trips, then the 5th completion request stalled and never returned. Root cause: the cloud provider clients (openai-compat/xai, anthropic, cloudflare) were built with `reqwest::Client::builder().build()` — no connect timeout, no read timeout, no keepalive — so a dead connection blocked `stream.next()` indefinitely and the backoff-retry loop never got a chance to run. The turn only ended when the user pressed Esc.

**Fix 1:** shared `cloud_http_builder()` — 20s connect timeout, 300s read (idle-stream) timeout, 30s TCP keepalive. No overall request timeout since long generations are legitimate; any SSE frame (including keepalive comments) resets the read timer. A timed-out read surfaces as a transient error, which the existing backoff-retry loop picks up. Local backends (llama.cpp/Ollama) intentionally keep their own clients — slow silent prefill would misread as a stall.

**Fix 2:** mid-stream retries used to duplicate text — the TUI flushed the dead attempt's partial text to the transcript, then the retry re-streamed the full response. New `AgentEvent::StreamRetrying` (emitted before the backoff notice) makes consumers discard the partial: TUI and JsonSink drop it, the plain-text printer marks the cut, stream-json emits a typed record.

Tests: `stream_retry_discards_the_partial_streamed_text`, `json_sink_drops_a_retried_attempts_partial_text`. Full suite 791 passed, clippy clean.