### PR TITLE
feat: wizard sync — signed config/skills bundles across machines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +424,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +517,16 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -620,6 +669,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ego-tree"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +742,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1544,6 +1623,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "plist"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1724,7 +1813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2155,6 +2253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2293,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3429,6 +3546,7 @@ dependencies = [
  "croner",
  "crossterm",
  "dirs",
+ "ed25519-dalek",
  "flate2",
  "fusion-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ flate2 = "1"
 tar = "0.4"
 semver = "1"
 
+# Config/skills sync (`wizard sync`): ed25519 signatures over the bundle
+# manifest. Keys are seeded from getrandom — no rand/rand_core dependency.
+ed25519-dalek = "2"
+
 # Process-group kill for background tasks (`task_kill`, timeouts)
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ One command installs the `wizard` binary and a small default loadout (a Playwrig
 - [Doctor & status](docs/doctor.md): `wizard doctor` diagnostics, `/status`
 - [Scheduler](docs/scheduler.md): cron-scheduled headless runs
 - [Fleet](docs/fleet.md): parallel workers over git worktrees
+- [Sync](docs/sync.md): `wizard sync` moves config, skills, and custom tooling between machines as a signed bundle
 - [Fork and distribute](docs/market.md): publish your evolved Wizard
 - [Architecture](docs/architecture.md): how it's built
 - [Security](SECURITY.md): threat model

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,17 @@ mv /usr/local/bin/wizard.prev /usr/local/bin/wizard
 
 Be clear about what the smoke test is: it proves the new binary launches and reports a version, nothing more. It does not prove the change is correct, safe, or what you asked for. Deep evolve is the model rewriting its own agent loop, checked only by the compiler and the smoke test. The record and the rollback are the safety net: every deep evolution is logged with its diff to `~/.wizard/evolution.jsonl`, the source checkout at `~/.wizard/src` keeps the change as a git commit, and the prior binary stays one `mv` away.
 
+## `wizard sync` bundles
+
+`wizard sync` moves config, skills, commands, subagents, and scripted tools between machines as a signed bundle ([sync.md](docs/sync.md)). The mechanics:
+
+- **Signed manifest.** Bundles are ed25519-signed: the manifest lists the sha256 of every file, `manifest.sig` signs the manifest, and the bundle embeds the sender's public key. Each machine's key seed lives at `~/.wizard/sync/key` (mode 0600).
+- **All-or-nothing verification.** `pull` checks the signature, then the trust list, then every file hash; nothing is written to `~/.wizard/` unless all of it passes.
+- **Trust on first use.** Like SSH: the first pull pins the sender's public key into `~/.wizard/sync/trusted_keys` and prints its fingerprint for out-of-band comparison (`wizard sync key` on the source machine). Later pulls reject bundles signed by unknown keys.
+- **Signed, not encrypted.** Anyone who obtains a bundle can read it. Credentials (`credentials.toml`, `xai_oauth.json`) are excluded by default; `--include-credentials` opts them in, writes the bundle file 0600, and prints a warning. Transfer such a bundle privately (`scp`), never over a public URL.
+
+Be clear about what pinning a key means: a bundle carries commands, subagents, and scripted tools, which later run with your privileges. Trusting a machine's key in `trusted_keys` trusts whoever controls that machine to ship that state to this one.
+
 ## No sandbox
 
 All tools run directly with your user's privileges. The `execute` tool runs real shell commands and cannot be confined to the working directory: absolute paths, `cd ..`, pipes, and network access are all reachable. The same is true of MCP servers and scripted tools. Treat tool execution as full local access, because it is.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,6 +228,9 @@ Ratatui + crossterm terminal UI:
 | `~/.wizard/src/` | Source checkout for deep evolve (created on demand) |
 | `~/.wizard/sessions/*.jsonl` | Chat history |
 | `~/.wizard/evolution.jsonl` | Self-extension log |
+| `~/.wizard/sync/key` | Ed25519 signing-key seed for `wizard sync` (mode 0600; see [sync.md](sync.md)) |
+| `~/.wizard/sync/trusted_keys` | Public keys `wizard sync pull` accepts, one per line, pinned on first use |
+| `~/.wizard/sync/backups/` | Timestamped backups of files overwritten by `wizard sync pull` |
 | `~/.wizard/logs/` | Debug traces |
 | `.wizard/loop-control` | Sovereign-mode run control (per project) |
 | `.wizard/checkpoints/` | Per-file edit snapshots powering `/rewind` (per project; see [checkpoints.md](checkpoints.md)) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,7 +165,7 @@ gguf_path = "/home/you/.wizard/models/Qwen3.6-27B-Q4_K_M.gguf"
 
 `gguf_path` is what lets Wizard start `llama-server` for you; without it (e.g. a server you run yourself, or on another machine) Wizard just connects to `base_url`. `gguf_path` only applies to `kind = "llamacpp"` providers, which never use an API key.
 
-The installer also lays down `~/.wizard/mcp.toml` (Playwright browser MCP) and `~/.wizard/subagents/` (a four-subagent roster), each file only if absent; see [the default loadout](loadout.md).
+The installer also lays down `~/.wizard/mcp.toml` (Playwright browser MCP) and `~/.wizard/subagents/` (a four-subagent roster), each file only if absent; see [the default loadout](loadout.md). To move this state (config, skills, commands, subagents, scripted tools) to another machine, see [Sync](sync.md).
 
 ### Spinner verbs (`[ui]`)
 
@@ -432,4 +432,5 @@ RUST_LOG=wizard=debug wizard
 - [Personality modes](modes.md): genie vs sovereign
 - [Self-extension](evolve.md): how `/evolve` adds capabilities
 - [Bring your own model](byom.md): any GGUF, or custom Ollama models
+- [Sync](sync.md): move your config and skills to another machine as a signed bundle
 - [Architecture](architecture.md): how Wizard works under the hood

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,72 @@
+# `wizard sync`: move state between machines
+
+`wizard sync` packs Wizard's portable state — config, skills, custom commands, subagents, and scripted tools — into a signed bundle that another machine can verify and apply.
+
+| Command | What it does |
+|---------|--------------|
+| `wizard sync pack [--out <path>] [--include-credentials]` | Write a signed `.tar.gz` bundle (default `wizard-sync-<YYYYMMDD>.tar.gz` in the current directory); prints the path, file count, size, and signing-key fingerprint |
+| `wizard sync pull <source> [--dry-run]` | Verify a bundle (file path or http(s) URL, downloaded if needed), print a new / changed / identical summary, then apply it; `--dry-run` stops after the summary. With no `<source>`, uses `source` from `[sync]` in `~/.wizard/config.toml` |
+| `wizard sync key` | Print this machine's sync public key (base64) and its fingerprint (`SHA256:…`, OpenSSH-style), generating the keypair on first use |
+
+## Quickstart
+
+On the machine that has the state (a laptop, say):
+
+```bash
+wizard sync pack
+scp wizard-sync-20260709.tar.gz workbox:
+```
+
+On the other machine:
+
+```bash
+wizard sync pull wizard-sync-20260709.tar.gz
+```
+
+One command each side. Pull verifies the bundle, prints what is new, changed, and identical, backs up anything it overwrites, and applies. The first pull pins the sender's signing key; compare the fingerprint it prints against `wizard sync key` on the source machine (see [Trust model](#trust-model)). To preview without changing anything, add `--dry-run`: it runs the full verification and prints the same summary, then stops.
+
+## What's in a bundle
+
+Paths are relative to `~/.wizard/`. Pieces missing on the packing machine are skipped silently.
+
+| Contents | Bundled |
+|----------|---------|
+| `config.toml`, `mcp.toml`, the system prompt file | always |
+| `skills/`, `commands/`, `subagents/`, `tools/` | always |
+| `credentials.toml`, `xai_oauth.json` (API keys, OAuth tokens) | only with `--include-credentials` |
+| `sessions/`, `logs/`, `models/`, `memory/`, `sync/`, the evolution log, caches | never |
+
+`--include-credentials` puts your API keys and OAuth tokens in the bundle. The bundle file is then written with mode 0600 and pack prints a warning: the bundle is signed but **not encrypted**, so anyone who obtains it can read the keys. Transfer such a bundle privately (`scp`), never over a public URL.
+
+## Trust model
+
+Bundles are signed with ed25519. Each machine generates a signing keypair on its first `pack`; the seed lives at `~/.wizard/sync/key` (mode 0600). The bundle embeds the sender's public key, and `manifest.sig` signs the manifest, which lists the sha256 of every file.
+
+Verification on `pull` is all-or-nothing: the signature, then the trust check, then every file hash. Nothing is written to `~/.wizard/` until everything passes.
+
+Trust is on first use, like SSH:
+
+- The first `pull` on a machine pins the sender's public key into `~/.wizard/sync/trusted_keys` and prints its fingerprint. Compare it against `wizard sync key` on the source machine.
+- Later pulls require the bundle's key to already be in `trusted_keys`; a bundle signed by an unknown key is rejected.
+- To trust an additional machine, add its public key (`wizard sync key` there) as a line in `trusted_keys`.
+
+## Pulling from a URL
+
+`<source>` can be an http(s) URL; the bundle is downloaded and then verified exactly like a local file. To make the pull side a single command, set the source in `~/.wizard/config.toml`:
+
+```toml
+[sync]
+source = "https://example.com/wizard-sync.tar.gz"  # or a file path; used when `wizard sync pull` gets no argument
+```
+
+Then `wizard sync pull` with no argument pulls from there. Host the bundle somewhere private, and never publish a bundle made with `--include-credentials`: it is signed, not encrypted.
+
+## Backups
+
+Existing files a pull would overwrite are first copied to `~/.wizard/sync/backups/<timestamp>/`; restore by copying them back. Pull is additive: it overwrites and adds, never deletes, so local files absent from the bundle are left alone. There are no interactive prompts, consistent with the rest of Wizard.
+
+## Limitations
+
+- Not continuous sync. A bundle is a snapshot; last write wins, and there is no merge or conflict resolution.
+- Pull never deletes, so removing a skill on one machine won't remove it elsewhere. Delete it on each machine by hand.
+- Bundles are signed, not encrypted.

--- a/src/app.rs
+++ b/src/app.rs
@@ -453,7 +453,9 @@ impl SlashCommand {
             "effort" => match args.first().map(|s| s.to_ascii_lowercase()).as_deref() {
                 None => Ok(Self::Effort(None)),
                 Some("low") => Ok(Self::Effort(Some(Some(ReasoningEffort::Low)))),
-                Some("medium") | Some("med") => Ok(Self::Effort(Some(Some(ReasoningEffort::Medium)))),
+                Some("medium") | Some("med") => {
+                    Ok(Self::Effort(Some(Some(ReasoningEffort::Medium))))
+                }
                 Some("high") => Ok(Self::Effort(Some(Some(ReasoningEffort::High)))),
                 Some("default") | Some("off") | Some("none") => Ok(Self::Effort(Some(None))),
                 Some(other) => Err(format!(
@@ -535,11 +537,27 @@ impl SlashCommand {
         use SlashCommand::*;
         match self {
             // State the agent can set on itself, plus read-only info toggles.
-            Model(Some(_)) | Mode(Some(_)) | Effort(Some(_)) | Goal(_) | Diff | Todos
-            | Subagents | Dashboard | Cost | Memory | Doctor | Status | Bashes | Compact
-            | Reload | Plan | Omakase | Settings | Vim | Help | Fusion(FusionAction::Toggle) => {
-                Ok(())
-            }
+            Model(Some(_))
+            | Mode(Some(_))
+            | Effort(Some(_))
+            | Goal(_)
+            | Diff
+            | Todos
+            | Subagents
+            | Dashboard
+            | Cost
+            | Memory
+            | Doctor
+            | Status
+            | Bashes
+            | Compact
+            | Reload
+            | Plan
+            | Omakase
+            | Settings
+            | Vim
+            | Help
+            | Fusion(FusionAction::Toggle) => Ok(()),
 
             // Interactive pickers: there is no human at the keyboard mid-turn,
             // so require the argument that names the choice directly.
@@ -549,9 +567,9 @@ impl SlashCommand {
             Fusion(FusionAction::Config) => {
                 Err("`/fusion config` opens an interactive editor; use `/fusion` to toggle".into())
             }
-            Agents => {
-                Err("`/agents` opens a picker for the user; spawn subagents with the spawn tool".into())
-            }
+            Agents => Err(
+                "`/agents` opens a picker for the user; spawn subagents with the spawn tool".into(),
+            ),
 
             // Session-ending, destructive, or external-setup commands are off
             // limits to the agent.
@@ -559,14 +577,20 @@ impl SlashCommand {
             Clear => Err("refusing to clear the conversation on the user's behalf".into()),
             Rewind(_) => Err("`/rewind` restores checkpoints and is the user's call".into()),
             Resume(_) => Err("`/resume` switches sessions and is the user's call".into()),
-            Evolve { .. } => Err("`/evolve` is a heavyweight self-edit; leave it to the user".into()),
+            Evolve { .. } => {
+                Err("`/evolve` is a heavyweight self-edit; leave it to the user".into())
+            }
             Publish { .. } => Err("`/publish` forks the tool; leave it to the user".into()),
             Provider(_) | ProviderSetup { .. } => {
                 Err("provider setup is the user's call; use `/model` to switch models".into())
             }
-            Server(_) => Err("`/server` manages the local model server; leave it to the user".into()),
+            Server(_) => {
+                Err("`/server` manages the local model server; leave it to the user".into())
+            }
             Login(_) => Err("`/login` is an interactive sign-in; leave it to the user".into()),
-            ImportClaude(_) => Err("`/settings` import is driven from a picker; leave it to the user".into()),
+            ImportClaude(_) => {
+                Err("`/settings` import is driven from a picker; leave it to the user".into())
+            }
         }
     }
 }
@@ -5747,10 +5771,26 @@ impl CommandContext<'_> {
         }
         let current = self.app.config.reasoning_effort;
         let rows = [
-            ("high", "most reasoning — slowest, best on hard tasks", Some(ReasoningEffort::High)),
-            ("medium", "balanced reasoning", Some(ReasoningEffort::Medium)),
-            ("low", "least reasoning — fastest, cheapest", Some(ReasoningEffort::Low)),
-            ("default", "leave the provider default (e.g. Grok 4.5 → high)", None),
+            (
+                "high",
+                "most reasoning — slowest, best on hard tasks",
+                Some(ReasoningEffort::High),
+            ),
+            (
+                "medium",
+                "balanced reasoning",
+                Some(ReasoningEffort::Medium),
+            ),
+            (
+                "low",
+                "least reasoning — fastest, cheapest",
+                Some(ReasoningEffort::Low),
+            ),
+            (
+                "default",
+                "leave the provider default (e.g. Grok 4.5 → high)",
+                None,
+            ),
         ];
         let items: Vec<PickerItem> = rows
             .iter()
@@ -7653,9 +7693,7 @@ mod tests {
         // Render a frame so the click hit map is populated.
         let backend = ratatui::backend::TestBackend::new(80, 24);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| crate::ui::draw(frame, &app))
-            .unwrap();
+        terminal.draw(|frame| crate::ui::draw(frame, &app)).unwrap();
         let (row, hit_index) = *app
             .card_hits
             .borrow()
@@ -7674,9 +7712,7 @@ mod tests {
         ));
 
         // ...and a second click (at its possibly-shifted row) collapses it.
-        terminal
-            .draw(|frame| crate::ui::draw(frame, &app))
-            .unwrap();
+        terminal.draw(|frame| crate::ui::draw(frame, &app)).unwrap();
         let row = app.card_hits.borrow().first().map(|(y, _)| *y).unwrap();
         click(&mut app, 2, row);
         assert!(matches!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,7 +110,8 @@ pub struct Cli {
 impl Cli {
     /// Names of top-level flags set on this invocation that a self-contained
     /// subcommand (bench, doctor, schedule, scheduler, fleet, usage, evolve,
-    /// update) would silently ignore. `--cwd` is honored everywhere and excluded.
+    /// update, sync) would silently ignore. `--cwd` is honored everywhere and
+    /// excluded.
     /// [`crate::run`] turns a non-empty result into a hard error rather than
     /// silently dropping the flags.
     pub fn ignored_top_level_flags(&self) -> Vec<&'static str> {
@@ -253,6 +254,57 @@ pub enum Command {
         #[arg(long)]
         rollback: bool,
     },
+
+    /// Sync config and skills across machines: pack the portable parts of
+    /// ~/.wizard into a signed bundle, pull and verify one from a file or
+    /// URL. Self-contained: never loads config or triggers onboarding.
+    Sync {
+        #[command(subcommand)]
+        cmd: SyncCmd,
+    },
+}
+
+/// `wizard sync` subcommands. Self-contained like update: no config load
+/// (pull reads `[sync].source` from config.toml directly), no onboarding,
+/// no LLM. Bundles are ed25519-signed; trust is pinned on first use in
+/// `~/.wizard/sync/trusted_keys` (compare fingerprints via `wizard sync key`).
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum SyncCmd {
+    /// Create a signed bundle of portable ~/.wizard state: config.toml,
+    /// mcp.toml, system_prompt.md, and the skills/, commands/, subagents/,
+    /// and tools/ directories. Credentials stay out unless explicitly
+    /// included.
+    Pack {
+        /// Output path (default: `wizard-sync-<YYYYMMDD>.tar.gz` in the
+        /// current directory).
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+
+        /// Also pack credentials.toml and xai_oauth.json. The bundle then
+        /// contains API keys — transfer it privately. The bundle file is
+        /// written with 0600 permissions.
+        #[arg(long)]
+        include_credentials: bool,
+    },
+
+    /// Fetch, verify, and apply a bundle (file path or http(s) URL). Falls
+    /// back to `[sync].source` in config.toml when no source is given.
+    /// Additive only: replaced files are backed up under
+    /// ~/.wizard/sync/backups/, nothing is deleted.
+    Pull {
+        /// Bundle to pull: a local file path (`~` expands) or an http(s) URL.
+        source: Option<String>,
+
+        /// Verify the bundle and show what would change without writing
+        /// anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Print this machine's sync public key and fingerprint (generating the
+    /// keypair on first use). Compare the fingerprint against what `pull`
+    /// reports on the other machine.
+    Key,
 }
 
 /// `wizard evolve` subcommands. Self-contained: they read
@@ -661,6 +713,76 @@ mod tests {
         assert_eq!(to.as_deref(), Some("v0.5.0"));
         assert!(force);
         assert!(rollback);
+    }
+
+    #[test]
+    fn sync_subcommands_parse() {
+        let cli = parse(&["sync", "pack"]).expect("sync pack parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Sync {
+                cmd: SyncCmd::Pack {
+                    out: None,
+                    include_credentials: false,
+                }
+            })
+        ));
+
+        let cli = parse(&[
+            "sync",
+            "pack",
+            "--out",
+            "/tmp/b.tar.gz",
+            "--include-credentials",
+        ])
+        .expect("sync pack flags parse");
+        let Some(Command::Sync {
+            cmd:
+                SyncCmd::Pack {
+                    out,
+                    include_credentials,
+                },
+        }) = cli.command
+        else {
+            panic!("expected sync pack");
+        };
+        assert_eq!(out, Some(PathBuf::from("/tmp/b.tar.gz")));
+        assert!(include_credentials);
+
+        let cli = parse(&["sync", "pull"]).expect("sync pull without a source parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Sync {
+                cmd: SyncCmd::Pull {
+                    source: None,
+                    dry_run: false,
+                }
+            })
+        ));
+
+        let cli = parse(&["sync", "pull", "~/b.tar.gz", "--dry-run"])
+            .expect("sync pull with a source parses");
+        let Some(Command::Sync {
+            cmd: SyncCmd::Pull { source, dry_run },
+        }) = cli.command
+        else {
+            panic!("expected sync pull");
+        };
+        assert_eq!(source.as_deref(), Some("~/b.tar.gz"));
+        assert!(dry_run);
+
+        let cli = parse(&["sync", "key"]).expect("sync key parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Sync { cmd: SyncCmd::Key })
+        ));
+
+        let err = parse(&["sync"]).expect_err("bare sync requires a subcommand");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -384,6 +384,16 @@ impl Default for UpdateConfig {
     }
 }
 
+/// Cross-machine sync settings (`[sync]` in `config.toml`); see `wizard sync`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SyncConfig {
+    /// Default source for `wizard sync pull`: a bundle file path or http(s)
+    /// URL, used when no positional source is given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
 /// Model-fusion settings (`[fusion]` in `config.toml`); see `/fusion` and
 /// [`crate::llm::fusion`]. Panel and synthesizer reference existing
 /// [`ProviderConfig`] entries by name — each provider already binds a model, so
@@ -628,6 +638,9 @@ pub struct Config {
     /// Self-update settings (`wizard update` + the passive startup check).
     #[serde(default)]
     pub update: UpdateConfig,
+    /// Cross-machine sync settings (`wizard sync`).
+    #[serde(default)]
+    pub sync: SyncConfig,
     /// Model-fusion settings (`/fusion`). Absent until configured; the toggle
     /// falls back to a default panel derived from `providers` when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -670,6 +683,7 @@ impl Default for Config {
             checkpoints: CheckpointConfig::default(),
             fleet: FleetConfig::default(),
             update: UpdateConfig::default(),
+            sync: SyncConfig::default(),
             fusion: None,
         }
     }
@@ -1201,6 +1215,9 @@ mod tests {
                 repo: "acme/wizard".to_string(),
                 interval_hours: 6,
             },
+            sync: SyncConfig {
+                source: Some("https://example.com/wizard-sync.tar.gz".to_string()),
+            },
             fusion: Some(FusionConfig {
                 panel: vec!["openai".to_string()],
                 synthesizer: "openai".to_string(),
@@ -1246,7 +1263,19 @@ mod tests {
         assert_eq!(parsed.checkpoints, original.checkpoints);
         assert_eq!(parsed.fleet, original.fleet);
         assert_eq!(parsed.update, original.update);
+        assert_eq!(parsed.sync, original.sync);
         assert_eq!(parsed.fusion, original.fusion);
+    }
+
+    #[test]
+    fn sync_defaults_when_section_missing() {
+        let config: Config = toml::from_str("model = \"m\"").expect("valid toml");
+        assert_eq!(config.sync, SyncConfig::default());
+        assert!(config.sync.source.is_none());
+
+        let config: Config =
+            toml::from_str("[sync]\nsource = \"~/bundles/w.tar.gz\"").expect("valid toml");
+        assert_eq!(config.sync.source.as_deref(), Some("~/bundles/w.tar.gz"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod schedule;
 pub mod server;
 pub mod session_registry;
 pub mod skills;
+pub mod sync;
 pub mod tools;
 pub mod ui;
 pub mod update;
@@ -117,6 +118,17 @@ pub async fn run(cli: cli::Cli) -> Result<i32> {
             std::env::set_current_dir(dir)?;
         }
         return update::run(*check, to.clone(), *force, *rollback).await;
+    }
+
+    // Config/skills sync: `wizard sync` packs and pulls signed bundles of
+    // portable ~/.wizard state. Self-contained — no config load (pull reads
+    // `[sync].source` from config.toml directly), no onboarding, no LLM — so
+    // it dispatches before the config load like `update`.
+    if let Some(cli::Command::Sync { cmd }) = &cli.command {
+        if let Some(dir) = &cli.cwd {
+            std::env::set_current_dir(dir)?;
+        }
+        return sync::run(cmd.clone()).await;
     }
 
     // Doctor diagnoses the environment — starting with "does the config

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,1425 @@
+//! Cross-machine sync: `wizard sync` packs the portable parts of `~/.wizard`
+//! (config.toml, mcp.toml, the system prompt, and the skills/, commands/,
+//! subagents/, tools/ directories) into a signed `.tar.gz` bundle, and pulls
+//! one back on another machine.
+//!
+//! A bundle holds `manifest.json` (the file list with sha256s, plus the
+//! signer's ed25519 public key), `manifest.sig` (a signature over the exact
+//! manifest bytes), and the files under `payload/`. Trust is TOFU like SSH:
+//! the first `pull` pins the signer's key into `~/.wizard/sync/trusted_keys`;
+//! later pulls must be signed by a pinned key. Compare fingerprints out of
+//! band with `wizard sync key`. Pulls are additive/overwrite only — replaced
+//! files are backed up under `~/.wizard/sync/backups/`, nothing is deleted —
+//! and every verification failure aborts before a single byte is written.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine as _;
+use base64::engine::general_purpose::{STANDARD as BASE64, STANDARD_NO_PAD as BASE64_NO_PAD};
+use chrono::Utc;
+use ed25519_dalek::{Signature, Signer as _, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::SyncCmd;
+use crate::config::Config;
+use crate::update::sha256_hex;
+
+/// Bundle format version; bump on incompatible manifest changes.
+const BUNDLE_VERSION: u32 = 1;
+
+/// HTTP connect timeout for a URL pull (mirrors `update::download_and_install`).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+
+// ---------------------------------------------------------------------------
+// Bundle format
+// ---------------------------------------------------------------------------
+
+/// `manifest.json`: everything needed to verify the payload. The signature in
+/// `manifest.sig` covers the exact serialized bytes of this file, so the file
+/// list, hashes, and embedded public key are all tamper-evident.
+#[derive(Debug, Serialize, Deserialize)]
+struct Manifest {
+    version: u32,
+    created_at: String,
+    wizard_version: String,
+    host: String,
+    includes_credentials: bool,
+    /// base64 of the signer's raw 32-byte ed25519 public key.
+    public_key: String,
+    files: Vec<ManifestEntry>,
+}
+
+/// One payload file: its path relative to `~/.wizard`, sha256 (lowercase
+/// hex), and size in bytes.
+#[derive(Debug, Serialize, Deserialize)]
+struct ManifestEntry {
+    path: String,
+    sha256: String,
+    size: u64,
+}
+
+/// A parsed-but-unverified bundle: the raw manifest bytes (the signature
+/// covers these exactly), the base64 signature line, and the payload files
+/// keyed by their `~/.wizard`-relative path.
+struct RawBundle {
+    manifest_bytes: Vec<u8>,
+    signature: String,
+    payload: BTreeMap<String, Vec<u8>>,
+}
+
+// ---------------------------------------------------------------------------
+// What gets packed
+// ---------------------------------------------------------------------------
+
+/// The portable file set, as paths relative to `wizard_dir`. Resolved from
+/// the [`Config`] path helpers in production ([`SyncPaths::resolve`]); tests
+/// build one over a temp dir. Anything not listed here — sessions, logs,
+/// models, memory, sync state itself — never enters a bundle.
+struct SyncPaths {
+    wizard_dir: PathBuf,
+    /// Single files (skipped silently when missing).
+    files: Vec<PathBuf>,
+    /// Directories packed recursively (skipped silently when missing).
+    dirs: Vec<PathBuf>,
+    /// Secret files, packed only with `--include-credentials`.
+    credential_files: Vec<PathBuf>,
+}
+
+impl SyncPaths {
+    /// Resolve against the real `~/.wizard`, deriving the relative names from
+    /// the canonical path helpers so a moved file can never silently desync.
+    fn resolve() -> Result<Self> {
+        let wizard_dir = Config::wizard_dir()?;
+        let rel = |path: PathBuf| -> Result<PathBuf> {
+            Ok(path
+                .strip_prefix(&wizard_dir)
+                .with_context(|| {
+                    format!("{} is not under {}", path.display(), wizard_dir.display())
+                })?
+                .to_path_buf())
+        };
+        Ok(Self {
+            files: vec![
+                rel(Config::path()?)?,
+                rel(Config::mcp_config_path()?)?,
+                rel(Config::system_prompt_path()?)?,
+            ],
+            dirs: vec![
+                rel(Config::skills_dir()?)?,
+                // User slash commands; no dedicated Config helper (discovery
+                // in `crate::commands` joins the same name).
+                PathBuf::from("commands"),
+                rel(Config::subagents_dir()?)?,
+                rel(Config::scripted_tools_dir()?)?,
+            ],
+            credential_files: vec![
+                rel(crate::credentials::path()?)?,
+                rel(crate::llm::xai_oauth::token_path()?)?,
+            ],
+            wizard_dir,
+        })
+    }
+}
+
+/// Relative paths that hold secrets: written 0600 on pull, and packed only
+/// with `--include-credentials`.
+fn is_credential_path(path: &str) -> bool {
+    path == "credentials.toml" || path == "xai_oauth.json"
+}
+
+/// Collect the bundle payload: file contents keyed by `~/.wizard`-relative
+/// path (forward slashes). Missing files and directories are skipped without
+/// error — a fresh machine packs whatever it has.
+fn collect_entries(
+    paths: &SyncPaths,
+    include_credentials: bool,
+) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut entries = BTreeMap::new();
+    for rel in &paths.files {
+        add_file(&paths.wizard_dir, rel, &mut entries)?;
+    }
+    if include_credentials {
+        for rel in &paths.credential_files {
+            add_file(&paths.wizard_dir, rel, &mut entries)?;
+        }
+    }
+    for rel in &paths.dirs {
+        add_dir(&paths.wizard_dir, rel, &mut entries)?;
+    }
+    Ok(entries)
+}
+
+/// Add one regular file (following symlinks); anything else is skipped.
+fn add_file(wizard_dir: &Path, rel: &Path, entries: &mut BTreeMap<String, Vec<u8>>) -> Result<()> {
+    let abs = wizard_dir.join(rel);
+    match std::fs::metadata(&abs) {
+        Ok(meta) if meta.is_file() => {
+            let data = std::fs::read(&abs).with_context(|| format!("reading {}", abs.display()))?;
+            entries.insert(rel_string(rel)?, data);
+        }
+        // Missing, or not a regular file: skip without error.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Recursively add a directory's regular files. A missing directory is fine;
+/// unreadable entries (e.g. broken symlinks) are skipped.
+fn add_dir(
+    wizard_dir: &Path,
+    rel_dir: &Path,
+    entries: &mut BTreeMap<String, Vec<u8>>,
+) -> Result<()> {
+    let abs = wizard_dir.join(rel_dir);
+    let read_dir = match std::fs::read_dir(&abs) {
+        Ok(read_dir) => read_dir,
+        Err(_) => return Ok(()),
+    };
+    for entry in read_dir {
+        let entry = entry.with_context(|| format!("listing {}", abs.display()))?;
+        let rel = rel_dir.join(entry.file_name());
+        let Ok(meta) = std::fs::metadata(entry.path()) else {
+            continue; // broken symlink or the like
+        };
+        if meta.is_dir() {
+            add_dir(wizard_dir, &rel, entries)?;
+        } else if meta.is_file() {
+            add_file(wizard_dir, &rel, entries)?;
+        }
+    }
+    Ok(())
+}
+
+/// A relative path as the forward-slash string stored in the manifest.
+fn rel_string(rel: &Path) -> Result<String> {
+    Ok(rel
+        .to_str()
+        .with_context(|| format!("non-UTF-8 path under ~/.wizard: {}", rel.display()))?
+        .to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Keys and trust
+// ---------------------------------------------------------------------------
+
+/// `~/.wizard/sync/` — signing key, trusted keys, pull backups.
+fn sync_dir(wizard_dir: &Path) -> PathBuf {
+    wizard_dir.join("sync")
+}
+
+/// `~/.wizard/sync/key` — base64 of this machine's 32-byte ed25519 seed.
+fn key_path(wizard_dir: &Path) -> PathBuf {
+    sync_dir(wizard_dir).join("key")
+}
+
+/// `~/.wizard/sync/trusted_keys` — one base64 public key per line, optional
+/// ` # comment` suffix.
+fn trusted_keys_path(wizard_dir: &Path) -> PathBuf {
+    sync_dir(wizard_dir).join("trusted_keys")
+}
+
+/// Load the signing key, generating (and persisting, 0600) a fresh one when
+/// the key file does not exist yet. The seed comes straight from the OS RNG.
+fn load_or_generate_key(wizard_dir: &Path) -> Result<SigningKey> {
+    let path = key_path(wizard_dir);
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => {
+            let bytes = BASE64
+                .decode(raw.trim())
+                .with_context(|| format!("decoding {}", path.display()))?;
+            let seed: [u8; 32] = bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| anyhow!("{} does not hold a base64 32-byte seed", path.display()))?;
+            Ok(SigningKey::from_bytes(&seed))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let mut seed = [0u8; 32];
+            getrandom::fill(&mut seed).map_err(|err| anyhow!("gathering key randomness: {err}"))?;
+            write_secret_atomic(&path, format!("{}\n", BASE64.encode(seed)).as_bytes())
+                .with_context(|| format!("writing {}", path.display()))?;
+            Ok(SigningKey::from_bytes(&seed))
+        }
+        Err(err) => Err(anyhow!(err).context(format!("reading {}", path.display()))),
+    }
+}
+
+/// OpenSSH-style fingerprint of a public key: `SHA256:` + unpadded base64 of
+/// sha256 over the raw 32 key bytes.
+fn fingerprint(key: &VerifyingKey) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(key.to_bytes());
+    format!("SHA256:{}", BASE64_NO_PAD.encode(hasher.finalize()))
+}
+
+/// Decode a manifest's base64 public key into a verifying key.
+fn decode_public_key(b64: &str) -> Result<VerifyingKey> {
+    let bytes = BASE64
+        .decode(b64)
+        .context("decoding the bundle's public key")?;
+    let raw: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("the bundle's public key is not 32 bytes"))?;
+    VerifyingKey::from_bytes(&raw)
+        .map_err(|_| anyhow!("the bundle's public key is not a valid ed25519 key"))
+}
+
+/// The keys in a `trusted_keys` file: one base64 key per line, `#` starts a
+/// comment, blank lines ignored.
+fn parse_trusted_keys(raw: &str) -> Vec<String> {
+    raw.lines()
+        .filter_map(|line| {
+            let key = line.split('#').next().unwrap_or("").trim();
+            (!key.is_empty()).then(|| key.to_string())
+        })
+        .collect()
+}
+
+/// Outcome of the trust check for a verified signing key.
+#[derive(Debug, PartialEq, Eq)]
+enum Trust {
+    /// The key is already pinned in `trusted_keys`.
+    AlreadyTrusted,
+    /// First use: no keys were pinned yet, so this one was pinned now.
+    Pinned,
+    /// Dry run of the first-use case: the key would be pinned, nothing written.
+    WouldPin,
+}
+
+/// Enforce the TOFU trust model for a bundle key that already passed
+/// signature verification. Empty/missing `trusted_keys` pins the key (unless
+/// `dry_run`); a non-empty file must already list it.
+fn check_trust(
+    wizard_dir: &Path,
+    public_key: &str,
+    fingerprint: &str,
+    source: &str,
+    dry_run: bool,
+) -> Result<Trust> {
+    let path = trusted_keys_path(wizard_dir);
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let keys = parse_trusted_keys(&raw);
+    if keys.iter().any(|key| key == public_key) {
+        return Ok(Trust::AlreadyTrusted);
+    }
+    if !keys.is_empty() {
+        bail!(
+            "the bundle is signed by an UNTRUSTED key.\n  fingerprint: {fingerprint}\n\
+             To trust it: run `wizard sync key` on the source machine, compare its\n\
+             fingerprint with the one above, and if they match add this line to\n\
+             {}:\n  {public_key}",
+            path.display()
+        );
+    }
+    if dry_run {
+        return Ok(Trust::WouldPin);
+    }
+    ensure_sync_dir(wizard_dir)?;
+    let line = format!(
+        "{public_key} # pinned {} from {source}\n",
+        Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    );
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    file.write_all(line.as_bytes())
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(Trust::Pinned)
+}
+
+/// Create `~/.wizard/sync/` with 0700 permissions (mirrors
+/// `credentials::write_at`).
+fn ensure_sync_dir(wizard_dir: &Path) -> Result<()> {
+    let dir = sync_dir(wizard_dir);
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("restricting permissions on {}", dir.display()))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Atomic writes
+// ---------------------------------------------------------------------------
+
+/// Write `data` to `dest` atomically: a temp file in the same directory
+/// (created as needed), then a rename over the target.
+fn write_file_atomic(dest: &Path, data: &[u8], secret: bool) -> Result<()> {
+    let dir = dest
+        .parent()
+        .with_context(|| format!("{} has no parent directory", dest.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let name = dest
+        .file_name()
+        .and_then(|name| name.to_str())
+        .with_context(|| format!("{} has no usable file name", dest.display()))?;
+    let tmp = dir.join(format!(".{name}.sync.tmp"));
+    {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        if secret {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&tmp)
+            .with_context(|| format!("creating {}", tmp.display()))?;
+        // create(true) keeps the mode of a pre-existing file; enforce 0600.
+        #[cfg(unix)]
+        if secret {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("restricting permissions on {}", tmp.display()))?;
+        }
+        file.write_all(data)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("syncing {}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, dest).with_context(|| format!("moving {} into place", dest.display()))?;
+    Ok(())
+}
+
+/// Atomic write with 0600 perms and a 0700 parent (the key file).
+fn write_secret_atomic(dest: &Path, data: &[u8]) -> Result<()> {
+    let dir = dest
+        .parent()
+        .with_context(|| format!("{} has no parent directory", dest.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("restricting permissions on {}", dir.display()))?;
+    }
+    write_file_atomic(dest, data, true)
+}
+
+// ---------------------------------------------------------------------------
+// Pack
+// ---------------------------------------------------------------------------
+
+/// What `pack` produced, for the CLI summary.
+struct PackOutcome {
+    file_count: usize,
+    payload_bytes: u64,
+    bundle_bytes: u64,
+    includes_credentials: bool,
+    fingerprint: String,
+}
+
+/// Pack the portable file set into a signed bundle at `out`.
+fn pack(paths: &SyncPaths, out: &Path, include_credentials: bool) -> Result<PackOutcome> {
+    let key = load_or_generate_key(&paths.wizard_dir)?;
+    let entries = collect_entries(paths, include_credentials)?;
+    if entries.is_empty() {
+        bail!(
+            "nothing to pack — no portable files found under {}",
+            paths.wizard_dir.display()
+        );
+    }
+    // Reflect what actually landed, not just the flag: with the flag set but
+    // no credential files on disk, the bundle carries no secrets.
+    let includes_credentials = entries.keys().any(|path| is_credential_path(path));
+
+    let manifest = Manifest {
+        version: BUNDLE_VERSION,
+        created_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        wizard_version: crate::update::current_version().to_string(),
+        host: host_name(),
+        includes_credentials,
+        public_key: BASE64.encode(key.verifying_key().to_bytes()),
+        files: entries
+            .iter()
+            .map(|(path, data)| ManifestEntry {
+                path: path.clone(),
+                sha256: sha256_hex(data),
+                size: data.len() as u64,
+            })
+            .collect(),
+    };
+    let manifest_bytes =
+        serde_json::to_vec_pretty(&manifest).context("serializing the bundle manifest")?;
+    let signature = BASE64.encode(key.sign(&manifest_bytes).to_bytes());
+    let bundle = assemble_bundle(&manifest_bytes, &signature, &entries)?;
+
+    // A bundle carrying API keys is itself a secret; write it 0600.
+    write_file_atomic(out, &bundle, includes_credentials)
+        .with_context(|| format!("writing {}", out.display()))?;
+
+    Ok(PackOutcome {
+        file_count: entries.len(),
+        payload_bytes: entries.values().map(|data| data.len() as u64).sum(),
+        bundle_bytes: bundle.len() as u64,
+        includes_credentials,
+        fingerprint: fingerprint(&key.verifying_key()),
+    })
+}
+
+/// Serialize a bundle: gzip over a tar of `manifest.json`, `manifest.sig`,
+/// and `payload/<path>` entries.
+fn assemble_bundle(
+    manifest_bytes: &[u8],
+    signature: &str,
+    payload: &BTreeMap<String, Vec<u8>>,
+) -> Result<Vec<u8>> {
+    let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    let mut tar = tar::Builder::new(gz);
+    append_entry(&mut tar, "manifest.json", manifest_bytes)?;
+    append_entry(
+        &mut tar,
+        "manifest.sig",
+        format!("{signature}\n").as_bytes(),
+    )?;
+    for (path, data) in payload {
+        append_entry(&mut tar, &format!("payload/{path}"), data)?;
+    }
+    let gz = tar.into_inner().context("finalizing the bundle tar")?;
+    gz.finish().context("finalizing the bundle gzip")
+}
+
+/// Append one in-memory file to the bundle tar.
+fn append_entry<W: Write>(tar: &mut tar::Builder<W>, path: &str, data: &[u8]) -> Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_mtime(Utc::now().timestamp().max(0) as u64);
+    header.set_cksum();
+    tar.append_data(&mut header, path, data)
+        .with_context(|| format!("adding {path} to the bundle"))
+}
+
+/// Best-effort hostname for the manifest; `unknown` when undeterminable.
+fn host_name() -> String {
+    if let Ok(host) = std::env::var("HOSTNAME")
+        && !host.trim().is_empty()
+    {
+        return host.trim().to_string();
+    }
+    for path in ["/proc/sys/kernel/hostname", "/etc/hostname"] {
+        if let Ok(raw) = std::fs::read_to_string(path)
+            && !raw.trim().is_empty()
+        {
+            return raw.trim().to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Pull: parse and verify
+// ---------------------------------------------------------------------------
+
+/// Split a bundle into manifest bytes, signature, and payload map. Structural
+/// checks only (plus path safety on payload names); cryptographic and hash
+/// verification happen in [`verify_bundle`].
+fn parse_bundle(bytes: &[u8]) -> Result<RawBundle> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+    let mut manifest_bytes = None;
+    let mut signature = None;
+    let mut payload: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for entry in archive.entries().context("reading the bundle")? {
+        let mut entry = entry.context("reading a bundle entry")?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = {
+            let raw = entry.path().context("a bundle entry has a bad path")?;
+            raw.to_str()
+                .context("a bundle entry path is not UTF-8")?
+                .to_string()
+        };
+        let mut data = Vec::new();
+        std::io::Read::read_to_end(&mut entry, &mut data)
+            .with_context(|| format!("reading {path} from the bundle"))?;
+        match path.as_str() {
+            "manifest.json" => manifest_bytes = Some(data),
+            "manifest.sig" => {
+                signature = Some(
+                    String::from_utf8(data)
+                        .context("manifest.sig is not UTF-8")?
+                        .trim()
+                        .to_string(),
+                )
+            }
+            _ => {
+                let Some(rel) = path.strip_prefix("payload/") else {
+                    bail!("unexpected file {path:?} in the bundle");
+                };
+                validate_rel_path(rel)?;
+                if payload.insert(rel.to_string(), data).is_some() {
+                    bail!("duplicate payload entry {rel:?} in the bundle");
+                }
+            }
+        }
+    }
+    Ok(RawBundle {
+        manifest_bytes: manifest_bytes.context("the bundle has no manifest.json")?,
+        signature: signature.context("the bundle has no manifest.sig")?,
+        payload,
+    })
+}
+
+/// Reject any bundle path that could escape `~/.wizard`: absolute paths,
+/// `..` components, backslashes, and anything that is not a chain of plain
+/// path components.
+fn validate_rel_path(path: &str) -> Result<()> {
+    if path.is_empty() {
+        bail!("the bundle contains an empty file path");
+    }
+    if path.contains('\\') {
+        bail!("bundle path {path:?} contains a backslash");
+    }
+    let rel = Path::new(path);
+    if rel.is_absolute() {
+        bail!("bundle path {path:?} is absolute");
+    }
+    for component in rel.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::ParentDir => bail!("bundle path {path:?} contains a `..` component"),
+            _ => bail!("bundle path {path:?} is not a plain relative path"),
+        }
+    }
+    Ok(())
+}
+
+/// Full verification: manifest signature (over the exact manifest bytes,
+/// against the embedded public key), manifest path safety, exact
+/// payload/manifest correspondence, and per-file size + sha256. Any failure
+/// is a hard error; nothing is written anywhere.
+fn verify_bundle(raw: &RawBundle) -> Result<Manifest> {
+    let manifest: Manifest =
+        serde_json::from_slice(&raw.manifest_bytes).context("parsing manifest.json")?;
+    if manifest.version != BUNDLE_VERSION {
+        bail!(
+            "unsupported bundle version {} (this wizard understands version {BUNDLE_VERSION}) \
+             — update wizard on this machine",
+            manifest.version
+        );
+    }
+
+    let key = decode_public_key(&manifest.public_key)?;
+    let sig_bytes = BASE64
+        .decode(&raw.signature)
+        .context("decoding manifest.sig")?;
+    let signature = Signature::from_slice(&sig_bytes)
+        .map_err(|_| anyhow!("manifest.sig is not a 64-byte ed25519 signature"))?;
+    key.verify_strict(&raw.manifest_bytes, &signature)
+        .map_err(|_| {
+            anyhow!(
+                "bundle signature verification FAILED — the manifest does not match its \
+             signature; refusing to touch ~/.wizard"
+            )
+        })?;
+
+    let mut listed: BTreeMap<&str, &ManifestEntry> = BTreeMap::new();
+    for entry in &manifest.files {
+        validate_rel_path(&entry.path)?;
+        if listed.insert(entry.path.as_str(), entry).is_some() {
+            bail!("the manifest lists {:?} twice", entry.path);
+        }
+    }
+    for path in raw.payload.keys() {
+        if !listed.contains_key(path.as_str()) {
+            bail!("payload file {path:?} is not listed in the manifest");
+        }
+    }
+    for (path, entry) in &listed {
+        let Some(data) = raw.payload.get(*path) else {
+            bail!("the manifest lists {path:?} but the payload does not contain it");
+        };
+        if data.len() as u64 != entry.size {
+            bail!(
+                "size mismatch for {path:?}: the manifest says {} bytes, the payload has {}",
+                entry.size,
+                data.len()
+            );
+        }
+        if sha256_hex(data) != entry.sha256.to_ascii_lowercase() {
+            bail!("sha256 mismatch for {path:?} — the bundle is corrupt or tampered with");
+        }
+    }
+    Ok(manifest)
+}
+
+// ---------------------------------------------------------------------------
+// Pull: diff and apply
+// ---------------------------------------------------------------------------
+
+/// How a payload file relates to what is on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileState {
+    New,
+    Changed,
+    Identical,
+}
+
+impl FileState {
+    fn label(self) -> &'static str {
+        match self {
+            FileState::New => "new",
+            FileState::Changed => "changed",
+            FileState::Identical => "identical",
+        }
+    }
+}
+
+/// Classify every payload file against the live `wizard_dir`.
+fn diff_against(
+    wizard_dir: &Path,
+    payload: &BTreeMap<String, Vec<u8>>,
+) -> Vec<(String, FileState)> {
+    payload
+        .iter()
+        .map(|(path, data)| {
+            let state = match std::fs::read(wizard_dir.join(path)) {
+                Ok(existing) if existing == *data => FileState::Identical,
+                Ok(_) => FileState::Changed,
+                Err(_) => FileState::New,
+            };
+            (path.clone(), state)
+        })
+        .collect()
+}
+
+/// What `apply` did, for the CLI summary.
+struct ApplyOutcome {
+    applied: usize,
+    unchanged: usize,
+    backup_dir: Option<PathBuf>,
+}
+
+/// Write every new/changed payload file into `wizard_dir`, backing up any
+/// existing version first. Additive only: files on disk that are not in the
+/// bundle are never touched.
+fn apply(
+    wizard_dir: &Path,
+    payload: &BTreeMap<String, Vec<u8>>,
+    diff: &[(String, FileState)],
+) -> Result<ApplyOutcome> {
+    let backup_root = sync_dir(wizard_dir)
+        .join("backups")
+        .join(Utc::now().format("%Y%m%d-%H%M%S").to_string());
+    let mut outcome = ApplyOutcome {
+        applied: 0,
+        unchanged: 0,
+        backup_dir: None,
+    };
+    for (path, state) in diff {
+        if *state == FileState::Identical {
+            outcome.unchanged += 1;
+            continue;
+        }
+        let dest = wizard_dir.join(path);
+        if dest.exists() {
+            let backup = backup_root.join(path);
+            let dir = backup
+                .parent()
+                .with_context(|| format!("{} has no parent directory", backup.display()))?;
+            std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+            std::fs::copy(&dest, &backup).with_context(|| {
+                format!("backing up {} to {}", dest.display(), backup.display())
+            })?;
+            outcome.backup_dir = Some(backup_root.clone());
+        }
+        let data = payload
+            .get(path)
+            .with_context(|| format!("payload lost {path:?}"))?; // unreachable: diff comes from payload
+        write_file_atomic(&dest, data, is_credential_path(path))?;
+        outcome.applied += 1;
+    }
+    Ok(outcome)
+}
+
+// ---------------------------------------------------------------------------
+// Source resolution
+// ---------------------------------------------------------------------------
+
+/// `[sync].source` from `~/.wizard/config.toml`, read directly (sync never
+/// runs the full config load, which could trigger onboarding side effects).
+fn configured_source() -> Option<String> {
+    let path = Config::path().ok()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let config: Config = toml::from_str(&raw).ok()?;
+    config
+        .sync
+        .source
+        .filter(|source| !source.trim().is_empty())
+}
+
+/// Fetch the bundle bytes: http(s) URLs download, everything else is a local
+/// path (`~` expands).
+async fn fetch_source(source: &str) -> Result<Vec<u8>> {
+    if source.starts_with("http://") || source.starts_with("https://") {
+        let client = reqwest::Client::builder()
+            .user_agent(format!("wizard/{}", crate::update::current_version()))
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .context("building HTTP client")?;
+        let bytes = client
+            .get(source)
+            .send()
+            .await
+            .and_then(|response| response.error_for_status())
+            .with_context(|| format!("downloading {source}"))?
+            .bytes()
+            .await
+            .with_context(|| format!("reading {source}"))?;
+        Ok(bytes.to_vec())
+    } else {
+        let path = PathBuf::from(shellexpand::tilde(source).into_owned());
+        std::fs::read(&path).with_context(|| format!("reading {}", path.display()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI handlers
+// ---------------------------------------------------------------------------
+
+/// The `wizard sync` command handler. Returns the process exit code.
+pub async fn run(cmd: SyncCmd) -> Result<i32> {
+    match cmd {
+        SyncCmd::Pack {
+            out,
+            include_credentials,
+        } => pack_cli(out, include_credentials),
+        SyncCmd::Pull { source, dry_run } => pull_cli(source, dry_run).await,
+        SyncCmd::Key => key_cli(),
+    }
+}
+
+fn pack_cli(out: Option<PathBuf>, include_credentials: bool) -> Result<i32> {
+    let paths = SyncPaths::resolve()?;
+    let out = out.unwrap_or_else(|| {
+        PathBuf::from(format!(
+            "wizard-sync-{}.tar.gz",
+            chrono::Local::now().format("%Y%m%d")
+        ))
+    });
+    let outcome = pack(&paths, &out, include_credentials)?;
+    println!(
+        "packed {} file(s) ({} payload) into {} ({})",
+        outcome.file_count,
+        format_size(outcome.payload_bytes),
+        out.display(),
+        format_size(outcome.bundle_bytes),
+    );
+    println!("signing key: {}", outcome.fingerprint);
+    if outcome.includes_credentials {
+        println!();
+        println!("WARNING: this bundle contains API keys (credentials.toml / xai_oauth.json).");
+        println!("         Transfer it privately and delete it after pulling; the file was");
+        println!("         written with 0600 permissions.");
+    } else {
+        println!("credentials: not included (pass --include-credentials to add them)");
+    }
+    Ok(0)
+}
+
+async fn pull_cli(source: Option<String>, dry_run: bool) -> Result<i32> {
+    let Some(source) = source.or_else(configured_source) else {
+        bail!(
+            "no bundle source: pass one (`wizard sync pull <path-or-url>`) or set\n  \
+             [sync]\n  source = \"<path-or-url>\"\nin {}",
+            Config::path()?.display()
+        );
+    };
+    let bytes = fetch_source(&source).await?;
+    let wizard_dir = Config::wizard_dir()?;
+    pull_bundle(&wizard_dir, &bytes, &source, dry_run)
+}
+
+/// Verify `bytes` as a bundle and apply it into `wizard_dir` (or just report,
+/// on `dry_run`). Split from [`pull_cli`] so tests can drive it against a
+/// temp dir.
+fn pull_bundle(wizard_dir: &Path, bytes: &[u8], source: &str, dry_run: bool) -> Result<i32> {
+    let raw = parse_bundle(bytes)?;
+    let manifest = verify_bundle(&raw)?;
+    let key = decode_public_key(&manifest.public_key)?;
+    let fingerprint = fingerprint(&key);
+
+    println!(
+        "bundle: {} file(s), created {} on {} (wizard v{})",
+        manifest.files.len(),
+        manifest.created_at,
+        manifest.host,
+        manifest.wizard_version
+    );
+    println!("signature: OK");
+    if manifest.includes_credentials {
+        println!("note: this bundle includes credentials (API keys).");
+    }
+
+    match check_trust(
+        wizard_dir,
+        &manifest.public_key,
+        &fingerprint,
+        source,
+        dry_run,
+    )? {
+        Trust::AlreadyTrusted => println!("signing key: trusted ({fingerprint})"),
+        Trust::Pinned => {
+            println!("signing key: NOT previously seen — pinned it (trust on first use).");
+            println!();
+            println!("  fingerprint: {fingerprint}");
+            println!();
+            println!("  Verify this matches `wizard sync key` on the source machine.");
+        }
+        Trust::WouldPin => {
+            println!(
+                "signing key: not yet trusted — a real pull would pin it (trust on first use)."
+            );
+            println!("  fingerprint: {fingerprint}");
+        }
+    }
+
+    let diff = diff_against(wizard_dir, &raw.payload);
+    println!();
+    for (path, state) in &diff {
+        println!("  {:<10} {path}", state.label());
+    }
+    println!();
+
+    if dry_run {
+        println!("dry run — nothing applied.");
+        return Ok(0);
+    }
+
+    let outcome = apply(wizard_dir, &raw.payload, &diff)?;
+    println!(
+        "applied {} file(s), {} unchanged.",
+        outcome.applied, outcome.unchanged
+    );
+    if let Some(dir) = outcome.backup_dir {
+        println!("replaced files backed up under {}", dir.display());
+    }
+    Ok(0)
+}
+
+fn key_cli() -> Result<i32> {
+    let wizard_dir = Config::wizard_dir()?;
+    let key = load_or_generate_key(&wizard_dir)?;
+    let public = key.verifying_key();
+    println!("public key:  {}", BASE64.encode(public.to_bytes()));
+    println!("fingerprint: {}", fingerprint(&public));
+    Ok(0)
+}
+
+/// Human byte size for the pack summary (`532 B`, `12.3 KiB`, `1.2 MiB`).
+fn format_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KiB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `SyncPaths` over a temp `wizard_dir`, with the same relative layout
+    /// [`SyncPaths::resolve`] derives from the `Config` helpers.
+    fn test_paths(wizard_dir: &Path) -> SyncPaths {
+        SyncPaths {
+            wizard_dir: wizard_dir.to_path_buf(),
+            files: ["config.toml", "mcp.toml", "system_prompt.md"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect(),
+            dirs: ["skills", "commands", "subagents", "tools"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect(),
+            credential_files: ["credentials.toml", "xai_oauth.json"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect(),
+        }
+    }
+
+    /// Populate a fake `~/.wizard` with portable files, secrets, and some
+    /// state that must never be packed.
+    fn seed_wizard_dir(wizard_dir: &Path) {
+        let write = |rel: &str, contents: &str| {
+            let path = wizard_dir.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, contents).unwrap();
+        };
+        write("config.toml", "model = \"qwen3.6:27b\"\n");
+        write("mcp.toml", "[servers]\n");
+        write("system_prompt.md", "You are Wizard.\n");
+        write("skills/demo/SKILL.md", "# demo skill\n");
+        write("skills/deep/nested/notes.md", "nested\n");
+        write("commands/deploy.md", "deploy things\n");
+        write("subagents/reviewer.toml", "name = \"reviewer\"\n");
+        write("tools/hello.sh", "#!/bin/sh\necho hi\n");
+        // Secrets: packed only with --include-credentials.
+        write("credentials.toml", "[keys]\nopenai = \"sk-secret\"\n");
+        write("xai_oauth.json", "{\"access_token\":\"tok\"}\n");
+        // Never packed.
+        write("sessions/2026.jsonl", "{}\n");
+        write("logs/trace.log", "log\n");
+        write("evolution.jsonl", "{}\n");
+    }
+
+    fn pack_to_bytes(wizard_dir: &Path, include_credentials: bool) -> Vec<u8> {
+        let out = wizard_dir.join("out-bundle.tar.gz");
+        pack(&test_paths(wizard_dir), &out, include_credentials).expect("pack");
+        std::fs::read(&out).expect("read bundle")
+    }
+
+    #[test]
+    fn pack_pull_round_trip_lands_all_portable_files() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        let code = pull_bundle(dst.path(), &bundle, "test", false).expect("pull");
+        assert_eq!(code, 0);
+
+        for rel in [
+            "config.toml",
+            "mcp.toml",
+            "system_prompt.md",
+            "skills/demo/SKILL.md",
+            "skills/deep/nested/notes.md",
+            "commands/deploy.md",
+            "subagents/reviewer.toml",
+            "tools/hello.sh",
+        ] {
+            let original = std::fs::read(src.path().join(rel)).expect("source file");
+            let pulled =
+                std::fs::read(dst.path().join(rel)).unwrap_or_else(|_| panic!("{rel} must arrive"));
+            assert_eq!(original, pulled, "{rel} round-trips byte-identical");
+        }
+        // Non-portable state never travels.
+        for rel in ["sessions/2026.jsonl", "logs/trace.log", "evolution.jsonl"] {
+            assert!(!dst.path().join(rel).exists(), "{rel} must not travel");
+        }
+        // TOFU pinned the source key.
+        let pinned = std::fs::read_to_string(trusted_keys_path(dst.path())).expect("trusted_keys");
+        let source_key = load_or_generate_key(src.path()).expect("key");
+        let source_b64 = BASE64.encode(source_key.verifying_key().to_bytes());
+        assert!(
+            parse_trusted_keys(&pinned).contains(&source_b64),
+            "the source public key is pinned: {pinned}"
+        );
+        assert!(
+            pinned.contains("# pinned"),
+            "pin carries a comment: {pinned}"
+        );
+    }
+
+    #[test]
+    fn second_pull_is_idempotent_and_backs_up_changes() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        pull_bundle(dst.path(), &bundle, "test", false).expect("first pull");
+
+        // Identical second pull: nothing applied, no backups.
+        let raw = parse_bundle(&bundle).expect("parse");
+        let diff = diff_against(dst.path(), &raw.payload);
+        assert!(diff.iter().all(|(_, state)| *state == FileState::Identical));
+        let outcome = apply(dst.path(), &raw.payload, &diff).expect("apply");
+        assert_eq!(outcome.applied, 0);
+        assert_eq!(outcome.unchanged, diff.len());
+        assert!(outcome.backup_dir.is_none());
+
+        // Local edit, then pull again: overwritten, and the edit is backed up.
+        std::fs::write(dst.path().join("config.toml"), "model = \"edited\"\n").unwrap();
+        pull_bundle(dst.path(), &bundle, "test", false).expect("second pull");
+        let restored = std::fs::read_to_string(dst.path().join("config.toml")).unwrap();
+        assert_eq!(restored, "model = \"qwen3.6:27b\"\n");
+        let backups_root = sync_dir(dst.path()).join("backups");
+        let stamp_dirs: Vec<_> = std::fs::read_dir(&backups_root)
+            .expect("backups dir")
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(stamp_dirs.len(), 1, "one backup batch");
+        let backed_up = std::fs::read_to_string(stamp_dirs[0].path().join("config.toml")).unwrap();
+        assert_eq!(
+            backed_up, "model = \"edited\"\n",
+            "the local edit is preserved"
+        );
+    }
+
+    #[test]
+    fn dry_run_changes_nothing_and_pins_nothing() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        let code = pull_bundle(dst.path(), &bundle, "test", true).expect("dry run");
+        assert_eq!(code, 0);
+        assert!(
+            !dst.path().join("config.toml").exists(),
+            "dry run writes no payload files"
+        );
+        assert!(
+            !trusted_keys_path(dst.path()).exists(),
+            "dry run pins no key"
+        );
+    }
+
+    #[test]
+    fn tampered_manifest_fails_signature_verification() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        let raw = parse_bundle(&bundle).expect("parse");
+
+        // Flip a value inside the signed manifest bytes, keeping the JSON
+        // schema intact so the failure is the signature, not the parse.
+        let original = String::from_utf8(raw.manifest_bytes.clone()).unwrap();
+        let tampered_manifest = original.replace(
+            "\"includes_credentials\": false",
+            "\"includes_credentials\": true",
+        );
+        assert_ne!(tampered_manifest, original, "the tamper must change bytes");
+        let tampered = assemble_bundle(tampered_manifest.as_bytes(), &raw.signature, &raw.payload)
+            .expect("assemble");
+
+        let err = pull_bundle(dst.path(), &tampered, "test", false)
+            .expect_err("tampered manifest must fail");
+        assert!(
+            format!("{err:#}").contains("signature"),
+            "error names the signature: {err:#}"
+        );
+        assert!(!dst.path().join("config.toml").exists(), "nothing written");
+    }
+
+    #[test]
+    fn tampered_payload_fails_hash_verification() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        let raw = parse_bundle(&bundle).expect("parse");
+
+        let mut payload = raw.payload.clone();
+        // Same length so only the hash (not the size check) can catch it.
+        payload.insert(
+            "config.toml".to_string(),
+            b"model = \"qwen0.0:00b\"\n".to_vec(),
+        );
+        assert_eq!(
+            payload["config.toml"].len(),
+            raw.payload["config.toml"].len(),
+            "tamper keeps the size"
+        );
+        let tampered =
+            assemble_bundle(&raw.manifest_bytes, &raw.signature, &payload).expect("assemble");
+
+        let err = pull_bundle(dst.path(), &tampered, "test", false)
+            .expect_err("tampered payload must fail");
+        assert!(
+            format!("{err:#}").contains("sha256 mismatch"),
+            "error names the hash: {err:#}"
+        );
+        assert!(!dst.path().join("config.toml").exists(), "nothing written");
+    }
+
+    #[test]
+    fn payload_and_manifest_must_correspond_exactly() {
+        let src = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let bundle = pack_to_bytes(src.path(), false);
+        let raw = parse_bundle(&bundle).expect("parse");
+
+        // A payload file the manifest does not list.
+        let mut extra = raw.payload.clone();
+        extra.insert("smuggled.txt".to_string(), b"boo".to_vec());
+        let tampered =
+            assemble_bundle(&raw.manifest_bytes, &raw.signature, &extra).expect("assemble");
+        let err = pull_bundle(dst.path(), &tampered, "test", false)
+            .expect_err("unlisted payload must fail");
+        assert!(
+            format!("{err:#}").contains("not listed in the manifest"),
+            "{err:#}"
+        );
+
+        // A manifest entry the payload does not carry.
+        let mut missing = raw.payload.clone();
+        missing.remove("config.toml");
+        let tampered =
+            assemble_bundle(&raw.manifest_bytes, &raw.signature, &missing).expect("assemble");
+        let err = pull_bundle(dst.path(), &tampered, "test", false)
+            .expect_err("missing payload must fail");
+        assert!(format!("{err:#}").contains("does not contain"), "{err:#}");
+    }
+
+    #[test]
+    fn traversal_and_absolute_paths_are_rejected() {
+        // The pure validator.
+        assert!(validate_rel_path("skills/demo/SKILL.md").is_ok());
+        assert!(validate_rel_path("config.toml").is_ok());
+        for bad in [
+            "../evil",
+            "skills/../../evil",
+            "/etc/passwd",
+            "a\\b",
+            "..",
+            "./config.toml",
+            "",
+        ] {
+            assert!(validate_rel_path(bad).is_err(), "{bad:?} must be rejected");
+        }
+
+        // A correctly signed bundle whose manifest lists a traversal path (and
+        // an absolute one) still fails before anything is written.
+        let dst = tempfile::tempdir().expect("tempdir");
+        let keydir = tempfile::tempdir().expect("tempdir");
+        let key = load_or_generate_key(keydir.path()).expect("key");
+        for evil in ["../evil", "/etc/evil"] {
+            let manifest = Manifest {
+                version: BUNDLE_VERSION,
+                created_at: Utc::now().to_rfc3339(),
+                wizard_version: "0.0.0".to_string(),
+                host: "test".to_string(),
+                includes_credentials: false,
+                public_key: BASE64.encode(key.verifying_key().to_bytes()),
+                files: vec![ManifestEntry {
+                    path: evil.to_string(),
+                    sha256: sha256_hex(b"pwned"),
+                    size: 5,
+                }],
+            };
+            let manifest_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+            let signature = BASE64.encode(key.sign(&manifest_bytes).to_bytes());
+            let bundle =
+                assemble_bundle(&manifest_bytes, &signature, &BTreeMap::new()).expect("assemble");
+
+            let err = pull_bundle(dst.path(), &bundle, "test", false)
+                .expect_err("unsafe manifest path must fail");
+            let message = format!("{err:#}");
+            assert!(
+                message.contains("..") || message.contains("absolute"),
+                "{message}"
+            );
+        }
+        assert!(
+            !dst.path().parent().unwrap().join("evil").exists(),
+            "nothing escapes the wizard dir"
+        );
+
+        // A tar entry smuggling `payload/../evil` (crafted by writing the raw
+        // GNU header name, since tar::Builder itself refuses such paths) is
+        // rejected at parse time.
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        let data = b"pwned";
+        let mut header = tar::Header::new_gnu();
+        let name = b"payload/../evil";
+        header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append(&header, &data[..]).expect("append raw entry");
+        let bytes = tar.into_inner().unwrap().finish().unwrap();
+
+        let Err(err) = parse_bundle(&bytes) else {
+            panic!("traversal payload path must fail");
+        };
+        assert!(format!("{err:#}").contains(".."), "{err:#}");
+    }
+
+    #[test]
+    fn tofu_pins_first_key_and_rejects_a_different_one() {
+        let src_a = tempfile::tempdir().expect("tempdir");
+        let src_c = tempfile::tempdir().expect("tempdir");
+        let dst = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src_a.path());
+        seed_wizard_dir(src_c.path());
+
+        // First pull pins machine A's key.
+        let bundle_a = pack_to_bytes(src_a.path(), false);
+        pull_bundle(dst.path(), &bundle_a, "test", false).expect("first pull");
+
+        // Machine C generates its own key; its bundle must be rejected.
+        let bundle_c = pack_to_bytes(src_c.path(), false);
+        let err = pull_bundle(dst.path(), &bundle_c, "test", false)
+            .expect_err("a different key must be rejected");
+        let message = format!("{err:#}");
+        assert!(message.contains("UNTRUSTED"), "{message}");
+        assert!(
+            message.contains("wizard sync key"),
+            "error explains how to trust: {message}"
+        );
+        assert!(
+            message.contains("trusted_keys"),
+            "error names the trust file: {message}"
+        );
+
+        // Pulls from A keep working.
+        pull_bundle(dst.path(), &bundle_a, "test", false).expect("trusted pull still works");
+
+        // Manually trusting C's key (with a comment) unblocks it.
+        let key_c = load_or_generate_key(src_c.path()).expect("key");
+        let line = format!(
+            "{} # machine C\n",
+            BASE64.encode(key_c.verifying_key().to_bytes())
+        );
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(trusted_keys_path(dst.path()))
+            .unwrap();
+        file.write_all(line.as_bytes()).unwrap();
+        pull_bundle(dst.path(), &bundle_c, "test", false).expect("manually trusted pull");
+    }
+
+    #[test]
+    fn credentials_stay_out_unless_asked_for() {
+        let src = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        // Default: no secrets in the payload, manifest says so.
+        let bundle = pack_to_bytes(src.path(), false);
+        let raw = parse_bundle(&bundle).expect("parse");
+        let manifest = verify_bundle(&raw).expect("verify");
+        assert!(!manifest.includes_credentials);
+        assert!(!raw.payload.contains_key("credentials.toml"));
+        assert!(!raw.payload.contains_key("xai_oauth.json"));
+
+        // Opt-in: both secrets travel and the manifest flags it.
+        let bundle = pack_to_bytes(src.path(), true);
+        let raw = parse_bundle(&bundle).expect("parse");
+        let manifest = verify_bundle(&raw).expect("verify");
+        assert!(manifest.includes_credentials);
+        assert!(raw.payload.contains_key("credentials.toml"));
+        assert!(raw.payload.contains_key("xai_oauth.json"));
+
+        // Pulled secrets land 0600.
+        let dst = tempfile::tempdir().expect("tempdir");
+        pull_bundle(dst.path(), &bundle, "test", false).expect("pull");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for rel in ["credentials.toml", "xai_oauth.json"] {
+                let mode = std::fs::metadata(dst.path().join(rel))
+                    .expect("stat")
+                    .permissions()
+                    .mode();
+                assert_eq!(mode & 0o777, 0o600, "{rel} must be 0600");
+            }
+            let mode = std::fs::metadata(dst.path().join("config.toml"))
+                .expect("stat")
+                .permissions()
+                .mode();
+            assert_ne!(mode & 0o777, 0o600, "non-secrets keep normal perms");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_bundles_are_written_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let src = tempfile::tempdir().expect("tempdir");
+        seed_wizard_dir(src.path());
+
+        let out = src.path().join("secret-bundle.tar.gz");
+        pack(&test_paths(src.path()), &out, true).expect("pack");
+        let mode = std::fs::metadata(&out).expect("stat").permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "a bundle holding keys must be 0600");
+    }
+
+    #[test]
+    fn key_file_is_0600_and_stable_across_loads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = load_or_generate_key(dir.path()).expect("generate");
+        let second = load_or_generate_key(dir.path()).expect("reload");
+        assert_eq!(
+            first.verifying_key().to_bytes(),
+            second.verifying_key().to_bytes(),
+            "the key survives reloads"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let key_mode = std::fs::metadata(key_path(dir.path()))
+                .expect("stat key")
+                .permissions()
+                .mode();
+            assert_eq!(key_mode & 0o777, 0o600, "the seed file must be 0600");
+            let dir_mode = std::fs::metadata(sync_dir(dir.path()))
+                .expect("stat sync dir")
+                .permissions()
+                .mode();
+            assert_eq!(dir_mode & 0o777, 0o700, "the sync dir must be 0700");
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_openssh_shaped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = load_or_generate_key(dir.path()).expect("generate");
+        let fp = fingerprint(&key.verifying_key());
+        assert!(fp.starts_with("SHA256:"), "{fp}");
+        let b64 = fp.strip_prefix("SHA256:").unwrap();
+        assert!(!b64.ends_with('='), "no padding: {fp}");
+        // sha256 → 32 bytes → 43 unpadded base64 chars.
+        assert_eq!(b64.len(), 43, "{fp}");
+    }
+
+    #[test]
+    fn trusted_keys_parsing_handles_comments_and_blanks() {
+        let raw = "\
+# a full-line comment
+KEYAAA # pinned 2026-07-09 from test
+
+KEYBBB
+   KEYCCC   #trailing
+";
+        assert_eq!(parse_trusted_keys(raw), vec!["KEYAAA", "KEYBBB", "KEYCCC"]);
+        assert!(parse_trusted_keys("").is_empty());
+        assert!(parse_trusted_keys("# only comments\n").is_empty());
+    }
+
+    #[test]
+    fn garbage_and_truncated_bundles_fail_cleanly() {
+        let dst = tempfile::tempdir().expect("tempdir");
+        assert!(pull_bundle(dst.path(), b"not a bundle", "test", false).is_err());
+
+        // A valid gzip+tar with no manifest.
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        append_entry(&mut tar, "payload/x", b"y").expect("append");
+        let bytes = tar.into_inner().unwrap().finish().unwrap();
+        let err = pull_bundle(dst.path(), &bytes, "test", false).expect_err("no manifest");
+        assert!(format!("{err:#}").contains("manifest"), "{err:#}");
+    }
+
+    #[test]
+    fn format_size_is_readable() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(532), "532 B");
+        assert_eq!(format_size(12 * 1024 + 307), "12.3 KiB");
+        assert_eq!(format_size(6 * 1024 * 1024 / 5), "1.2 MiB");
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -154,8 +154,9 @@ fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
-/// sha256 of a byte slice, lowercase hex.
-fn sha256_hex(bytes: &[u8]) -> String {
+/// sha256 of a byte slice, lowercase hex. Shared with `crate::sync`, which
+/// hashes bundle payload files the same way.
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,8 +12,12 @@ struct TempDir(PathBuf);
 
 impl TempDir {
     fn new() -> Self {
+        // A per-process counter so one test can hold several dirs at once
+        // (e.g. two fake homes for a sync round trip).
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!(
-            "wizard-itest-{}-{:?}",
+            "wizard-itest-{}-{:?}-{seq}",
             std::process::id(),
             std::thread::current().id()
         ));
@@ -604,6 +608,113 @@ fn e2e_inference_with_auto_spawned_llama_server() {
         "wizard must report the server it spawned:\n{stdout}"
     );
     assert!(!stderr.contains("panicked"), "must not panic:\n{stderr}");
+}
+
+#[test]
+fn sync_key_prints_public_key_and_fingerprint() {
+    let home = TempDir::new();
+    let output = run_wizard(&home.0, &["sync", "key"], &[]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "sync key must exit 0.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("public key:"), "{stdout}");
+    assert!(stdout.contains("SHA256:"), "fingerprint printed:\n{stdout}");
+    assert!(
+        home.0.join(".wizard/sync/key").is_file(),
+        "the keypair is generated on first use"
+    );
+
+    // A second invocation reuses the key: identical output.
+    let again = run_wizard(&home.0, &["sync", "key"], &[]);
+    assert!(again.status.success());
+    assert_eq!(output.stdout, again.stdout, "the key is stable");
+}
+
+#[test]
+fn sync_pack_and_pull_round_trip_across_homes() {
+    let home_a = TempDir::new();
+    let home_b = TempDir::new();
+
+    // Seed machine A with portable state.
+    write_config(&home_a.0, "model = \"qwen3.6:27b\"\n");
+    let skill = home_a.0.join(".wizard/skills/demo/SKILL.md");
+    std::fs::create_dir_all(skill.parent().unwrap()).expect("create skill dir");
+    std::fs::write(&skill, "# demo skill\n").expect("write skill");
+
+    // Pack on A.
+    let bundle = home_a.0.join("bundle.tar.gz");
+    let bundle_str = bundle.to_string_lossy().to_string();
+    let output = run_wizard(&home_a.0, &["sync", "pack", "--out", &bundle_str], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "pack must exit 0.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("packed"), "pack summary:\n{stdout}");
+    assert!(stdout.contains("SHA256:"), "signing fingerprint:\n{stdout}");
+    assert!(
+        stdout.contains("not included"),
+        "credentials excluded by default:\n{stdout}"
+    );
+    assert!(bundle.is_file(), "the bundle file exists");
+
+    // Dry-run pull on B: verified, reported, nothing written.
+    let output = run_wizard(&home_b.0, &["sync", "pull", &bundle_str, "--dry-run"], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry-run pull must exit 0.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("signature: OK"), "{stdout}");
+    assert!(stdout.contains("dry run"), "{stdout}");
+    assert!(
+        !home_b.0.join(".wizard/config.toml").exists(),
+        "dry run writes nothing"
+    );
+    assert!(
+        !home_b.0.join(".wizard/sync/trusted_keys").exists(),
+        "dry run pins nothing"
+    );
+
+    // Real pull on B: files arrive, the key is pinned (TOFU).
+    let output = run_wizard(&home_b.0, &["sync", "pull", &bundle_str], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "pull must exit 0.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("applied"), "apply summary:\n{stdout}");
+    assert_eq!(
+        std::fs::read_to_string(home_b.0.join(".wizard/config.toml")).expect("config arrived"),
+        "model = \"qwen3.6:27b\"\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(home_b.0.join(".wizard/skills/demo/SKILL.md"))
+            .expect("skill arrived"),
+        "# demo skill\n"
+    );
+    let pinned = std::fs::read_to_string(home_b.0.join(".wizard/sync/trusted_keys"))
+        .expect("trusted_keys pinned");
+    assert!(pinned.contains("# pinned"), "pin comment present: {pinned}");
+}
+
+#[test]
+fn sync_pull_without_a_source_is_an_actionable_error() {
+    let home = TempDir::new();
+    let output = run_wizard(&home.0, &["sync", "pull"], &[]);
+    assert!(!output.status.success(), "no source anywhere must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[sync]") && stderr.contains("source"),
+        "error points at the config key:\n{stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds \`wizard sync\`: move the portable parts of \`~/.wizard\` between machines as a signed bundle. Motivated by user feedback — working across a laptop and a workbox needs config and generated skills to travel with one command per side.

**Commands**

- \`wizard sync pack [--out <path>] [--include-credentials]\` — ed25519-signed tar.gz of \`config.toml\`, \`mcp.toml\`, the system prompt, and \`skills/\`, \`commands/\`, \`subagents/\`, \`tools/\`. Credentials stay out unless explicitly included (then the bundle is 0600 with a warning; signed, not encrypted).
- \`wizard sync pull <source> [--dry-run]\` — file path or http(s) URL, or \`[sync].source\` from config.toml when omitted. Verification is all-or-nothing (signature via \`verify_strict\`, trust check, per-file sha256 + size) before a single byte lands in \`~/.wizard\`. Additive apply: overwritten files are backed up under \`~/.wizard/sync/backups/<timestamp>/\`, nothing is ever deleted.
- \`wizard sync key\` — print this machine's public key + OpenSSH-style fingerprint.

**Trust model:** trust-on-first-use like SSH. First pull pins the sender's key into \`~/.wizard/sync/trusted_keys\` and prints the fingerprint for out-of-band comparison; later pulls reject unknown keys with pasteable trust instructions.

**Hardening:** path traversal rejected (absolute, \`..\`, backslash — including a raw-tar \`payload/../evil\` smuggling test), exact manifest⇄payload correspondence both directions, key seed 0600 / sync dir 0700, no interactive prompts.

**Also:** \`style: cargo fmt\` commit fixes the \`src/app.rs\` formatting drift that is currently failing CI on main.

New dep: \`ed25519-dalek 2\` (seed from existing \`getrandom\`; no rand/rand_core).

Docs: \`docs/sync.md\`, README index, getting-started, architecture data-on-disk table, SECURITY.md trust-model section.

Tests: 14 new unit tests (round-trip, signature/hash tamper, traversal, TOFU pin→reject→manual trust, credentials in/out, perms), 3 integration tests over the built binary with isolated homes, 1 clap test. Full suite 815 passed, fmt/clippy clean with CI's exact flags. Manually exercised: pack→pull across fake homes, dry-run, tamper rejection, untrusted-key rejection, URL pull, \`[sync].source\` fallback.