### PR TITLE
Use as_chunks in the pixel assertions to satisfy clippy

### DIFF
--- a/src/native/graph/tests.rs
+++ b/src/native/graph/tests.rs
@@ -302,7 +302,9 @@ fn the_explorer_draws_with_fifty_peers_with_none_and_with_an_unreachable_one() {
         ];
         assert!(
             pixels
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .any(|pixel| pixel[..3] != ground && pixel[..3] != [0, 0, 0]),
             "{name}: every pixel is the background, so nothing was drawn"
         );

--- a/src/native/tests.rs
+++ b/src/native/tests.rs
@@ -1066,7 +1066,11 @@ fn the_fixture_session_draws_headlessly_with_a_selection_over_it() {
         "the software rasterizer produced a full frame"
     );
     assert!(
-        pixels.chunks_exact(4).any(|pixel| pixel[..3] != [0, 0, 0]),
+        pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|pixel| pixel[..3] != [0, 0, 0]),
         "every pixel is black, so nothing was drawn"
     );
 }
@@ -1257,7 +1261,9 @@ fn the_bundled_fonts_rasterize_to_a_committed_digest() {
     // The frame really has glyphs in it, so a digest of an empty canvas cannot
     // pass for a rendering.
     let ink = pixels
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|pixel| pixel[..3] != [12, 12, 14])
         .count();
     assert!(


### PR DESCRIPTION
The Rust checks job has been failing on main since the stable toolchain picked up `clippy::chunks_exact_to_as_chunks`. Three test assertions walk a screenshot buffer four bytes at a time with `chunks_exact(4)`, and with `-D warnings` under `--features native` that stops the build.

Switched them to `as_chunks::<4>().0.iter()`, which is what the lint asks for and is stable well under the 1.88 MSRV. No behaviour change.

`cargo clippy --all-targets --locked --features native` and `cargo test --locked --features native` pass locally.