### PR TITLE
Add plain-writing and undercover to the stock skills registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Releases before 2.0.0 (v1.6.0 through v1.8.0) predate this file; their notes are
 
 ## [Unreleased]
 
+### Added
+
+- **plain-writing and undercover in the stock skills registry.** `wizard skills search` can find them and `wizard skills install` can pull them from `registry/skills/teddytennant/`. Undercover here is the model-facing clean-history skill; the commit-guard hooks stay in the undercover repo.
+
 ## [3.0.1] - 2026-09-03
 
 ### Fixed

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-08-21T14:04:59Z",
+  "generated_at": "2026-09-09T00:09:21Z",
   "entries": [
     {
       "name": "conventional-commit",
@@ -17,6 +17,21 @@
       "path": "skills/teddytennant/conventional-commit"
     },
     {
+      "name": "plain-writing",
+      "version": "0.1.0",
+      "author": "teddytennant",
+      "description": "Write prose that reads like a person wrote it. Use for comments, READMEs, commits, PRs, and docs.",
+      "tags": [
+        "writing",
+        "docs",
+        "style"
+      ],
+      "kind": "skill",
+      "checksum": "303eb3dde57015cf989a9b965d83b9369797ff8f45859789560bca6f3a90a96d",
+      "capabilities": [],
+      "path": "skills/teddytennant/plain-writing"
+    },
+    {
       "name": "pr-description",
       "version": "1.0.0",
       "author": "teddytennant",
@@ -30,6 +45,21 @@
       "checksum": "f06852d445ff082c06613c4ce1224b084c614f774162bbd7793e5ba8c7d72fe8",
       "capabilities": [],
       "path": "skills/teddytennant/pr-description"
+    },
+    {
+      "name": "undercover",
+      "version": "1.0.0",
+      "author": "teddytennant",
+      "description": "Keep public git history clean: no AI attribution footers, no blocklist leaks in commits or PRs.",
+      "tags": [
+        "git",
+        "privacy",
+        "style"
+      ],
+      "kind": "skill",
+      "checksum": "0be76bd6268f97ed24da3257a8c5a353df00e7dc5103cc5b2d1946b93fc88086",
+      "capabilities": [],
+      "path": "skills/teddytennant/undercover"
     }
   ]
 }

--- a/registry/skills/teddytennant/plain-writing/SKILL.md
+++ b/registry/skills/teddytennant/plain-writing/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: plain-writing
+description: Write prose that reads like a person wrote it, not a model. Use before writing or editing any code comment, docstring, README, doc page, tool or API description, config help text, commit message, PR title or body, review reply, issue comment, changelog entry, or release note. Also use when the user says the writing sounds like AI, is slop, is too long, or asks to make it sound human.
+version: 0.1.0
+---
+
+# Plain writing
+
+Someone decides whether to trust the work based on the first two sentences. They
+also decide, in those two sentences, whether a person wrote it.
+
+The default failure is not being wrong. It is being padded, evenly formatted, and
+weightless: three paragraphs where one line was needed, a bullet list that
+restates the thing above it, adjectives about how robust it is. That reads as
+machine output and people discount everything after it.
+
+## Before writing
+
+Answer three questions. If you cannot, you are not ready to write.
+
+1. Who reads this, and what do they already know? Never explain their own
+   codebase back to them.
+2. What do they do differently after reading it? If nothing, do not write it.
+3. What is the shortest form that still carries the fact?
+
+## Rules everywhere
+
+- **No em dashes.** Comma, period, or semicolon.
+- **No AI-tell vocabulary.** delve, leverage (as a verb), robust, seamless,
+  comprehensive, streamlined, moreover, furthermore, "it's worth noting", "in
+  conclusion", "let's dive in", "at its core", "under the hood".
+- **No bolded restatement** of the title as the first line of the body. No "Key
+  changes:" list that repeats what the reader can see.
+- **No bullet walls.** Bullets are for things that are genuinely a list: flags,
+  steps, options. Not for splitting one thought into four fragments.
+- **No emoji** and no emoji headers, unless the surrounding project already uses
+  them.
+- **No hedge-and-claim.** Do not write "should fix" or "this likely resolves".
+  Either you checked or you say plainly that you did not.
+- **Never name a command you did not run**, a test you did not see pass, or a
+  file you did not read. One invented detail costs more than the whole document
+  earns.
+- **No flattery, no apology, no closing offer to help.** "Great question", "Hope
+  this helps", "Happy to elaborate" are filler.
+- **No AI attribution.** Not in commits, PR text, comments, or docs.
+- **A little unevenness is fine.** Perfectly sanded prose is itself the tell. A
+  dry aside or a slightly informal sentence reads human. A wrong fact does not.
+
+## Code comments
+
+The line already says what it does. The comment says why, or it does not exist.
+
+Delete: `// increment i`, `// Constructor`, `# returns the result`. Delete
+banner blocks of `====` around a section name. Delete a comment that repeats the
+function name back in a sentence.
+
+Keep: the reason a value is 4096, the bug a workaround dodges with a link, the
+invariant the next person will break, the ordering that matters and looks
+arbitrary. Match the density and style of the file you are in.
+
+```
+// Retry twice. The upstream API 503s on cold start and recovers by the
+// second attempt; more than that and we are papering over a real outage.
+```
+
+TODOs carry a name or an issue, or they are noise: `// TODO(#412): drop once
+the v1 endpoint is gone.`
+
+## Docstrings, tool and API descriptions
+
+First line does the work: what it does, in one sentence, no restating the
+signature. Then only what the caller cannot see from the types: what it returns
+in the odd case, what it raises and when, what it mutates, units, whether it
+blocks.
+
+For a tool or agent description, the reader is choosing whether to call it. Say
+what it is for and when to reach for it over the neighbor. Skip the paragraph on
+how it works internally.
+
+## READMEs and docs
+
+As short as possible but no shorter. What it is, how to install it, how to run
+it. A real example beats a description of the example.
+
+No badge rows. No feature-bullet marketing. No "Contributing" or
+"Acknowledgements" boilerplate unless the project actually has that process. No
+architecture essay in the README when the reader is trying to run the thing.
+
+If a section exists only because READMEs usually have it, cut the section.
+
+## Commits, PRs, and comments on other people's repos
+
+**Commit.** Imperative, present tense, specific, one logical change. `Fix panic
+in Table when a column constraint underflows`, not `fix bug` or `[FIX] Panic
+Issue`. Body only when the why is not obvious. Commits are permanent, so keep
+them dry.
+
+**PR body.** Three or four short paragraphs: what is broken and what triggers
+it, how to see it, what you changed and why that layer, how you verified it with
+the exact commands. No adjectives about how important the fix is.
+
+**Review replies.** One or two sentences, then act. "Good catch, moved it to
+layout.rs. Pushed." Never argue past one exchange. If the maintainer says no,
+"Makes sense, thanks for looking" and close it.
+
+**Issue comments.** Environment, minimal repro, observed output, expected
+output. Nothing else.
+
+Put uncertainty at the end as a question. "I put the clamp in column_widths, but
+layout.rs may be the better home. Happy to move it." That reads as a person and
+it makes review easier.
+
+## Changelog and release notes
+
+One line per change, written for someone deciding whether to upgrade. Lead with
+what changed for them, not with the internal refactor that caused it. Breaking
+changes first, with the migration in the same line if it fits.
+
+## Slop and the fix
+
+```
+This PR implements a comprehensive fix to address the aforementioned overflow.
+It is worth noting that the solution is robust across edge cases and should
+improve reliability going forward.
+
+**Key changes:**
+- Improved overflow handling
+- Enhanced test coverage
+```
+
+```
+Table panics on a one-column terminal when Length is wider than the area. I hit
+this resizing a scratch TUI down to nothing, which is a dumb way to find it, but
+the subtraction wraps before the clamp.
+
+Moved the clamp above the subtraction. cargo test is green; added
+underflow_one_column as a regression test.
+```
+
+## Last pass, always
+
+Run this before you hand the text over.
+
+1. Read it out loud in your head. If you would not send it to a coworker,
+   rewrite it.
+2. Cut every sentence that does not change what the reader does. Usually the
+   first one and the last one.
+3. Search for em dashes and the banned words. Replace, do not soften.
+4. Check the facts against what you actually ran. Title, body, and diff have to
+   agree.
+5. Ask whether half the length would lose anything. If not, ship the half.
+
+## Delegating
+
+Subagents default to verbose technical writing and README slop. Any subagent
+prompt that will produce prose gets these constraints pasted in, not a pointer
+to them.

--- a/registry/skills/teddytennant/plain-writing/manifest.toml
+++ b/registry/skills/teddytennant/plain-writing/manifest.toml
@@ -1,0 +1,7 @@
+name = "plain-writing"
+version = "0.1.0"
+author = "teddytennant"
+description = "Write prose that reads like a person wrote it. Use for comments, READMEs, commits, PRs, and docs."
+tags = ["writing", "docs", "style"]
+kind = "skill"
+checksum = "303eb3dde57015cf989a9b965d83b9369797ff8f45859789560bca6f3a90a96d"

--- a/registry/skills/teddytennant/undercover/SKILL.md
+++ b/registry/skills/teddytennant/undercover/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: undercover
+description: Keep git history clean in public repos. Use when writing commits, PR titles/bodies, or any text that will land in a public remote. Strips AI attribution habits and blocks leaking project-sensitive terms.
+version: 1.0.0
+---
+
+# Undercover
+
+You are writing text that may land in a public git history. Keep it clean.
+
+## Rules
+
+- Describe only what the change does. Write like a human developer on the project.
+- Do **not** add AI-assistant attribution: no "Generated with …", no "Co-Authored-By: \<assistant\>", no robot emoji footer, no mention that an AI wrote the change.
+- Do **not** put project blocklist terms (codenames, client names, internal URLs from `.undercover.json` if present) into commits, PR text, comments, or docs meant for the remote.
+- Prefer concrete subjects: "Fix race in file watcher init", not "Update code for better reliability".
+
+## When this applies
+
+Default assumption for public remotes: on. Private remotes the user trusts may turn it off; if they have `.undercover.json` with `mode`, follow it. Session override: `UNDERCOVER=on` / `UNDERCOVER=off`.
+
+## Not a substitute for hooks
+
+This skill is the model-facing reminder. For enforce-on-commit guards, install the full Undercover plugin from https://github.com/teddytennant/undercover (Wizard hooks + `/undercover` status).

--- a/registry/skills/teddytennant/undercover/manifest.toml
+++ b/registry/skills/teddytennant/undercover/manifest.toml
@@ -1,0 +1,7 @@
+name = "undercover"
+version = "1.0.0"
+author = "teddytennant"
+description = "Keep public git history clean: no AI attribution footers, no blocklist leaks in commits or PRs."
+tags = ["git", "privacy", "style"]
+kind = "skill"
+checksum = "0be76bd6268f97ed24da3257a8c5a353df00e7dc5103cc5b2d1946b93fc88086"


### PR DESCRIPTION
## Summary
- Publish `plain-writing` and `undercover` under `registry/skills/teddytennant/`
- Regenerate `registry/registry.json` (4 entries; checksums match artifacts)
- CHANGELOG note under Unreleased

Stock `wizard skills search` could only find `conventional-commit` and `pr-description`. These two skills already exist as standalone repos people install by hand.

`undercover` in the registry is the **model-facing** clean-history skill. The commit-guard hooks remain in https://github.com/teddytennant/undercover.

## Test plan
- [x] `python3 contrib/check-registry.py` → ok (4 entries)
- [x] Local registry HTTP: `wizard skills search writing` → plain-writing + undercover
- [x] `WIZARD_HOME=… WIZARD_REGISTRY_URL=… wizard skills install plain-writing` → checksum match
- [x] same for `undercover`
- [ ] CI registry / cargo tests on the PR