### PR TITLE
Add callable plugin services for Lua provide/inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Releases before 2.0.0 (v1.6.0 through v1.8.0) predate this file; their notes are
 
 ### Added
 
+- **Callable plugin services.** `Service::Callable` is a JSON→JSON function both
+  Rust and Lua can `provide` and `inject`. Lua `ctx:provide(name, fn)` holds the
+  function in the plugin VM; `ctx:inject` returns it as a Lua function. Native
+  services stay invisible to scripts; data stays a snapshot. Closes the host
+  bridge gap that blocked Lua ports of `memory` / `image`.
 - **plain-writing and undercover in the stock skills registry.** `wizard skills search` can find them and `wizard skills install` can pull them from `registry/skills/teddytennant/`. Undercover here is the model-facing clean-history skill; the commit-guard hooks stay in the undercover repo.
 
 ## [3.0.1] - 2026-09-03

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1651,11 +1651,12 @@ because its daemon supervises long-lived children and the host bridge has no
 shape to hold one in. The section at the end of this document is the argument,
 and it adds the two questions that would have caught them.
 
-**Blocked, not decided.** `memory` and `image` are Lua-shaped in body and
-blocked on a service: both need a *core* store reachable from a plugin, and
-`ctx:inject` hands Lua only JSON data. `Ctx::provide` with a callable service
-Lua could invoke is the missing piece, and it is the same piece
-`tools/image.rs`'s four-provider-id branch already needs.
+**Unblocked on the service side.** `memory` and `image` still need a *core*
+store reachable from a plugin, but the callable gap is closed: `Service::Callable`
+lets Rust and Lua `provide` a JSON→JSON function and `inject` it as a callable
+(Lua sees a function; Rust sees [`Service::as_callable`](../src/kernel/services.rs)).
+Native stays invisible to scripts; data stays a snapshot. The remaining work for
+those two plugins is the store itself, not the host bridge.
 ## As built: two more surfaces, and what three call sites did to `entrypoint.rs`
 
 `wizard acp` and `wizard fleet` went through the door the window opened.
@@ -2002,11 +2003,12 @@ implementation appearing between them.
 
 ### Host-bridge and kernel gaps these two found
 
-- **A Lua plugin cannot expose a callable.** `ctx:provide` from Lua is
-  `Service::data`, so core injects a snapshot. `Ctx::provide` with a callable
-  Lua service is already listed above as the piece `memory` and `image` are
-  blocked on; this is the same gap from the other side, and it would not have
-  been enough on its own, because the callers here also cannot await.
+- **A Lua plugin can expose a callable.** `ctx:provide(name, function)` holds
+  the function in that plugin's VM and publishes `Service::Callable`; injectors
+  in Rust or Lua can invoke it with JSON in and JSON out. That closes the
+  `memory` / `image` host-bridge gap named above. It would still not have been
+  enough on its own for `hardware` / `schedule`, because those callers also
+  cannot await.
 - **There is no synchronous door into a plugin VM**, and there should not be
   one: `load_source` is async because the VM is a task, and a `block_on` from a
   tokio worker is a panic. What is missing is not a door but a rule, which is

--- a/src/kernel/ctx.rs
+++ b/src/kernel/ctx.rs
@@ -29,7 +29,8 @@
 //!    service some Rust plugin provided as an `Arc<dyn Trait>` returns `nil`
 //!    (`undefined` in JavaScript), because a script cannot call it. It is the
 //!    same absent-service answer, so a scripted plugin's degrade path already
-//!    covers the case.
+//!    covers the case. A [`Service::Callable`](super::services::Service::Callable)
+//!    is the other door: JSON in, JSON out, visible to both languages.
 //! 2. **A script's teardown runs inside its own VM.** `ctx:effect(fn)` cannot
 //!    become a Rust `FnOnce`, so it is recorded in the VM and run there during
 //!    shutdown, after the registries are already clear. From Rust an effect is

--- a/src/kernel/lua/host.rs
+++ b/src/kernel/lua/host.rs
@@ -531,7 +531,7 @@ fn build_ctx_table(
     table.set("provider", provider_fn(lua, ctx)?)?;
     table.set("on", on_fn(lua, ctx, handle, registry)?)?;
     table.set("emit", emit_fn(lua, ctx)?)?;
-    table.set("provide", provide_fn(lua, ctx)?)?;
+    table.set("provide", provide_fn(lua, ctx, handle, registry)?)?;
     table.set("inject", inject_fn(lua, ctx)?)?;
     table.set("plugin", plugin_fn(lua, ctx)?)?;
     table.set("effect", effect_fn(lua, registry)?)?;
@@ -722,11 +722,31 @@ fn emit_fn(lua: &Lua, ctx: &Ctx) -> mlua::Result<mlua::Function> {
     )
 }
 
-fn provide_fn(lua: &Lua, ctx: &Ctx) -> mlua::Result<mlua::Function> {
+fn provide_fn(
+    lua: &Lua,
+    ctx: &Ctx,
+    handle: &VmHandle,
+    registry: &Registry,
+) -> mlua::Result<mlua::Function> {
     let ctx = ctx.clone();
+    let handle = handle.clone();
+    let registry = registry.clone();
     lua.create_function(
         move |lua, (_this, name, value): (Table, String, LuaValue)| {
-            ctx.provide(name, Service::data(lua_to_json(lua, value)?));
+            // A function becomes a callable the other side can invoke. Anything
+            // else stays a JSON snapshot, which is what Lua could always provide.
+            let service = match value {
+                LuaValue::Function(func) => {
+                    let func = registry.hold(func);
+                    let handle = handle.clone();
+                    Service::callable(move |args| {
+                        let handle = handle.clone();
+                        async move { handle.call(func, vec![args]).await }
+                    })
+                }
+                other => Service::data(lua_to_json(lua, other)?),
+            };
+            ctx.provide(name, service);
             Ok(())
         },
     )
@@ -735,13 +755,28 @@ fn provide_fn(lua: &Lua, ctx: &Ctx) -> mlua::Result<mlua::Function> {
 fn inject_fn(lua: &Lua, ctx: &Ctx) -> mlua::Result<mlua::Function> {
     let ctx = ctx.clone();
     lua.create_function(move |lua, (_this, name): (Table, String)| {
-        // A native service is `nil` here, which is the same `nil` an absent one
-        // gives — see the `Ctx` module docs. Lua cannot call a Rust trait
-        // object, and pretending otherwise would only move the failure later.
-        match ctx.inject(&name).as_ref().and_then(Service::as_data) {
-            Some(value) => json_to_lua(lua, value),
-            None => Ok(LuaValue::Nil),
+        // Native stays `nil` — Lua cannot call a Rust trait object. Data is a
+        // table. A callable is a Lua function that round-trips JSON through it.
+        let Some(service) = ctx.inject(&name) else {
+            return Ok(LuaValue::Nil);
+        };
+        if let Some(value) = service.as_data() {
+            return json_to_lua(lua, value);
         }
+        let Some(call) = service.as_callable() else {
+            return Ok(LuaValue::Nil);
+        };
+        let call = Arc::clone(call);
+        let func = lua.create_async_function(move |lua, args: LuaValue| {
+            let call = Arc::clone(&call);
+            let args = lua_to_json(&lua, args);
+            async move {
+                let args = args?;
+                let out = call(args).await.map_err(mlua::Error::external)?;
+                json_to_lua(&lua, &out)
+            }
+        })?;
+        Ok(LuaValue::Function(func))
     })
 }
 

--- a/src/kernel/lua/tests.rs
+++ b/src/kernel/lua/tests.rs
@@ -505,6 +505,126 @@ async fn lua_and_rust_plugins_share_one_service_namespace() {
 }
 
 #[tokio::test]
+async fn rust_callable_is_invokable_from_lua() {
+    let dir = TempDir::new("lua-callable-rust");
+    let kernel = kernel_in(&dir.path);
+
+    kernel
+        .load(TestPlugin::boxed("echo", |ctx| {
+            ctx.provide(
+                "echo",
+                Service::callable(|v| async move {
+                    Ok(json!({"got": v}))
+                }),
+            );
+            Ok(())
+        }))
+        .expect("rust plugin");
+
+    load(
+        &kernel,
+        "caller",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        return {
+          apply = function(ctx)
+            local echo = ctx:inject("echo")
+            assert(type(echo) == "function", "callable injects as a function")
+            local out = echo({ n = 3 })
+            ctx:provide("report", out)
+          end,
+        }
+        "#,
+    )
+    .await
+    .expect("lua plugin");
+
+    let report = kernel.services().inject("report").expect("provided");
+    assert_eq!(report.as_data(), Some(&json!({"got": {"n": 3}})));
+}
+
+#[tokio::test]
+async fn lua_callable_is_invokable_from_rust_and_lua() {
+    let dir = TempDir::new("lua-callable-lua");
+    let kernel = kernel_in(&dir.path);
+
+    load(
+        &kernel,
+        "provider",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        return {
+          apply = function(ctx)
+            ctx:provide("double", function(args)
+              return { n = args.n * 2 }
+            end)
+          end,
+        }
+        "#,
+    )
+    .await
+    .expect("provider");
+
+    let service = kernel.services().inject("double").expect("provided");
+    assert!(service.is_callable());
+    let out = service
+        .call(json!({"n": 21}))
+        .await
+        .expect("rust call");
+    assert_eq!(out, json!({"n": 42}));
+
+    load(
+        &kernel,
+        "peer",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        return {
+          apply = function(ctx)
+            local double = ctx:inject("double")
+            ctx:provide("report", double({ n = 11 }))
+          end,
+        }
+        "#,
+    )
+    .await
+    .expect("peer");
+
+    let report = kernel.services().inject("report").expect("provided");
+    assert_eq!(report.as_data(), Some(&json!({"n": 22})));
+}
+
+#[tokio::test]
+async fn unloading_withdraws_a_lua_callable() {
+    let dir = TempDir::new("lua-callable-unload");
+    let kernel = kernel_in(&dir.path);
+
+    let id = load(
+        &kernel,
+        "provider",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        return {
+          apply = function(ctx)
+            ctx:provide("ping", function(args)
+              return args
+            end)
+          end,
+        }
+        "#,
+    )
+    .await
+    .expect("provider");
+
+    assert!(kernel.services().inject("ping").expect("live").is_callable());
+    kernel.unload(&id).await.expect("unload");
+    assert!(kernel.services().inject("ping").is_none());
+}
+
+#[tokio::test]
 async fn a_lua_plugin_reads_its_config_slice() {
     let dir = TempDir::new("lua-config");
     let kernel = kernel_in(&dir.path);

--- a/src/kernel/services.rs
+++ b/src/kernel/services.rs
@@ -22,6 +22,15 @@
 //! cannot call the thing — and it is the same answer it gets for a service
 //! nobody provided, which means a Lua plugin's degrade path already covers it.
 //!
+//! # Callables
+//!
+//! [`Service::Callable`] is the third arm: a function both languages can invoke
+//! with JSON in and JSON out. Rust provides one with [`Service::callable`]; a
+//! Lua `ctx:provide(name, function)` holds the function in that plugin's VM and
+//! publishes a callable that resumes it. `ctx:inject` returns a callable to Lua
+//! as a function, and to Rust as [`Service::as_callable`]. Native services stay
+//! invisible to Lua; data stays a snapshot.
+//!
 //! # Withdrawal, and why `inject` is not the last word
 //!
 //! Unloading a plugin has to withdraw its services "from anyone who injected
@@ -33,11 +42,17 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, PoisonError};
 
 use serde_json::Value;
 
 use super::lifecycle::PluginId;
+
+/// JSON in, JSON out, sendable across the service table.
+pub type ServiceCall =
+    Arc<dyn Fn(Value) -> Pin<Box<dyn Future<Output = anyhow::Result<Value>> + Send>> + Send + Sync>;
 
 /// Something one plugin exposed for others to take.
 #[derive(Clone)]
@@ -48,6 +63,8 @@ pub enum Service {
     /// Plain data, which is what a Lua plugin can provide and what either
     /// language can read.
     Data(Value),
+    /// A function both languages can invoke. See the module docs.
+    Callable(ServiceCall),
 }
 
 impl Service {
@@ -68,12 +85,21 @@ impl Service {
         Service::Data(value)
     }
 
+    /// Wrap an async JSON→JSON function.
+    pub fn callable<F, Fut>(f: F) -> Self
+    where
+        F: Fn(Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<Value>> + Send + 'static,
+    {
+        Service::Callable(Arc::new(move |args| Box::pin(f(args))))
+    }
+
     /// Recover the concrete type. `None` when this is data, or when the caller
     /// guessed a different type than the provider published.
     pub fn downcast<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
         match self {
             Service::Native(any) => Arc::clone(any).downcast::<T>().ok(),
-            Service::Data(_) => None,
+            Service::Data(_) | Service::Callable(_) => None,
         }
     }
 
@@ -82,12 +108,33 @@ impl Service {
     pub fn as_data(&self) -> Option<&Value> {
         match self {
             Service::Data(value) => Some(value),
-            Service::Native(_) => None,
+            Service::Native(_) | Service::Callable(_) => None,
+        }
+    }
+
+    /// The function behind a callable service.
+    pub fn as_callable(&self) -> Option<&ServiceCall> {
+        match self {
+            Service::Callable(call) => Some(call),
+            Service::Native(_) | Service::Data(_) => None,
         }
     }
 
     pub fn is_native(&self) -> bool {
         matches!(self, Service::Native(_))
+    }
+
+    pub fn is_callable(&self) -> bool {
+        matches!(self, Service::Callable(_))
+    }
+
+    /// Invoke a callable. Errors when this is data or native.
+    pub async fn call(&self, args: Value) -> anyhow::Result<Value> {
+        match self {
+            Service::Callable(call) => call(args).await,
+            Service::Data(_) => anyhow::bail!("service is data, not a callable"),
+            Service::Native(_) => anyhow::bail!("service is native, not a callable"),
+        }
     }
 }
 
@@ -98,6 +145,7 @@ impl std::fmt::Debug for Service {
             // use, so this says what it is and stops.
             Service::Native(_) => f.write_str("Service::Native(..)"),
             Service::Data(value) => write!(f, "Service::Data({value})"),
+            Service::Callable(_) => f.write_str("Service::Callable(..)"),
         }
     }
 }
@@ -449,6 +497,28 @@ mod tests {
             "Service::Native(..)"
         );
         assert_eq!(format!("{:?}", Service::data(json!(1))), "Service::Data(1)");
+        assert_eq!(
+            format!("{:?}", Service::callable(|v| async move { Ok(v) })),
+            "Service::Callable(..)"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_callable_service_rounds_json_through_rust() {
+        let registry = ServiceRegistry::new();
+        registry.provide(
+            &plugin("echo"),
+            "echo",
+            Service::callable(|v| async move { Ok(v) }),
+        );
+        let service = registry.inject("echo").expect("provided");
+        assert!(service.as_callable().is_some());
+        assert!(service.as_data().is_none());
+        let out = service
+            .call(json!({"n": 3}))
+            .await
+            .expect("call");
+        assert_eq!(out, json!({"n": 3}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `Service::Callable`: a JSON→JSON function both Rust and Lua can `provide` / `inject`.
- Lua `ctx:provide(name, fn)` holds the function in the plugin VM; `ctx:inject` returns it as a Lua function (native still `nil`, data still a snapshot).
- Closes the host-bridge gap in `docs/plugins.md` that blocked Lua ports of `memory` / `image`.

## Test plan
- [x] `cargo test --lib callable` (Rust round-trip, Rust→Lua, Lua→Rust/Lua, unload withdraws)
- [ ] CI green on this PR