### PR TITLE
Add callable plugin services for JavaScript provide/inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Notable changes, newest first. The format follows [Keep a Changelog](https://kee
 
 Releases before 2.0.0 (v1.6.0 through v1.8.0) predate this file; their notes are on their [GitHub release pages](https://github.com/teddytennant/wizard/releases).
 
+## [Unreleased]
+
+### Added
+
+- **JavaScript callable services.** `ctx.provide(name, fn)` from QuickJS holds
+  the function in that plugin's VM and publishes `Service::Callable`; `ctx.inject`
+  returns a callable as a JS function. Matches the Lua host so all three
+  languages share one callable namespace.
+
 ## [3.1.1] - 2026-09-12
 
 ### Added

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2003,12 +2003,12 @@ implementation appearing between them.
 
 ### Host-bridge and kernel gaps these two found
 
-- **A Lua plugin can expose a callable.** `ctx:provide(name, function)` holds
-  the function in that plugin's VM and publishes `Service::Callable`; injectors
-  in Rust or Lua can invoke it with JSON in and JSON out. That closes the
-  `memory` / `image` host-bridge gap named above. It would still not have been
-  enough on its own for `hardware` / `schedule`, because those callers also
-  cannot await.
+- **A Lua or JavaScript plugin can expose a callable.** `ctx:provide(name, function)`
+  (JS: `ctx.provide`) holds the function in that plugin's VM and publishes
+  `Service::Callable`; injectors in Rust, Lua, or JavaScript can invoke it with
+  JSON in and JSON out. That closes the `memory` / `image` host-bridge gap named
+  above. It would still not have been enough on its own for `hardware` /
+  `schedule`, because those callers also cannot await.
 - **There is no synchronous door into a plugin VM**, and there should not be
   one: `load_source` is async because the VM is a task, and a `block_on` from a
   tokio worker is a panic. What is missing is not a door but a rule, which is

--- a/src/kernel/js/host.rs
+++ b/src/kernel/js/host.rs
@@ -790,7 +790,7 @@ fn install_ctx<'js>(
     object.set("provider", provider_fn(js, ctx)?)?;
     object.set("on", on_fn(js, ctx, handle, registry)?)?;
     object.set("emit", emit_fn(js, ctx)?)?;
-    object.set("provide", provide_fn(js, ctx)?)?;
+    object.set("provide", provide_fn(js, ctx, handle, registry)?)?;
     object.set("inject", inject_fn(js, ctx)?)?;
     object.set("plugin", plugin_fn(js, ctx)?)?;
     object.set("effect", effect_fn(js, registry)?)?;
@@ -1006,25 +1006,68 @@ fn emit_fn<'js>(js: &JsCtx<'js>, ctx: &Ctx) -> rquickjs::Result<Function<'js>> {
     )
 }
 
-fn provide_fn<'js>(js: &JsCtx<'js>, ctx: &Ctx) -> rquickjs::Result<Function<'js>> {
+fn provide_fn<'js>(
+    js: &JsCtx<'js>,
+    ctx: &Ctx,
+    handle: &VmHandle,
+    registry: &Registry,
+) -> rquickjs::Result<Function<'js>> {
     let ctx = ctx.clone();
-    Function::new(js.clone(), move |name: String, value: JsValue<'_>| {
-        ctx.provide(name, Service::data(js_to_json(&value)?));
-        Ok::<(), rquickjs::Error>(())
-    })
+    let handle = handle.clone();
+    let registry = registry.clone();
+    Function::new(
+        js.clone(),
+        move |cx: JsCtx<'js>, name: String, value: JsValue<'js>| {
+            // A function becomes a callable the other side can invoke. Anything
+            // else stays a JSON snapshot, which is what JS could always provide.
+            let service = if let Some(func) = value.as_function() {
+                let func = registry.hold(&cx, func.clone())?;
+                let handle = handle.clone();
+                Service::callable(move |args| {
+                    let handle = handle.clone();
+                    async move { handle.call(func, vec![args]).await }
+                })
+            } else {
+                Service::data(js_to_json(&value)?)
+            };
+            ctx.provide(name, service);
+            Ok::<(), rquickjs::Error>(())
+        },
+    )
 }
 
 fn inject_fn<'js>(js: &JsCtx<'js>, ctx: &Ctx) -> rquickjs::Result<Function<'js>> {
     let ctx = ctx.clone();
     Function::new(js.clone(), move |cx: JsCtx<'js>, name: String| {
-        // A native service is `undefined` here, which is the same `undefined`
-        // an absent one gives — see the `Ctx` module docs. JavaScript cannot
-        // call a Rust trait object, and pretending otherwise would only move
-        // the failure later.
-        match ctx.inject(&name).as_ref().and_then(Service::as_data) {
-            Some(value) => json_to_js(&cx, value),
-            None => Ok(JsValue::new_undefined(cx.clone())),
+        // Native stays `undefined` — JS cannot call a Rust trait object. Data
+        // is a value. A callable is a JS function that round-trips JSON.
+        let Some(service) = ctx.inject(&name) else {
+            return Ok(JsValue::new_undefined(cx.clone()));
+        };
+        if let Some(value) = service.as_data() {
+            return json_to_js(&cx, value);
         }
+        let Some(call) = service.as_callable() else {
+            return Ok(JsValue::new_undefined(cx.clone()));
+        };
+        let call = Arc::clone(call);
+        let func = Function::new(
+            cx.clone(),
+            Async(move |cx: JsCtx<'js>, args: Opt<JsValue<'js>>| {
+                let call = Arc::clone(&call);
+                let args = args
+                    .0
+                    .filter(|value| !value.is_undefined() && !value.is_null())
+                    .map(|value| js_to_json(&value))
+                    .unwrap_or(Ok(Value::Null));
+                async move {
+                    let args = args?;
+                    let out = call(args).await.map_err(|err| external(&cx, err))?;
+                    json_to_js(&cx, &out)
+                }
+            }),
+        )?;
+        Ok(func.into_value())
     })
 }
 

--- a/src/kernel/js/tests.rs
+++ b/src/kernel/js/tests.rs
@@ -607,10 +607,7 @@ async fn js_callable_is_invokable_from_rust_and_js() {
 
     let service = kernel.services().inject("double").expect("provided");
     assert!(service.is_callable());
-    let out = service
-        .call(json!({"n": 21}))
-        .await
-        .expect("rust call");
+    let out = service.call(json!({"n": 21})).await.expect("rust call");
     assert_eq!(out, json!({"n": 42}));
 
     load(
@@ -655,7 +652,13 @@ async fn unloading_withdraws_a_js_callable() {
     .await
     .expect("provider");
 
-    assert!(kernel.services().inject("ping").expect("live").is_callable());
+    assert!(
+        kernel
+            .services()
+            .inject("ping")
+            .expect("live")
+            .is_callable()
+    );
     kernel.unload(&id).await.expect("unload");
     assert!(kernel.services().inject("ping").is_none());
 }

--- a/src/kernel/js/tests.rs
+++ b/src/kernel/js/tests.rs
@@ -546,6 +546,121 @@ async fn all_three_backends_share_one_service_namespace() {
 }
 
 #[tokio::test]
+async fn rust_callable_is_invokable_from_js() {
+    let dir = TempDir::new("js-callable-rust");
+    let kernel = kernel_in(&dir.path);
+
+    kernel
+        .load(TestPlugin::boxed("echo", |ctx| {
+            ctx.provide(
+                "echo",
+                Service::callable(|v| async move { Ok(json!({"got": v})) }),
+            );
+            Ok(())
+        }))
+        .expect("rust plugin");
+
+    load(
+        &kernel,
+        "caller",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        export default {
+          async apply(ctx) {
+            const echo = ctx.inject("echo");
+            if (typeof echo !== "function") {
+              throw new Error("callable injects as a function");
+            }
+            ctx.provide("report", await echo({ n: 3 }));
+          },
+        };
+        "#,
+    )
+    .await
+    .expect("js plugin");
+
+    let report = kernel.services().inject("report").expect("provided");
+    assert_eq!(report.as_data(), Some(&json!({"got": {"n": 3}})));
+}
+
+#[tokio::test]
+async fn js_callable_is_invokable_from_rust_and_js() {
+    let dir = TempDir::new("js-callable-js");
+    let kernel = kernel_in(&dir.path);
+
+    load(
+        &kernel,
+        "provider",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        export default {
+          apply(ctx) {
+            ctx.provide("double", (args) => ({ n: args.n * 2 }));
+          },
+        };
+        "#,
+    )
+    .await
+    .expect("provider");
+
+    let service = kernel.services().inject("double").expect("provided");
+    assert!(service.is_callable());
+    let out = service
+        .call(json!({"n": 21}))
+        .await
+        .expect("rust call");
+    assert_eq!(out, json!({"n": 42}));
+
+    load(
+        &kernel,
+        "peer",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        export default {
+          async apply(ctx) {
+            const double = ctx.inject("double");
+            ctx.provide("report", await double({ n: 11 }));
+          },
+        };
+        "#,
+    )
+    .await
+    .expect("peer");
+
+    let report = kernel.services().inject("report").expect("provided");
+    assert_eq!(report.as_data(), Some(&json!({"n": 22})));
+}
+
+#[tokio::test]
+async fn unloading_withdraws_a_js_callable() {
+    let dir = TempDir::new("js-callable-unload");
+    let kernel = kernel_in(&dir.path);
+
+    let id = load(
+        &kernel,
+        "provider",
+        &[],
+        PluginSource::FirstParty,
+        r#"
+        export default {
+          apply(ctx) {
+            ctx.provide("ping", (args) => args);
+          },
+        };
+        "#,
+    )
+    .await
+    .expect("provider");
+
+    assert!(kernel.services().inject("ping").expect("live").is_callable());
+    kernel.unload(&id).await.expect("unload");
+    assert!(kernel.services().inject("ping").is_none());
+}
+
+#[tokio::test]
 async fn a_tool_can_emit_to_a_handler_in_its_own_vm() {
     // The re-entrancy the Lua module's `FuturesUnordered` loop exists for,
     // asked of the other engine, where the answer was not obvious: an


### PR DESCRIPTION
## Summary
- JS `ctx.provide(name, fn)` holds the function in the plugin VM and publishes `Service::Callable`.
- `ctx.inject` returns a callable as a JS function (native still `undefined`, data still a snapshot).
- Matches the Lua host from #50 so Rust, Lua, and JavaScript share one callable namespace.

## Test plan
- [x] `cargo test --lib callable` (Rust, Lua, JS round-trips + unload withdraws)
- [ ] CI green on this PR